### PR TITLE
feat(components): &lt;ReferencePicker&gt; search-and-pick widget (closes #5)

### DIFF
--- a/packages/react-fhir/src/components/ReferencePicker.test.tsx
+++ b/packages/react-fhir/src/components/ReferencePicker.test.tsx
@@ -1,0 +1,164 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Reference } from "fhir/r4";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { FetchFhirClient } from "../client/FetchFhirClient.js";
+import { FhirClientProvider } from "../hooks/FhirClientProvider.js";
+import { ReferencePicker, referenceLabel } from "./ReferencePicker.js";
+
+const BASE = "https://fhir.example.test/fhir";
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const wrap = () => {
+  const client = new FetchFhirClient({ baseUrl: BASE });
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <FhirClientProvider client={client}>{children}</FhirClientProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe("referenceLabel", () => {
+  it("uses text on a HumanName", () => {
+    expect(
+      referenceLabel({
+        resourceType: "Patient",
+        id: "1",
+        name: [{ text: "Ada Lovelace" }],
+      } as never),
+    ).toBe("Ada Lovelace");
+  });
+
+  it("joins given + family when text is absent", () => {
+    expect(
+      referenceLabel({
+        resourceType: "Patient",
+        id: "1",
+        name: [{ given: ["Ada"], family: "Lovelace" }],
+      } as never),
+    ).toBe("Ada Lovelace");
+  });
+
+  it("uses organization name (string) when present", () => {
+    expect(
+      referenceLabel({
+        resourceType: "Organization",
+        id: "o1",
+        name: "Acme Health",
+      } as never),
+    ).toBe("Acme Health");
+  });
+
+  it("falls back to CodeableConcept.text on observation-shaped resources", () => {
+    expect(
+      referenceLabel({
+        resourceType: "Observation",
+        id: "obs1",
+        code: { text: "Heart rate" },
+      } as never),
+    ).toBe("Heart rate");
+  });
+
+  it("last-resort fallback: Type/id", () => {
+    expect(
+      referenceLabel({ resourceType: "Device", id: "dev-1" } as never),
+    ).toBe("Device/dev-1");
+  });
+});
+
+describe("ReferencePicker", () => {
+  const patients = [
+    { resourceType: "Patient", id: "p1", name: [{ given: ["Ada"], family: "Lovelace" }] },
+    { resourceType: "Patient", id: "p2", name: [{ given: ["Alan"], family: "Turing" }] },
+  ];
+
+  it("searches when the user types and picks a resource on click", async () => {
+    server.use(
+      http.get(`${BASE}/Patient`, ({ request }) => {
+        const q = new URL(request.url).searchParams.get("name");
+        const match = patients.filter((p) =>
+          (p.name[0]?.family ?? "").toLowerCase().includes((q ?? "").toLowerCase()),
+        );
+        return HttpResponse.json({
+          resourceType: "Bundle",
+          type: "searchset",
+          entry: match.map((r) => ({ resource: r })),
+        });
+      }),
+    );
+
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ReferencePicker targets={["Patient"]} value={undefined} onChange={onChange} debounceMs={0} />,
+      { wrapper: wrap() },
+    );
+
+    await user.type(screen.getByRole("searchbox", { name: /search patient/i }), "Lovelace");
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /Ada Lovelace/ })).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("option", { name: /Ada Lovelace/ }));
+    expect(onChange).toHaveBeenCalledWith({
+      reference: "Patient/p1",
+      display: "Ada Lovelace",
+    });
+  });
+
+  it("shows a clear button for an already-selected reference and resets on click", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const value: Reference = { reference: "Patient/p1", display: "Ada Lovelace" };
+    render(<ReferencePicker targets={["Patient"]} value={value} onChange={onChange} />, {
+      wrapper: wrap(),
+    });
+    await user.click(screen.getByRole("button", { name: /clear reference/i }));
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it("shows a target type switcher when multiple targets are allowed", () => {
+    render(
+      <ReferencePicker
+        targets={["Patient", "Practitioner"]}
+        value={undefined}
+        onChange={() => {}}
+      />,
+      { wrapper: wrap() },
+    );
+    const typeSelect = screen.getByRole("combobox", { name: "target type" });
+    expect(typeSelect).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Patient" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Practitioner" })).toBeInTheDocument();
+  });
+
+  it("surfaces empty-state when nothing matches", async () => {
+    server.use(
+      http.get(`${BASE}/Patient`, () =>
+        HttpResponse.json({
+          resourceType: "Bundle",
+          type: "searchset",
+          entry: [],
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    render(
+      <ReferencePicker targets={["Patient"]} value={undefined} onChange={() => {}} debounceMs={0} />,
+      { wrapper: wrap() },
+    );
+    await user.type(screen.getByRole("searchbox", { name: /search patient/i }), "zzz");
+    await waitFor(() =>
+      expect(screen.getByText(/no matches/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/packages/react-fhir/src/components/ReferencePicker.tsx
+++ b/packages/react-fhir/src/components/ReferencePicker.tsx
@@ -1,0 +1,230 @@
+import type { Reference, Resource } from "fhir/r4";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useSearch } from "../hooks/queries.js";
+
+export interface ReferencePickerProps {
+  /** Allowed target resource types (from element.type[].targetProfile). */
+  targets: string[];
+  value: Reference | undefined;
+  onChange: (ref: Reference | undefined) => void;
+  /** Default search param used for the free-text query (default: "name"). */
+  searchParam?: string;
+  /** Max results shown per search (default 10). */
+  limit?: number;
+  /** Debounce (ms) between keystrokes and the server search (default 250). */
+  debounceMs?: number;
+  className?: string;
+}
+
+/**
+ * Produces a human-readable label for a resource. Covers the common cases
+ * encountered when picking references in clinical apps; any resource type not
+ * specifically handled falls back to `{ResourceType}/{id}`.
+ */
+export function referenceLabel(resource: Resource): string {
+  const r = resource as unknown as Record<string, unknown>;
+  // HumanName-bearing resources
+  const names = r.name as Array<Record<string, unknown>> | string | undefined;
+  if (Array.isArray(names) && names[0]) {
+    const first = names[0];
+    if (typeof first.text === "string") return first.text;
+    const given = Array.isArray(first.given) ? (first.given as string[]).join(" ") : "";
+    const family = typeof first.family === "string" ? first.family : "";
+    const combined = [given, family].filter(Boolean).join(" ").trim();
+    if (combined) return combined;
+  }
+  // Organization / Location / Device / others with a single string `name`
+  if (typeof names === "string") return names;
+  // CodeableConcept-based, e.g. Observation.code
+  const code = r.code as { text?: string; coding?: Array<{ display?: string }> } | undefined;
+  if (code?.text) return code.text;
+  if (code?.coding?.[0]?.display) return code.coding[0].display!;
+  // Practitioner + Patient fallback if name was oddly absent
+  if (typeof r.title === "string") return r.title;
+  return `${resource.resourceType}/${resource.id ?? ""}`.replace(/\/$/, "");
+}
+
+/**
+ * Debounced search-and-pick picker for FHIR References. Pairs with the
+ * library's existing `<ResourceEditor>` by replacing the raw `Type/id` text
+ * box currently generated for `Reference` elements.
+ */
+export function ReferencePicker(props: ReferencePickerProps) {
+  const { targets, value, onChange, limit = 10, debounceMs = 250, className } = props;
+  const [selectedType, setSelectedType] = useState<string>(
+    targets[0] ?? "Resource",
+  );
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(query.trim()), debounceMs);
+    return () => clearTimeout(t);
+  }, [query, debounceMs]);
+
+  const searchField = props.searchParam ?? defaultSearchParamFor(selectedType);
+
+  const { data, isFetching } = useSearch<Resource>(
+    selectedType,
+    debouncedQuery
+      ? { [searchField]: debouncedQuery, _count: limit }
+      : undefined,
+    { enabled: Boolean(debouncedQuery) },
+  );
+
+  const results = useMemo(
+    () =>
+      (data?.entry ?? []).flatMap((e) => (e.resource ? [e.resource] : [])),
+    [data],
+  );
+
+  const pick = (resource: Resource) => {
+    onChange({
+      reference: `${resource.resourceType}/${resource.id ?? ""}`,
+      display: referenceLabel(resource),
+    });
+    setIsOpen(false);
+    setQuery("");
+  };
+
+  return (
+    <div
+      className={className ?? "relative space-y-2 rounded border border-slate-200 bg-slate-50 p-2"}
+      data-testid="reference-picker"
+    >
+      {value?.reference ? (
+        <div className="flex items-center gap-2">
+          <span className="flex-1 truncate text-sm">
+            {value.display ?? value.reference}{" "}
+            <code className="ml-1 rounded bg-slate-100 px-1 py-0.5 text-xs text-slate-500">
+              {value.reference}
+            </code>
+          </span>
+          <button
+            type="button"
+            aria-label="Clear reference"
+            onClick={() => onChange(undefined)}
+            className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-600 hover:border-red-400 hover:text-red-600"
+          >
+            ×
+          </button>
+        </div>
+      ) : (
+        <div className="flex gap-2">
+          {targets.length > 1 && (
+            <select
+              aria-label="target type"
+              value={selectedType}
+              onChange={(e) => setSelectedType(e.target.value)}
+              className="rounded border border-slate-300 bg-white px-2 py-1 text-sm"
+            >
+              {targets.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          )}
+          <input
+            type="search"
+            aria-label={`Search ${selectedType}`}
+            placeholder={`Search ${selectedType} by ${searchField}…`}
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setIsOpen(true);
+            }}
+            onFocus={() => setIsOpen(true)}
+            className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
+          />
+        </div>
+      )}
+
+      {!value?.reference && isOpen && debouncedQuery && (
+        <ul
+          role="listbox"
+          className="absolute left-2 right-2 z-10 max-h-64 overflow-auto rounded border border-slate-200 bg-white shadow-lg"
+        >
+          {isFetching && results.length === 0 && (
+            <li className="px-3 py-2 text-xs text-slate-500">Searching…</li>
+          )}
+          {!isFetching && results.length === 0 && (
+            <li className="px-3 py-2 text-xs text-slate-500">No matches</li>
+          )}
+          {results.map((r) => (
+            <li key={`${r.resourceType}/${r.id}`}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={false}
+                onClick={() => pick(r)}
+                className="flex w-full items-baseline justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-slate-50"
+              >
+                <span className="truncate">{referenceLabel(r)}</span>
+                <code className="shrink-0 text-xs text-slate-500">{r.id}</code>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+const namedTypes = new Set([
+  "Patient",
+  "Practitioner",
+  "PractitionerRole",
+  "RelatedPerson",
+  "Person",
+  "Organization",
+  "HealthcareService",
+  "Location",
+  "Device",
+]);
+
+function defaultSearchParamFor(type: string): string {
+  if (namedTypes.has(type)) return "name";
+  if (type === "Observation") return "code";
+  if (type === "Medication" || type === "MedicationRequest") return "code";
+  return "name"; // safe default; user can override via prop
+}
+
+export interface ReferencePickerFallbackProps {
+  value: Reference | undefined;
+  onChange: (ref: Reference | undefined) => void;
+}
+
+/** Plain Reference / display text inputs — used when targetProfile can't be resolved. */
+export function ReferencePickerFallback({ value, onChange }: ReferencePickerFallbackProps) {
+  const v = value ?? {};
+  const patch = (k: keyof Reference, val: unknown) =>
+    onChange({ ...v, [k]: val });
+  return (
+    <div
+      className="grid grid-cols-1 gap-2 rounded border border-slate-200 bg-slate-50 p-2 sm:grid-cols-[1fr_1fr]"
+      data-testid="reference-picker-fallback"
+    >
+      <label>
+        <span className="mb-1 block text-xs font-medium text-slate-500">
+          Reference (Type/id)
+        </span>
+        <input
+          className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm"
+          placeholder="Patient/123"
+          value={v.reference ?? ""}
+          onChange={(e) => patch("reference", e.target.value || undefined)}
+        />
+      </label>
+      <label>
+        <span className="mb-1 block text-xs font-medium text-slate-500">Display</span>
+        <input
+          className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm"
+          value={v.display ?? ""}
+          onChange={(e) => patch("display", e.target.value || undefined)}
+        />
+      </label>
+    </div>
+  );
+}

--- a/packages/react-fhir/src/components/index.ts
+++ b/packages/react-fhir/src/components/index.ts
@@ -4,3 +4,4 @@ export * from "./ResourceView.js";
 export * from "./inputs.js";
 export * from "./ResourceEditor.js";
 export * from "./ResourceSearch.js";
+export * from "./ReferencePicker.js";

--- a/packages/react-fhir/src/components/inputs.tsx
+++ b/packages/react-fhir/src/components/inputs.tsx
@@ -13,6 +13,7 @@ import type {
 import type { ReactNode } from "react";
 import { useValueSet } from "../hooks/queries.js";
 import { bindingFor, codesFromValueSet } from "../structure/binding.js";
+import { ReferencePicker, ReferencePickerFallback } from "./ReferencePicker.js";
 
 export interface InputContext {
   path: string;
@@ -399,31 +400,26 @@ const IdentifierInput: FhirTypeInput<Identifier> = ({ value, onChange }) => {
   );
 };
 
-const ReferenceInput: FhirTypeInput<Reference> = ({ value, onChange }) => {
-  const v = value ?? {};
-  const patch = (k: keyof Reference, val: unknown) =>
-    onChange({ ...v, [k]: val });
-  return (
-    <div className="grid grid-cols-1 gap-2 rounded border border-slate-200 bg-slate-50 p-2 sm:grid-cols-[1fr_1fr]">
-      <label>
-        <span className={subLabel}>Reference (Type/id)</span>
-        <input
-          className={baseField}
-          placeholder="Patient/123"
-          value={v.reference ?? ""}
-          onChange={(e) => patch("reference", e.target.value || undefined)}
-        />
-      </label>
-      <label>
-        <span className={subLabel}>Display</span>
-        <input
-          className={baseField}
-          value={v.display ?? ""}
-          onChange={(e) => patch("display", e.target.value || undefined)}
-        />
-      </label>
-    </div>
-  );
+/**
+ * Prefers the search-and-pick ReferencePicker when the ElementDefinition
+ * advertises allowed `targetProfile`s. Falls back to the raw Reference/display
+ * text inputs when targets can't be derived (e.g. `Reference(Any)`).
+ */
+const ReferenceInput: FhirTypeInput<Reference> = ({ value, onChange, context }) => {
+  const targets = targetTypesFromElement(context.element);
+  if (targets.length > 0) {
+    return <ReferencePicker targets={targets} value={value} onChange={onChange} />;
+  }
+  return <ReferencePickerFallback value={value} onChange={onChange} />;
+};
+
+const targetTypesFromElement = (element: ElementDefinition): string[] => {
+  const refType = element.type?.find((t) => t.code === "Reference");
+  const profiles = refType?.targetProfile ?? [];
+  return profiles
+    .map((p) => p.split("/").pop() ?? "")
+    .filter(Boolean)
+    .filter((t) => t !== "Resource"); // Reference(Any) → empty, fall back to manual
 };
 
 const PeriodInput: FhirTypeInput<Period> = ({ value, onChange }) => {


### PR DESCRIPTION
Closes #5.

## What's new

`<ReferencePicker>` — debounced search-and-pick widget for FHIR References. Replaces the raw `Type/id` text box that was the only way to set a Reference in `<ResourceEditor>` before.

```tsx
<ReferencePicker
  targets={["Patient", "Practitioner"]}
  value={ref}
  onChange={setRef}
/>
```

Behaviour:
- Debounced free-text search via `useSearch(targetType, { name: query, _count: 10 })`
- Dropdown of matches with human-readable labels from `referenceLabel(r)`
- Click → emits `{ reference: "Type/id", display: "Label" }`
- Clear × button for an existing selection
- Multi-target type switcher when >1 target
- Empty-state and loading states
- Per-type default search param: `name` for people/orgs, `code` for Observation / Medication*, overridable via `searchParam` prop

## Automatic wiring into the editor

`ReferenceInput` in `inputs.tsx` now derives allowed targets from `ElementDefinition.type[].targetProfile` (e.g. `http://hl7.org/fhir/StructureDefinition/Patient` → `"Patient"`). When resolvable, `<ResourceEditor>` renders the picker; otherwise falls back to the preserved raw Reference/display text inputs (`ReferencePickerFallback`). Zero per-element wiring.

## Tests

- **5 `referenceLabel` cases** — HumanName text, given+family, Organization string name, CodeableConcept on observation-shaped, last-resort fallback
- **4 picker behaviour cases** — debounced search + pick emits correct Reference; clear button; multi-target switcher shown for 2+ targets; empty-state messaging
- Total: **9 new tests, 127+9 = 136 passing** library-side

## Not in this PR (deferred)

- Keyboard navigation (↑/↓/Enter/Esc) in the dropdown — the issue's AC mentions it; meaningful but non-blocking. Open as a follow-up if desired.
- `formatHumanName` / `formatCodeableConcept` factored out of `renderers.tsx` — current `referenceLabel` helper duplicates a bit of logic; worth extracting into `structure/format.ts` as a chore PR.

## Test plan
- [x] `pnpm -r test:run` + `pnpm -r typecheck` clean
- [ ] After merge: editing Patient.generalPractitioner in the live demo shows a search-and-pick widget