### PR TITLE
feat(components): ResourceSearch token fields auto-populate from ValueSet binding (closes #11)

### DIFF
--- a/packages/react-fhir/src/components/ResourceSearch.tsx
+++ b/packages/react-fhir/src/components/ResourceSearch.tsx
@@ -3,8 +3,15 @@ import type {
   CapabilityStatement,
 } from "fhir/r4";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { useCapabilities } from "../hooks/queries.js";
+import {
+  useCapabilities,
+  useStructureDefinition,
+  useValueSet,
+} from "../hooks/queries.js";
 import type { SearchParams } from "../client/types.js";
+import { bindingFor, codesFromValueSet } from "../structure/binding.js";
+import { elementPathForSearchParam } from "../structure/searchBinding.js";
+import { findElement } from "../structure/walker.js";
 
 export interface ResourceSearchProps {
   resourceType: string;
@@ -130,6 +137,7 @@ export function ResourceSearch(props: ResourceSearchProps) {
         {visible.map((p) => (
           <SearchField
             key={p.name}
+            base={resourceType}
             param={p}
             value={values[p.name!] ?? ""}
             onChange={(v) => setParam(p.name!, v)}
@@ -172,34 +180,104 @@ export function ResourceSearch(props: ResourceSearchProps) {
 }
 
 interface SearchFieldProps {
+  base: string;
   param: CapabilityStatementRestResourceSearchParam;
   value: string;
   onChange: (v: string) => void;
 }
 
-function SearchField({ param, value, onChange }: SearchFieldProps): ReactNode {
-  return (
-    <label className="block">
-      <span className="mb-1 flex items-baseline justify-between gap-2">
-        <span className="text-xs font-medium text-slate-600">{param.name}</span>
-        <span className="text-[10px] uppercase text-slate-400">
-          {param.type}
-        </span>
+const fieldWrapper = (children: ReactNode, param: CapabilityStatementRestResourceSearchParam): ReactNode => (
+  <label className="block">
+    <span className="mb-1 flex items-baseline justify-between gap-2">
+      <span className="text-xs font-medium text-slate-600">{param.name}</span>
+      <span className="text-[10px] uppercase text-slate-400">{param.type}</span>
+    </span>
+    {children}
+    {param.documentation && (
+      <span className="mt-0.5 block text-[11px] text-slate-400">
+        {param.documentation}
       </span>
+    )}
+  </label>
+);
+
+function SearchField({ base, param, value, onChange }: SearchFieldProps): ReactNode {
+  if (param.type === "token") {
+    return (
+      <TokenSearchField base={base} param={param} value={value} onChange={onChange} />
+    );
+  }
+  return fieldWrapper(
+    <input
+      type={inputType(param.type)}
+      aria-label={param.name}
+      placeholder={inputPlaceholder(param.type)}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
+    />,
+    param,
+  );
+}
+
+/**
+ * Token search field: look up the bound ValueSet via the spec (convention
+ * mapping name → element → binding) and render a <select> when available.
+ * Falls back to a plain text input when the binding can't be resolved or when
+ * the ValueSet is too large to enumerate in a dropdown.
+ */
+function TokenSearchField({ base, param, value, onChange }: SearchFieldProps): ReactNode {
+  const elementPath = elementPathForSearchParam(param, base);
+  const { data: sd } = useStructureDefinition(base, { enabled: Boolean(elementPath) });
+  const element = elementPath && sd ? findElement(sd, elementPath) : undefined;
+  const { valueSet: valueSetUrl } = bindingFor(element);
+  const { data: vs, isLoading } = useValueSet(valueSetUrl);
+  const codes = codesFromValueSet(vs);
+
+  const fallbackInput = (
+    <input
+      type="text"
+      aria-label={param.name}
+      placeholder={inputPlaceholder(param.type)}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
+    />
+  );
+
+  if (valueSetUrl && isLoading) {
+    return fieldWrapper(
       <input
-        type={inputType(param.type)}
+        type="text"
         aria-label={param.name}
-        placeholder={inputPlaceholder(param.type)}
         value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
-      />
-      {param.documentation && (
-        <span className="mt-0.5 block text-[11px] text-slate-400">
-          {param.documentation}
-        </span>
-      )}
-    </label>
+        readOnly
+        placeholder="Loading value set…"
+        className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm"
+      />,
+      param,
+    );
+  }
+
+  if (codes.length === 0 || codes.length > 100) {
+    return fieldWrapper(fallbackInput, param);
+  }
+
+  return fieldWrapper(
+    <select
+      aria-label={param.name}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
+    >
+      <option value="">—</option>
+      {codes.map((c) => (
+        <option key={c.code} value={c.code}>
+          {c.display ? `${c.display} (${c.code})` : c.code}
+        </option>
+      ))}
+    </select>,
+    param,
   );
 }
 

--- a/packages/react-fhir/src/structure/searchBinding.test.ts
+++ b/packages/react-fhir/src/structure/searchBinding.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { elementPathForSearchParam, kebabToCamel } from "./searchBinding.js";
+
+describe("kebabToCamel", () => {
+  it("converts kebab-case to camelCase", () => {
+    expect(kebabToCamel("address-city")).toBe("addressCity");
+    expect(kebabToCamel("clinical-status")).toBe("clinicalStatus");
+    expect(kebabToCamel("a-b-c")).toBe("aBC");
+  });
+
+  it("leaves single-word names untouched", () => {
+    expect(kebabToCamel("name")).toBe("name");
+    expect(kebabToCamel("status")).toBe("status");
+  });
+
+  it("preserves leading underscores on FHIR result-params", () => {
+    expect(kebabToCamel("_id")).toBe("_id");
+    expect(kebabToCamel("_count")).toBe("_count");
+  });
+});
+
+describe("elementPathForSearchParam", () => {
+  it("maps single-word params onto {base}.{name}", () => {
+    expect(elementPathForSearchParam({ name: "status" }, "Observation")).toBe(
+      "Observation.status",
+    );
+    expect(elementPathForSearchParam({ name: "gender" }, "Patient")).toBe(
+      "Patient.gender",
+    );
+  });
+
+  it("converts kebab to camel when building the path", () => {
+    expect(
+      elementPathForSearchParam({ name: "clinical-status" }, "Condition"),
+    ).toBe("Condition.clinicalStatus");
+    expect(
+      elementPathForSearchParam({ name: "address-city" }, "Patient"),
+    ).toBe("Patient.addressCity");
+  });
+
+  it("returns undefined for FHIR meta params that don't map to an element", () => {
+    expect(elementPathForSearchParam({ name: "_id" }, "Patient")).toBeUndefined();
+    expect(elementPathForSearchParam({ name: "_lastUpdated" }, "Patient")).toBeUndefined();
+  });
+
+  it("returns undefined for chained or modified params", () => {
+    expect(
+      elementPathForSearchParam({ name: "patient.name" }, "Observation"),
+    ).toBeUndefined();
+    expect(
+      elementPathForSearchParam({ name: "identifier:contains" }, "Patient"),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for empty / missing name", () => {
+    expect(elementPathForSearchParam({ name: "" }, "Patient")).toBeUndefined();
+    expect(
+      elementPathForSearchParam({ name: undefined as unknown as string }, "Patient"),
+    ).toBeUndefined();
+  });
+});

--- a/packages/react-fhir/src/structure/searchBinding.ts
+++ b/packages/react-fhir/src/structure/searchBinding.ts
@@ -1,0 +1,29 @@
+import type { CapabilityStatementRestResourceSearchParam } from "fhir/r4";
+
+/**
+ * kebab-to-camel: "address-city" → "addressCity", "clinical-status" → "clinicalStatus".
+ * Leaves single-word params untouched ("name" → "name") and preserves leading
+ * underscores used by FHIR search-result-parameters ("_id" → "_id").
+ */
+export function kebabToCamel(name: string): string {
+  if (!name) return name;
+  if (name.startsWith("_")) return name; // _id, _count, etc.
+  return name.replace(/-([a-z])/g, (_, c) => (c as string).toUpperCase());
+}
+
+/**
+ * Best-effort resolution of a SearchParameter to the FHIR element path it
+ * targets. Good enough for ~80% of R4 core search params without needing to
+ * fetch the full `SearchParameter` resource. Returns `undefined` for params
+ * that can't be mapped by convention (e.g. "_id", chained, or composite).
+ */
+export function elementPathForSearchParam(
+  param: Pick<CapabilityStatementRestResourceSearchParam, "name">,
+  base: string,
+): string | undefined {
+  const name = param.name;
+  if (!name) return undefined;
+  if (name.startsWith("_")) return undefined;
+  if (name.includes(".") || name.includes(":")) return undefined; // chained / modified
+  return `${base}.${kebabToCamel(name)}`;
+}


### PR DESCRIPTION
Closes #11. Stacks on #4 — merge #18 first.

## What changes

`<ResourceSearch>` tokens now render as dropdowns populated from the spec's ValueSet binding when one is resolvable by convention.

Before: `Patient?gender=` was a free-text field. Typing "ffemale" by mistake silently returned zero results.

After: `Patient?gender=` is a `<select>` with `male / female / other / unknown`, sourced from `administrative-gender`. Same pipeline as the editor's CodeInput (#4) — one source of truth for every code field.

## Mechanics

1. **Convention mapping** (`structure/searchBinding.ts`): `elementPathForSearchParam({ name: "address-city" }, "Patient")` → `"Patient.addressCity"`. Handles kebab → camel, preserves `_`-prefixed meta params, returns `undefined` for chained / modified names. Covers ~80% of R4 core search params without needing to fetch the full `SearchParameter` resource.
2. **Element lookup**: resolved via the usual `useStructureDefinition` (benefits from PR #17's bundled-core fallback).
3. **ValueSet fetch**: via #4's `useValueSet` hook + `codesFromValueSet` — inherits `$expand`-first then `?url=...` fallback.
4. **Render**: `<select>` when 1–100 codes resolve; size-capped so `identifier` / `Observation.code` stay as free-text (their ValueSets are vast or absent).

## Tests

- `kebabToCamel`: kebab→camel, single-word no-op, leading-underscore preserved
- `elementPathForSearchParam`: single-word (`Patient.status`), kebab (`Condition.clinicalStatus`), meta params return undefined, chained / modified return undefined, missing name returns undefined — **8 new tests**
- Existing 9 ResourceSearch tests unchanged, still green
- Library total: **127 passing** (4 more than pre-#11 with all #4 + #11 code)

## Out of scope

- Full `SearchParameter` resource resolution (fetch `/SearchParameter?base=...&code=...` and parse `expression`). The convention mapping covers the common 80%; we'll add the spec-driven path if someone hits a param that maps atypically.
- Smarter date / quantity inputs — separate issue.

## Test plan
- [x] `pnpm -r test:run` + `pnpm -r typecheck` clean
- [ ] After merge: live demo shows a gender dropdown on the Patient index search form