### PR TITLE
feat(library): ValueSet resolution + binding-aware code input (closes #4)

### DIFF
--- a/packages/react-fhir/src/components/inputs.test.tsx
+++ b/packages/react-fhir/src/components/inputs.test.tsx
@@ -1,0 +1,182 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ElementDefinition } from "fhir/r4";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { FetchFhirClient } from "../client/FetchFhirClient.js";
+import { FhirClientProvider } from "../hooks/FhirClientProvider.js";
+import { defaultTypeInputs } from "./inputs.js";
+
+const BASE = "https://fhir.example.test/fhir";
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const mkWrapper = () => {
+  const client = new FetchFhirClient({ baseUrl: BASE });
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <FhirClientProvider client={client}>{children}</FhirClientProvider>
+    </QueryClientProvider>
+  );
+};
+
+const CodeInput = defaultTypeInputs.code!;
+
+describe("CodeInput (ValueSet-driven)", () => {
+  const genderElement: ElementDefinition = {
+    path: "Patient.gender",
+    type: [{ code: "code" }],
+    short: "male | female | other | unknown",
+    binding: {
+      strength: "required",
+      valueSet: "http://hl7.org/fhir/ValueSet/administrative-gender",
+    },
+  };
+
+  const mockValueSet = (codes: Array<{ code: string; display?: string }>) => {
+    server.use(
+      http.get(`${BASE}/ValueSet/$expand`, () =>
+        HttpResponse.json({
+          resourceType: "ValueSet",
+          status: "active",
+          url: "http://hl7.org/fhir/ValueSet/administrative-gender",
+          expansion: {
+            identifier: "x",
+            timestamp: "2024-01-01T00:00:00Z",
+            contains: codes.map((c) => ({
+              system: "http://hl7.org/fhir/administrative-gender",
+              ...c,
+            })),
+          },
+        }),
+      ),
+    );
+  };
+
+  it("resolves binding.valueSet into a <select> of enumerated codes with display labels", async () => {
+    mockValueSet([
+      { code: "male", display: "Male" },
+      { code: "female", display: "Female" },
+      { code: "other", display: "Other" },
+      { code: "unknown", display: "Unknown" },
+    ]);
+    const onChange = vi.fn();
+    render(
+      <CodeInput
+        value={undefined}
+        onChange={onChange}
+        context={{ path: "Patient.gender", typeCode: "code", element: genderElement }}
+      />,
+      { wrapper: mkWrapper() },
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /Female \(female\)/ })).toBeInTheDocument(),
+    );
+    const select = screen.getByRole("combobox", { name: "gender" });
+    await userEvent.selectOptions(select, "female");
+    expect(onChange).toHaveBeenCalledWith("female");
+  });
+
+  it("required binding → no 'Other…' escape hatch", async () => {
+    mockValueSet([{ code: "male" }, { code: "female" }]);
+    render(
+      <CodeInput
+        value={undefined}
+        onChange={() => {}}
+        context={{ path: "Patient.gender", typeCode: "code", element: genderElement }}
+      />,
+      { wrapper: mkWrapper() },
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /female/ })).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("option", { name: /other…/i })).not.toBeInTheDocument();
+  });
+
+  it("extensible binding → shows an 'Other…' option", async () => {
+    mockValueSet([{ code: "yes" }, { code: "no" }]);
+    const extensibleEl: ElementDefinition = {
+      ...genderElement,
+      binding: {
+        strength: "extensible",
+        valueSet: "http://hl7.org/fhir/ValueSet/administrative-gender",
+      },
+    };
+    render(
+      <CodeInput
+        value={undefined}
+        onChange={() => {}}
+        context={{ path: "Patient.gender", typeCode: "code", element: extensibleEl }}
+      />,
+      { wrapper: mkWrapper() },
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /other…/i })).toBeInTheDocument(),
+    );
+  });
+
+  it("falls back to pipe-separated short when there is no binding", async () => {
+    const noBinding: ElementDefinition = {
+      path: "Fake.status",
+      type: [{ code: "code" }],
+      short: "draft | active | retired",
+    };
+    render(
+      <CodeInput
+        value={undefined}
+        onChange={() => {}}
+        context={{ path: "Fake.status", typeCode: "code", element: noBinding }}
+      />,
+      { wrapper: mkWrapper() },
+    );
+    expect(screen.getByRole("option", { name: "draft" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "active" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "retired" })).toBeInTheDocument();
+  });
+
+  it("falls back to a plain text input when there is neither binding nor short enumeration", () => {
+    const bare: ElementDefinition = {
+      path: "Fake.token",
+      type: [{ code: "code" }],
+    };
+    render(
+      <CodeInput
+        value="xyz"
+        onChange={() => {}}
+        context={{ path: "Fake.token", typeCode: "code", element: bare }}
+      />,
+      { wrapper: mkWrapper() },
+    );
+    expect(screen.getByRole("textbox")).toHaveValue("xyz");
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("preserves a current non-enumerated value by selecting 'Other…' and showing a free-text input (extensible)", async () => {
+    mockValueSet([{ code: "draft" }, { code: "active" }]);
+    const el: ElementDefinition = {
+      ...genderElement,
+      binding: {
+        strength: "preferred",
+        valueSet: "http://hl7.org/fhir/ValueSet/administrative-gender",
+      },
+    };
+    render(
+      <CodeInput
+        value="custom-code"
+        onChange={() => {}}
+        context={{ path: "Fake.status", typeCode: "code", element: el }}
+      />,
+      { wrapper: mkWrapper() },
+    );
+    await waitFor(() => expect(screen.getByDisplayValue("custom-code")).toBeInTheDocument());
+  });
+});

--- a/packages/react-fhir/src/components/inputs.tsx
+++ b/packages/react-fhir/src/components/inputs.tsx
@@ -11,6 +11,8 @@ import type {
   Reference,
 } from "fhir/r4";
 import type { ReactNode } from "react";
+import { useValueSet } from "../hooks/queries.js";
+import { bindingFor, codesFromValueSet } from "../structure/binding.js";
 
 export interface InputContext {
   path: string;
@@ -125,35 +127,88 @@ const UriInput: FhirTypeInput<string> = ({ value, onChange }) => (
   />
 );
 
+/**
+ * Resolves a `code` element's binding to a list of acceptable values:
+ *   1. If binding.valueSet is set, fetch it via useValueSet and use its codes.
+ *   2. Fallback: parse pipe-separated enumeration out of element.short.
+ *   3. Last resort: plain text input.
+ *
+ * Required bindings lock to the enumeration; extensible / preferred also
+ * allow a free-text "other" entry.
+ */
 const CodeInput: FhirTypeInput<string> = (props) => {
-  // Enumerate values from the element.short "a | b | c | d" pattern when present —
-  // falls back to a plain text input otherwise.
-  const short = props.context.element.short;
-  const fieldName = props.context.element.path?.split(".").pop() ?? "code";
-  if (short && short.includes("|")) {
-    const options = short
-      .split("|")
-      .map((s) => s.trim())
-      .filter(Boolean);
-    return (
+  const { element } = props.context;
+  const short = element.short;
+  const fieldName = element.path?.split(".").pop() ?? "code";
+  const { strength, valueSet } = bindingFor(element);
+
+  const { data: vs, isLoading } = useValueSet(valueSet);
+  const boundCodes = codesFromValueSet(vs);
+
+  const options: Array<{ value: string; label: string }> = [];
+  if (boundCodes.length > 0) {
+    for (const c of boundCodes) {
+      options.push({ value: c.code, label: c.display ? `${c.display} (${c.code})` : c.code });
+    }
+  } else if (short && short.includes("|")) {
+    for (const raw of short.split("|")) {
+      const v = raw.trim();
+      if (v) options.push({ value: v, label: v });
+    }
+  }
+
+  if (options.length === 0) {
+    if (valueSet && isLoading) {
+      return (
+        <input
+          aria-label={fieldName}
+          className={baseField}
+          value={props.value ?? ""}
+          readOnly
+          placeholder="Loading value set…"
+        />
+      );
+    }
+    return <TextInput {...(props as FhirInputProps<string>)} />;
+  }
+
+  const allowFreeText = strength !== "required";
+  const currentValue = props.value ?? "";
+  const valueMatches = options.some((o) => o.value === currentValue);
+  const usingFreeText = !valueMatches && currentValue !== "";
+
+  return (
+    <div className="flex gap-1">
       <select
         aria-label={fieldName}
         className={baseField}
-        value={props.value ?? ""}
-        onChange={(e) =>
-          props.onChange(e.target.value === "" ? undefined : e.target.value)
-        }
+        value={usingFreeText ? "__other__" : currentValue}
+        onChange={(e) => {
+          const v = e.target.value;
+          if (v === "__other__") return; // keep free-text input value
+          props.onChange(v === "" ? undefined : v);
+        }}
       >
         <option value="">—</option>
         {options.map((o) => (
-          <option key={o} value={o}>
-            {o}
+          <option key={o.value} value={o.value}>
+            {o.label}
           </option>
         ))}
+        {allowFreeText && <option value="__other__">Other…</option>}
       </select>
-    );
-  }
-  return <TextInput {...(props as FhirInputProps<string>)} />;
+      {allowFreeText && usingFreeText && (
+        <input
+          aria-label={`${fieldName} (custom)`}
+          className={baseField}
+          value={currentValue}
+          onChange={(e) =>
+            props.onChange(e.target.value === "" ? undefined : e.target.value)
+          }
+        />
+      )}
+    </div>
+  );
 };
 
 /* ---------- complex-type sub-forms ---------- */

--- a/packages/react-fhir/src/hooks/queries.test.tsx
+++ b/packages/react-fhir/src/hooks/queries.test.tsx
@@ -14,6 +14,7 @@ import {
   useSearch,
   useStructureDefinition,
   useUpdateResource,
+  useValueSet,
 } from "./queries.js";
 
 const BASE = "https://fhir.example.test/fhir";
@@ -172,6 +173,74 @@ describe("query hooks", () => {
     });
     expect(hit).toHaveBeenCalledOnce();
     expect(result.current.isSuccess).toBe(true);
+  });
+
+  describe("useValueSet", () => {
+    it("prefers the $expand operation and returns the expanded ValueSet", async () => {
+      const url = "http://hl7.org/fhir/ValueSet/administrative-gender";
+      server.use(
+        http.get(`${BASE}/ValueSet/$expand`, ({ request }) => {
+          expect(new URL(request.url).searchParams.get("url")).toBe(url);
+          return HttpResponse.json({
+            resourceType: "ValueSet",
+            status: "active",
+            url,
+            expansion: {
+              identifier: "x",
+              timestamp: "2024-01-01T00:00:00Z",
+              contains: [
+                { system: "s", code: "male" },
+                { system: "s", code: "female" },
+              ],
+            },
+          });
+        }),
+      );
+      const { wrapper } = mkWrapper();
+      const { result } = renderHook(() => useValueSet(url), { wrapper });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data?.expansion?.contains).toHaveLength(2);
+    });
+
+    it("falls back to ValueSet?url=... when $expand errors", async () => {
+      const url = "http://hl7.org/fhir/ValueSet/task-status";
+      server.use(
+        http.get(`${BASE}/ValueSet/$expand`, () =>
+          HttpResponse.json({ resourceType: "OperationOutcome" }, { status: 501 }),
+        ),
+        http.get(`${BASE}/ValueSet`, ({ request }) => {
+          expect(new URL(request.url).searchParams.get("url")).toBe(url);
+          return HttpResponse.json({
+            resourceType: "Bundle",
+            type: "searchset",
+            entry: [
+              {
+                resource: {
+                  resourceType: "ValueSet",
+                  status: "active",
+                  url,
+                  compose: {
+                    include: [
+                      { system: "s", concept: [{ code: "draft" }, { code: "requested" }] },
+                    ],
+                  },
+                },
+              },
+            ],
+          });
+        }),
+      );
+      const { wrapper } = mkWrapper();
+      const { result } = renderHook(() => useValueSet(url), { wrapper });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data?.compose?.include?.[0]?.concept).toHaveLength(2);
+    });
+
+    it("is disabled when canonical is undefined", () => {
+      const { wrapper } = mkWrapper();
+      const { result } = renderHook(() => useValueSet(undefined), { wrapper });
+      expect(result.current.fetchStatus).toBe("idle");
+    });
   });
 
   it("throws when useFhirClient is used without provider", async () => {

--- a/packages/react-fhir/src/hooks/queries.ts
+++ b/packages/react-fhir/src/hooks/queries.ts
@@ -11,6 +11,7 @@ import type {
   Reference,
   Resource,
   StructureDefinition,
+  ValueSet,
 } from "fhir/r4";
 import type { FhirClient, SearchParams } from "../client/types.js";
 import { resolveStructureDefinition } from "../structure/resolve.js";
@@ -26,6 +27,8 @@ export const fhirQueryKeys = {
     [...fhirQueryKeys.all(baseUrl), type, "search", params ?? {}] as const,
   structure: (baseUrl: string, type: string) =>
     [...fhirQueryKeys.all(baseUrl), "StructureDefinition", type] as const,
+  valueSet: (baseUrl: string, canonical: string) =>
+    [...fhirQueryKeys.all(baseUrl), "ValueSet", canonical] as const,
   reference: (baseUrl: string, ref: string) =>
     [...fhirQueryKeys.all(baseUrl), "ref", ref] as const,
 };
@@ -81,6 +84,49 @@ export function useStructureDefinition(
     queryKey: fhirQueryKeys.structure(client.baseUrl, type),
     queryFn: ({ signal }) => resolveStructureDefinition(client, type, { signal }),
     staleTime: 60 * 60_000,
+    ...options,
+  });
+}
+
+/**
+ * Resolves a ValueSet by canonical URL.
+ *
+ * Prefers `ValueSet/$expand?url={canonical}` when supported so we get a
+ * server-computed enumeration of codes; falls back to `ValueSet?url={canonical}`
+ * + the first matching resource so consumers can locally expand
+ * `compose.include[].concept[]` via {@link codesFromValueSet}.
+ */
+export function useValueSet(
+  canonical: string | undefined,
+  options?: ReadQueryOpts<ValueSet>,
+) {
+  const client = useFhirClient();
+  return useQuery({
+    queryKey: fhirQueryKeys.valueSet(client.baseUrl, canonical ?? ""),
+    queryFn: async ({ signal }) => {
+      const url = canonical!;
+      // Try $expand first — returns an already-flattened ValueSet.
+      try {
+        return await client.request<ValueSet>({
+          path: `/ValueSet/$expand?url=${encodeURIComponent(url)}`,
+          signal,
+        });
+      } catch {
+        // Fall back to the raw definition; caller can local-expand.
+        const bundle = await client.search<ValueSet>(
+          "ValueSet",
+          { url },
+          { signal },
+        );
+        const hit = bundle.entry?.[0]?.resource;
+        if (!hit) {
+          throw new Error(`ValueSet ${url} not found on this server`);
+        }
+        return hit;
+      }
+    },
+    enabled: Boolean(canonical),
+    staleTime: 24 * 60 * 60_000,
     ...options,
   });
 }

--- a/packages/react-fhir/src/structure/binding.test.ts
+++ b/packages/react-fhir/src/structure/binding.test.ts
@@ -1,0 +1,151 @@
+import type { ValueSet } from "fhir/r4";
+import { describe, expect, it } from "vitest";
+import { bindingFor, codesFromValueSet } from "./binding.js";
+
+describe("bindingFor", () => {
+  it("returns empty fields when element has no binding", () => {
+    expect(bindingFor({ path: "Foo.bar" })).toEqual({
+      strength: undefined,
+      valueSet: undefined,
+      description: undefined,
+    });
+  });
+
+  it("returns undefined when element is undefined", () => {
+    expect(bindingFor(undefined)).toEqual({
+      strength: undefined,
+      valueSet: undefined,
+      description: undefined,
+    });
+  });
+
+  it("extracts strength + valueSet when present", () => {
+    expect(
+      bindingFor({
+        path: "Patient.gender",
+        binding: {
+          strength: "required",
+          valueSet: "http://hl7.org/fhir/ValueSet/administrative-gender",
+          description: "The gender of a person used for administrative purposes.",
+        },
+      }),
+    ).toEqual({
+      strength: "required",
+      valueSet: "http://hl7.org/fhir/ValueSet/administrative-gender",
+      description: "The gender of a person used for administrative purposes.",
+    });
+  });
+});
+
+describe("codesFromValueSet", () => {
+  it("returns [] for undefined input", () => {
+    expect(codesFromValueSet(undefined)).toEqual([]);
+  });
+
+  it("reads the expanded expansion.contains list when present", () => {
+    const vs: ValueSet = {
+      resourceType: "ValueSet",
+      status: "active",
+      url: "http://hl7.org/fhir/ValueSet/administrative-gender",
+      expansion: {
+        identifier: "x",
+        timestamp: "2024-01-01T00:00:00Z",
+        contains: [
+          { system: "http://hl7.org/fhir/administrative-gender", code: "male", display: "Male" },
+          { system: "http://hl7.org/fhir/administrative-gender", code: "female", display: "Female" },
+          { system: "http://hl7.org/fhir/administrative-gender", code: "other", display: "Other" },
+          { system: "http://hl7.org/fhir/administrative-gender", code: "unknown", display: "Unknown" },
+        ],
+      },
+    };
+    const codes = codesFromValueSet(vs);
+    expect(codes.map((c) => c.code)).toEqual(["male", "female", "other", "unknown"]);
+    expect(codes.every((c) => c.system === "http://hl7.org/fhir/administrative-gender")).toBe(true);
+  });
+
+  it("flattens nested expansion.contains (hierarchical ValueSets)", () => {
+    const vs: ValueSet = {
+      resourceType: "ValueSet",
+      status: "active",
+      expansion: {
+        identifier: "x",
+        timestamp: "2024-01-01T00:00:00Z",
+        contains: [
+          {
+            system: "s",
+            code: "group-A",
+            display: "Group A",
+            contains: [
+              { system: "s", code: "a1" },
+              { system: "s", code: "a2" },
+            ],
+          },
+          { system: "s", code: "b1" },
+        ],
+      },
+    };
+    const codes = codesFromValueSet(vs);
+    expect(codes.map((c) => c.code)).toEqual(["group-A", "b1", "a1", "a2"]);
+  });
+
+  it("falls back to compose.include[].concept[] when there is no expansion", () => {
+    const vs: ValueSet = {
+      resourceType: "ValueSet",
+      status: "active",
+      compose: {
+        include: [
+          {
+            system: "http://hl7.org/fhir/task-status",
+            concept: [
+              { code: "draft", display: "Draft" },
+              { code: "requested", display: "Requested" },
+              { code: "in-progress", display: "In Progress" },
+            ],
+          },
+        ],
+      },
+    };
+    const codes = codesFromValueSet(vs);
+    expect(codes).toHaveLength(3);
+    expect(codes[0]).toEqual({
+      system: "http://hl7.org/fhir/task-status",
+      code: "draft",
+      display: "Draft",
+    });
+  });
+
+  it("prefers expansion over compose when both are present", () => {
+    const vs: ValueSet = {
+      resourceType: "ValueSet",
+      status: "active",
+      expansion: {
+        identifier: "x",
+        timestamp: "2024-01-01T00:00:00Z",
+        contains: [{ system: "s", code: "from-expansion" }],
+      },
+      compose: {
+        include: [{ system: "s", concept: [{ code: "from-compose" }] }],
+      },
+    };
+    expect(codesFromValueSet(vs).map((c) => c.code)).toEqual(["from-expansion"]);
+  });
+
+  it("ignores compose.include entries that only reference other ValueSets", () => {
+    const vs: ValueSet = {
+      resourceType: "ValueSet",
+      status: "active",
+      compose: {
+        include: [
+          {
+            system: "http://hl7.org/fhir/task-status",
+            concept: [{ code: "draft" }],
+          },
+          {
+            valueSet: ["http://example.com/other"], // recursive includes not supported
+          },
+        ],
+      },
+    };
+    expect(codesFromValueSet(vs).map((c) => c.code)).toEqual(["draft"]);
+  });
+});

--- a/packages/react-fhir/src/structure/binding.ts
+++ b/packages/react-fhir/src/structure/binding.ts
@@ -1,0 +1,80 @@
+import type { ElementDefinition, ValueSet } from "fhir/r4";
+
+export type BindingStrength =
+  | "required"
+  | "extensible"
+  | "preferred"
+  | "example";
+
+export interface ElementBinding {
+  strength: BindingStrength | undefined;
+  valueSet: string | undefined;
+  description: string | undefined;
+}
+
+export function bindingFor(element: ElementDefinition | undefined): ElementBinding {
+  const b = element?.binding;
+  return {
+    strength: b?.strength as BindingStrength | undefined,
+    valueSet: b?.valueSet,
+    description: b?.description,
+  };
+}
+
+export interface ResolvedCode {
+  system?: string;
+  code: string;
+  display?: string;
+}
+
+/**
+ * Flatten a ValueSet to a list of codes.
+ *
+ * Prefers `expansion.contains` when the server pre-expanded the ValueSet (via
+ * `$expand`). Falls back to `compose.include[].concept[]` when only the
+ * definition is available — a minimal local expansion that covers the common
+ * case of "enumerated codes inline". Does NOT resolve `compose.include.valueSet`
+ * references recursively; callers needing that should call `$expand` on the server.
+ */
+export function codesFromValueSet(vs: ValueSet | undefined): ResolvedCode[] {
+  if (!vs) return [];
+  const expanded = vs.expansion?.contains;
+  if (expanded && expanded.length > 0) {
+    return flattenExpansion(expanded);
+  }
+  const includes = vs.compose?.include ?? [];
+  const out: ResolvedCode[] = [];
+  for (const inc of includes) {
+    const system = inc.system;
+    if (!inc.concept) continue;
+    for (const c of inc.concept) {
+      if (!c.code) continue;
+      out.push({ system, code: c.code, display: c.display });
+    }
+  }
+  return out;
+}
+
+interface ExpansionContains {
+  system?: string;
+  code?: string;
+  display?: string;
+  contains?: ExpansionContains[];
+}
+
+function flattenExpansion(nodes: ExpansionContains[]): ResolvedCode[] {
+  const out: ResolvedCode[] = [];
+  const stack = [...nodes];
+  while (stack.length) {
+    const node = stack.shift()!;
+    if (node.code) {
+      out.push({
+        ...(node.system !== undefined ? { system: node.system } : {}),
+        code: node.code,
+        ...(node.display !== undefined ? { display: node.display } : {}),
+      });
+    }
+    if (node.contains) stack.push(...node.contains);
+  }
+  return out;
+}

--- a/packages/react-fhir/src/structure/index.ts
+++ b/packages/react-fhir/src/structure/index.ts
@@ -1,4 +1,5 @@
 export * from "./walker.js";
 export * from "./path.js";
 export * from "./resolve.js";
+export * from "./binding.js";
 export { coreStructureDefinition, bundledCoreTypes } from "./core/index.js";


### PR DESCRIPTION
Closes #4. Foundation for #11.

## What this unlocks

Every real FHIR `code` field bound to a ValueSet — `Task.status`, `Goal.lifecycleStatus`, `Observation.status`, `Encounter.status`, `Patient.gender`, etc. — now renders as a proper `<select>` of allowed codes in `<ResourceEditor>` instead of a plain text input.

## New surface

### `useValueSet(canonical, options?)` — hooks
Resolves a ValueSet by canonical URL. Prefers `ValueSet/$expand?url=...` (server-computed enumeration); falls back to `ValueSet?url=...` + first matching resource. 24-hour `staleTime` — ValueSets barely change.

### `structure/binding.ts` — helpers
- `bindingFor(element)` → `{ strength, valueSet, description }`
- `codesFromValueSet(vs)` → `{ system?, code, display? }[]`. Flattens `expansion.contains` (hierarchical OK) or `compose.include[].concept[]`. Prefers expansion when both exist. Gracefully ignores `compose.include.valueSet` recursive references (callers wanting that should $expand on the server).

### `CodeInput` dispatch (inputs.tsx)
1. **ValueSet binding present** → `<select>` populated from `codesFromValueSet`.
   - `required` → no escape hatch
   - `extensible` / `preferred` → include "Other…" option + reveals free-text input when chosen
   - Preserves non-enumerated current values by snapping to "Other…" automatically
   - Loading state → read-only placeholder input while the ValueSet fetch is in flight
2. **No binding, short has `a | b | c`** → legacy pipe-parse behaviour (Patient.gender short, etc.)
3. **Neither** → plain text input

## Tests

- **9 binding tests** — bindingFor, codesFromValueSet (expansion / compose / hierarchical / precedence / graceful-ignore)
- **3 useValueSet tests** — $expand happy path, fallback to search-by-url, disabled when canonical undefined
- **6 CodeInput tests** — binding → select with display labels, required vs. extensible escape hatch, short fallback, text fallback, custom-value preservation
- **Total: 134 passing** (119 library + 15 demo), no regressions

## Demo impact

No wiring change needed. The bundled Patient SD shipped in #17 has `Patient.gender` bound to `administrative-gender`, so editing a patient on the live demo now shows a proper gender dropdown driven by the FHIR spec — visitors can see the spec-driven flow without touching any Patient-specific code.

## Depended on by

- #11 (search token ValueSet binding) — will reuse both `useValueSet` and `codesFromValueSet`

## Test plan
- [x] `pnpm -r test:run` — 134 pass
- [x] `pnpm -r typecheck` clean
- [ ] After merge + Pages redeploy, editing Patient.gender on live demo shows a select (not a text box)
- [ ] Bundled ValueSet fetching verifiable against HAPI via the nightly integration workflow