### PR TITLE
ci(pages): deploy live HAPI demo instead of MSW mock

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,10 +27,11 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @fhir-place/react-fhir build
-      - name: Build demo for GitHub Pages
+      - name: Build demo for GitHub Pages (live HAPI R4)
         run: pnpm --filter @fhir-place/demo build
         env:
-          VITE_USE_MOCK: "true"
+          VITE_USE_MOCK: "false"
+          VITE_FHIR_BASE_URL: "https://hapi.fhir.org/baseR4"
           VITE_BASE_PATH: "/${{ github.event.repository.name }}/"
       - name: SPA 404 fallback
         run: cp apps/demo/dist/index.html apps/demo/dist/404.html

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A React component library for building FHIR resource viewers and editors driven by the FHIR specification itself (`StructureDefinition`, `SearchParameter`, `CapabilityStatement`). Minimal resource-specific code — everything derives from the spec's own metadata, so the library works natively against any FHIR REST API.
 
-**Live demo:** <https://samsuffolksperoni.github.io/fhir-place/>
+**Live demo:** <https://samsuffolksperoni.github.io/fhir-place/> — hits the **public HAPI R4 server**. Patient data there is shared and reset periodically; creates / edits you make are visible to everyone (and won't last forever). Local `pnpm dev` uses an in-browser MSW mock by default so you can work offline.
 
 ## Status
 


### PR DESCRIPTION
Flips the deployed demo from MSW mock to live public HAPI R4, as requested.

## What changes

`.github/workflows/pages.yml`:
```yaml
env:
  VITE_USE_MOCK: "false"
  VITE_FHIR_BASE_URL: "https://hapi.fhir.org/baseR4"
  VITE_BASE_PATH: "/${{ github.event.repository.name }}/"
```

`config.ts` already routes correctly for both modes, so no code change. The existing header badge already flips from `mock · /fhir-place/fhir` to `live · https://hapi.fhir.org/baseR4` so visitors know they're hitting a shared server.

README updated so visitors know:
- The live demo shares a public test server
- Data resets periodically
- Creates / edits are public while they last
- `pnpm dev` still defaults to the offline MSW mock

## Tradeoffs

| Pro | Con |
|---|---|
| Demo exercises the real FHIR REST protocol end-to-end | Public HAPI is rate-limited + goes down sometimes |
| Visitors can hit real pagination, real CapabilityStatement, real StructureDefinitions | Lots of synthetic Patient clutter from other users' experiments |
| `ResourceSearch` now reflects HAPI's full advertised search params | First page-load cost: CapabilityStatement + StructureDefinition + search |
| CRUD flows persist for the session | Nothing stops demo visitors from writing test data visible to other demo visitors (HAPI wipes periodically; acceptable per its intended use) |

If HAPI hiccups degrade the live demo too much, reverting this is a one-line flip back to `VITE_USE_MOCK: "true"`.

## Test plan
- [x] `pnpm -r typecheck` clean
- [x] `pnpm -r test:run` — 94 lib + 15 demo tests pass (unaffected — tests are env-stubbed)
- [ ] After merge: <https://samsuffolksperoni.github.io/fhir-place/> loads patient list from HAPI
- [ ] Header shows `live · https://hapi.fhir.org/baseR4`
- [ ] Search by name returns HAPI matches
- [ ] Create a Patient → visible in list → edit → delete → 410 on subsequent read (handled by existing error UI)
- [ ] Mobile: works on iOS Safari + Android Chrome

## Depends on

This stacks cleanly on top of PR #9 (MSW base-path fix), but since this build uses live mode the bug in mock handlers no longer affects the deployed site. You can land either order; #9 is still valuable for anyone running `pnpm dev` locally in mock mode.