### PR TITLE
fix(demo): MSW handlers follow BASE_URL so GH Pages sub-path works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
       # during typecheck (demo depends on @fhir-place/react-fhir via workspace).
       - run: pnpm --filter @fhir-place/react-fhir build
       - run: pnpm -r typecheck
-      - run: pnpm --filter @fhir-place/react-fhir test:run
+      - run: pnpm -r test:run
       - run: pnpm --filter @fhir-place/demo build

--- a/apps/demo/src/mocks/handlers.test.ts
+++ b/apps/demo/src/mocks/handlers.test.ts
@@ -1,0 +1,87 @@
+import { setupServer } from "msw/node";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+/**
+ * Regression: see https://github.com/samsuffolksperoni/fhir-place/issues/8.
+ *
+ * The MSW handlers previously hardcoded `const BASE = "/fhir"` so the app
+ * silently 404'd on GH Pages (served under /fhir-place/). This suite proves
+ * the handlers follow `import.meta.env.BASE_URL` — i.e., the FHIR_BASE_URL
+ * used by the FhirClient.
+ */
+describe.each([
+  { base: "/", expectedFhir: "/fhir" },
+  { base: "/fhir-place/", expectedFhir: "/fhir-place/fhir" },
+  { base: "/nested/sub-path/", expectedFhir: "/nested/sub-path/fhir" },
+])("mock handlers with BASE_URL=$base", ({ base, expectedFhir }) => {
+  let server: ReturnType<typeof setupServer>;
+  let fhirBase: string;
+
+  beforeAll(async () => {
+    vi.resetModules();
+    vi.stubEnv("BASE_URL", base);
+    const { FHIR_BASE_URL } = await import("../config.js");
+    const { handlers } = await import("./handlers.js");
+    fhirBase = FHIR_BASE_URL;
+    server = setupServer(...handlers);
+    server.listen({ onUnhandledRequest: "error" });
+  });
+
+  afterAll(() => {
+    server.close();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => server.resetHandlers());
+
+  it("derives the expected FHIR base URL from BASE_URL", () => {
+    expect(fhirBase).toBe(expectedFhir);
+  });
+
+  it("serves CapabilityStatement at the derived path", async () => {
+    const res = await fetch(`http://localhost${fhirBase}/metadata`);
+    expect(res.status).toBe(200);
+    const cap = await res.json();
+    expect(cap.resourceType).toBe("CapabilityStatement");
+    expect(
+      cap.rest?.[0]?.resource?.some(
+        (r: { type: string }) => r.type === "Patient",
+      ),
+    ).toBe(true);
+  });
+
+  it("serves the Patient search at the derived path", async () => {
+    const res = await fetch(`http://localhost${fhirBase}/Patient?_count=5`);
+    expect(res.status).toBe(200);
+    const bundle = await res.json();
+    expect(bundle.resourceType).toBe("Bundle");
+    expect(bundle.entry?.length).toBeGreaterThan(0);
+  });
+
+  it("serves the Patient detail at the derived path", async () => {
+    const res = await fetch(`http://localhost${fhirBase}/Patient/ada`);
+    expect(res.status).toBe(200);
+    const patient = await res.json();
+    expect(patient.resourceType).toBe("Patient");
+    expect(patient.id).toBe("ada");
+  });
+
+  it("serves the Patient StructureDefinition at the derived path", async () => {
+    const res = await fetch(
+      `http://localhost${fhirBase}/StructureDefinition/Patient`,
+    );
+    expect(res.status).toBe(200);
+    const sd = await res.json();
+    expect(sd.resourceType).toBe("StructureDefinition");
+    expect(sd.type).toBe("Patient");
+  });
+});

--- a/apps/demo/src/mocks/handlers.ts
+++ b/apps/demo/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import type { Patient } from "fhir/r4";
+import { FHIR_BASE_URL } from "../config.js";
 import {
   observationsFor,
   observationStructureDefinition,
@@ -8,7 +9,10 @@ import {
   searchBundle,
 } from "./fixtures.js";
 
-const BASE = "/fhir";
+// Share the base URL with the client. Dev → "/fhir"; GH Pages → "/fhir-place/fhir".
+// A hardcoded "/fhir" here caused a production-only 404 when the app was served
+// under a non-root base path (see #8).
+const BASE = FHIR_BASE_URL;
 
 // Mutable in-memory store so create/update/delete actually persist during the session.
 const store = {
@@ -26,7 +30,7 @@ const okJson = (data: any, init?: ResponseInit) =>
   });
 
 export const handlers = [
-  http.get(`${BASE}/metadata`, () =>
+  http.get(`*${BASE}/metadata`, () =>
     okJson({
       resourceType: "CapabilityStatement",
       status: "active",
@@ -78,14 +82,14 @@ export const handlers = [
     }),
   ),
 
-  http.get(`${BASE}/StructureDefinition/Patient`, () =>
+  http.get(`*${BASE}/StructureDefinition/Patient`, () =>
     okJson(patientStructureDefinition),
   ),
-  http.get(`${BASE}/StructureDefinition/Observation`, () =>
+  http.get(`*${BASE}/StructureDefinition/Observation`, () =>
     okJson(observationStructureDefinition),
   ),
 
-  http.get(`${BASE}/Patient`, ({ request }) => {
+  http.get(`*${BASE}/Patient`, ({ request }) => {
     const url = new URL(request.url);
     const qp = url.searchParams;
     const name = qp.get("name")?.toLowerCase();
@@ -109,7 +113,7 @@ export const handlers = [
     return okJson(searchBundle(filtered.slice(0, count)));
   }),
 
-  http.get(`${BASE}/Patient/:id`, ({ params }) => {
+  http.get(`*${BASE}/Patient/:id`, ({ params }) => {
     const p = store.patients.get(String(params.id));
     if (!p) {
       return okJson(
@@ -125,7 +129,7 @@ export const handlers = [
     return okJson(p);
   }),
 
-  http.post(`${BASE}/Patient`, async ({ request }) => {
+  http.post(`*${BASE}/Patient`, async ({ request }) => {
     const body = (await request.json()) as Patient;
     const id = body.id ?? `p-${Date.now()}`;
     const created: Patient = {
@@ -137,7 +141,7 @@ export const handlers = [
     return okJson(created, { status: 201 });
   }),
 
-  http.put(`${BASE}/Patient/:id`, async ({ params, request }) => {
+  http.put(`*${BASE}/Patient/:id`, async ({ params, request }) => {
     const id = String(params.id);
     const body = (await request.json()) as Patient;
     const prev = store.patients.get(id);
@@ -151,12 +155,12 @@ export const handlers = [
     return okJson(updated);
   }),
 
-  http.delete(`${BASE}/Patient/:id`, ({ params }) => {
+  http.delete(`*${BASE}/Patient/:id`, ({ params }) => {
     store.patients.delete(String(params.id));
     return new HttpResponse(null, { status: 204 });
   }),
 
-  http.get(`${BASE}/Observation`, ({ request }) => {
+  http.get(`*${BASE}/Observation`, ({ request }) => {
     const url = new URL(request.url);
     const subject = url.searchParams.get("subject") ?? url.searchParams.get("patient");
     const id = subject?.replace(/^Patient\//, "") ?? "";

--- a/apps/demo/vitest.config.ts
+++ b/apps/demo/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "demo",
+    environment: "node",
+    globals: true,
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
Fixes #8.

## What was broken

Live GH Pages deploy at <https://samsuffolksperoni.github.io/fhir-place/> showed:

```
FHIR GET /fhir-place/fhir/Patient?_count=20 failed with 404
No searchable parameters advertised for Patient.
```

The demo runs entirely in-browser via MSW — no external server involved. The demo's client computes `FHIR_BASE_URL` from `import.meta.env.BASE_URL`:

- dev (`/`) → `/fhir`
- GH Pages (`/fhir-place/`) → `/fhir-place/fhir`

…but the MSW handlers were hardcoded to `const BASE = "/fhir"`. So every request in production missed the handler and returned 404.

## Fix

1. **Handlers derive their base from `FHIR_BASE_URL`** — single source of truth; can't drift.
2. **Every handler URL is prefixed with a wildcard origin (`*`)** — needed so the same handlers work both in the browser (relative URL against the current page) and under Node's `setupServer` (requires absolute / wildcard origins).

## Regression coverage

- New `apps/demo/vitest.config.ts` + `src/mocks/handlers.test.ts`.
- `describe.each` runs **three** `BASE_URL` values — `/`, `/fhir-place/`, `/nested/sub-path/` — stubbing `import.meta.env.BASE_URL` via `vi.stubEnv` + `vi.resetModules()` so the re-imported `config.ts` and `handlers.ts` pick up the new base.
- For each base, the suite proves CapabilityStatement, Patient search, Patient detail, and Patient StructureDefinition all resolve at the derived path. **15 new tests.**
- CI: replaced the filtered library-only invocation with `pnpm -r test:run` so the demo tests actually execute on every PR.

## Local verification

```bash
pnpm --filter @fhir-place/react-fhir build
VITE_USE_MOCK=true VITE_BASE_PATH=/fhir-place/ pnpm --filter @fhir-place/demo build
pnpm --filter @fhir-place/demo exec vite preview --port 5174 --base /fhir-place/
# → http://127.0.0.1:5174/fhir-place/ loads cleanly; Patient list populates
```

## Test plan
- [x] `pnpm -r test:run` — 94 lib + 15 demo = 109 tests pass locally
- [x] Typecheck clean
- [x] Built demo at `/fhir-place/` sub-path serves and loads via `vite preview`
- [ ] After merge: <https://samsuffolksperoni.github.io/fhir-place/> loads with the patient list
- [ ] Mobile browser reload — pull-to-refresh reload → clean, no 404 banner

## Follow-up

No runtime change to the library itself; no behaviour change in dev. The only caller-visible difference is that demo tests now ship and run in CI.