### PR TITLE
feat(components): generic &lt;ResourceTable&gt; driven by StructureDefinition (closes #6)

### DIFF
--- a/packages/react-fhir/src/components/ResourceTable.test.tsx
+++ b/packages/react-fhir/src/components/ResourceTable.test.tsx
@@ -1,0 +1,176 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Patient, StructureDefinition } from "fhir/r4";
+import { describe, expect, it, vi } from "vitest";
+import { FetchFhirClient } from "../client/FetchFhirClient.js";
+import { FhirClientProvider } from "../hooks/FhirClientProvider.js";
+import { getByPath, ResourceTable } from "./ResourceTable.js";
+
+const wrap = () => {
+  const client = new FetchFhirClient({ baseUrl: "https://fhir.example.test/fhir" });
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <FhirClientProvider client={client}>{children}</FhirClientProvider>
+    </QueryClientProvider>
+  );
+};
+
+const sd: StructureDefinition = {
+  resourceType: "StructureDefinition",
+  id: "Patient",
+  url: "http://hl7.org/fhir/StructureDefinition/Patient",
+  name: "Patient",
+  status: "active",
+  kind: "resource",
+  abstract: false,
+  type: "Patient",
+  snapshot: {
+    element: [
+      { id: "Patient", path: "Patient", min: 0, max: "*" },
+      { id: "Patient.name", path: "Patient.name", min: 0, max: "*", short: "Name", type: [{ code: "HumanName" }] },
+      { id: "Patient.gender", path: "Patient.gender", min: 0, max: "1", short: "Gender", type: [{ code: "code" }] },
+      { id: "Patient.birthDate", path: "Patient.birthDate", min: 0, max: "1", short: "Birth date", type: [{ code: "date" }] },
+    ],
+  },
+};
+
+const patients: Patient[] = [
+  {
+    resourceType: "Patient",
+    id: "p1",
+    name: [{ given: ["Ada"], family: "Lovelace" }],
+    gender: "female",
+    birthDate: "1815-12-10",
+  },
+  {
+    resourceType: "Patient",
+    id: "p2",
+    name: [{ given: ["Alan"], family: "Turing" }],
+    gender: "male",
+    birthDate: "1912-06-23",
+  },
+];
+
+describe("getByPath", () => {
+  it("reads nested string paths", () => {
+    expect(getByPath({ a: { b: { c: 42 } } }, "a.b.c")).toBe(42);
+  });
+
+  it("auto-indexes the first element of arrays", () => {
+    expect(
+      getByPath({ name: [{ family: "Smith" }, { family: "Jones" }] }, "name.family"),
+    ).toBe("Smith");
+  });
+
+  it("supports explicit [idx] segments", () => {
+    expect(
+      getByPath({ name: [{ family: "Smith" }, { family: "Jones" }] }, "name[1].family"),
+    ).toBe("Jones");
+  });
+
+  it("returns undefined for missing segments", () => {
+    expect(getByPath({ a: 1 }, "a.b.c")).toBeUndefined();
+  });
+});
+
+describe("ResourceTable", () => {
+  it("renders a header + row per resource with datatype-aware cells", () => {
+    render(
+      <ResourceTable<Patient>
+        resources={patients}
+        columns={["name", "gender", "birthDate"]}
+        structureDefinition={sd}
+      />,
+      { wrapper: wrap() },
+    );
+    // Headers derived from SD.short
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Gender")).toBeInTheDocument();
+    expect(screen.getByText("Birth date")).toBeInTheDocument();
+    // Rows rendered
+    const rows = screen.getAllByTestId("resource-row");
+    expect(rows).toHaveLength(2);
+    // HumanName cell uses the type renderer
+    expect(within(rows[0]!).getByText(/Ada Lovelace/)).toBeInTheDocument();
+  });
+
+  it("supports custom cellRenderers per path", () => {
+    render(
+      <ResourceTable<Patient>
+        resources={patients}
+        columns={["name"]}
+        cellRenderers={{
+          name: (p) => <span data-testid="custom-name">{p.id}</span>,
+        }}
+        structureDefinition={sd}
+      />,
+      { wrapper: wrap() },
+    );
+    expect(screen.getAllByTestId("custom-name")).toHaveLength(2);
+  });
+
+  it("invokes onRowClick when a row is clicked", async () => {
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ResourceTable<Patient>
+        resources={patients}
+        columns={["name"]}
+        onRowClick={onRowClick}
+        structureDefinition={sd}
+      />,
+      { wrapper: wrap() },
+    );
+    await user.click(screen.getAllByTestId("resource-row")[0]!);
+    expect(onRowClick).toHaveBeenCalledWith(patients[0]);
+  });
+
+  it("toggles sort direction via header click (controlled)", async () => {
+    const onSortChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ResourceTable<Patient>
+        resources={patients}
+        columns={["gender"]}
+        sort={{ by: "gender", direction: "asc" }}
+        onSortChange={onSortChange}
+        structureDefinition={sd}
+      />,
+      { wrapper: wrap() },
+    );
+    await user.click(screen.getByRole("button", { name: /gender/i }));
+    expect(onSortChange).toHaveBeenCalledWith({ by: "gender", direction: "desc" });
+  });
+
+  it("renders emptyState when resources is empty", () => {
+    render(
+      <ResourceTable<Patient>
+        resources={[]}
+        columns={["gender"]}
+        emptyState={<p data-testid="empty">Nothing here</p>}
+        structureDefinition={sd}
+      />,
+      { wrapper: wrap() },
+    );
+    expect(screen.getByTestId("empty")).toBeInTheDocument();
+  });
+
+  it("falls back to a friendly dash for missing cell values", () => {
+    const partial: Patient = { resourceType: "Patient", id: "p3", gender: "other" };
+    render(
+      <ResourceTable<Patient>
+        resources={[partial]}
+        columns={["name", "gender"]}
+        structureDefinition={sd}
+      />,
+      { wrapper: wrap() },
+    );
+    const row = screen.getByTestId("resource-row");
+    // Name missing → em-dash placeholder
+    expect(within(row).getByText("—")).toBeInTheDocument();
+    // Gender present → renders via code renderer
+    expect(within(row).getByText("other")).toBeInTheDocument();
+  });
+});

--- a/packages/react-fhir/src/components/ResourceTable.tsx
+++ b/packages/react-fhir/src/components/ResourceTable.tsx
@@ -1,0 +1,242 @@
+import type { Reference, Resource, StructureDefinition } from "fhir/r4";
+import { Fragment, useMemo, type ReactNode } from "react";
+import { useStructureDefinition } from "../hooks/queries.js";
+import { findElement } from "../structure/walker.js";
+import {
+  defaultTypeRenderers,
+  type RendererContext,
+  type TypeRenderers,
+} from "./renderers.js";
+
+export interface ResourceTableSort {
+  by: string;
+  direction: "asc" | "desc";
+}
+
+export interface ResourceTableProps<T extends Resource = Resource> {
+  resources: T[];
+  /** Dotted FHIR paths to show as columns, e.g. `["status", "code.text", "subject.display"]`. */
+  columns: string[];
+  /** Override the default cell renderer for specific column paths. */
+  cellRenderers?: Record<string, (resource: T) => ReactNode>;
+  /** Override column header labels (defaults to the StructureDefinition element's `short`). */
+  columnLabels?: Record<string, string>;
+  /** Row click handler — when present, rows become clickable (keyboard accessible). */
+  onRowClick?: (resource: T) => void;
+  /** Controlled sort state. When set, header cells become sort triggers. */
+  sort?: ResourceTableSort;
+  onSortChange?: (sort: ResourceTableSort) => void;
+  emptyState?: ReactNode;
+  /** When provided, overrides the fetched StructureDefinition (useful for tests / profiles). */
+  structureDefinition?: StructureDefinition;
+  /** Merged on top of `defaultTypeRenderers` for cell formatting. */
+  renderers?: TypeRenderers;
+  /** Click handler for Reference cells. */
+  onReferenceClick?: (ref: Reference) => void;
+  className?: string;
+}
+
+const headerFromPath = (path: string, short?: string): string => {
+  if (short && short.length <= 40 && !short.includes("|") && !short.includes(".")) {
+    return short;
+  }
+  const last = path.split(".").pop() ?? path;
+  return last.replace(/([A-Z])/g, " $1").replace(/^./, (c) => c.toUpperCase()).trim();
+};
+
+export function getByPath(obj: unknown, path: string): unknown {
+  if (!obj) return undefined;
+  let cur: unknown = obj;
+  for (const segment of path.split(".")) {
+    if (cur === null || cur === undefined) return undefined;
+    // Support "coding[0]" segments by resolving the index separately.
+    const match = segment.match(/^(\w+)\[(\d+)\]$/);
+    if (match) {
+      cur = (cur as Record<string, unknown>)[match[1]!];
+      if (Array.isArray(cur)) cur = cur[Number(match[2])];
+    } else {
+      cur = (cur as Record<string, unknown>)[segment];
+      if (Array.isArray(cur)) cur = cur[0]; // auto-pick first item for non-indexed segments
+    }
+  }
+  return cur;
+}
+
+/**
+ * Generic table driven by the StructureDefinition's datatype metadata. Cells
+ * format using the same `defaultTypeRenderers` map as `<ResourceView>`, so a
+ * CodeableConcept in a table cell and in a detail page render identically.
+ */
+export function ResourceTable<T extends Resource = Resource>({
+  resources,
+  columns,
+  cellRenderers,
+  columnLabels,
+  onRowClick,
+  sort,
+  onSortChange,
+  emptyState,
+  structureDefinition,
+  renderers: rendererOverrides,
+  onReferenceClick,
+  className,
+}: ResourceTableProps<T>) {
+  const resourceType = resources[0]?.resourceType ?? "";
+  const sdQuery = useStructureDefinition(resourceType, {
+    enabled: !structureDefinition && Boolean(resourceType),
+  });
+  const sd = structureDefinition ?? sdQuery.data;
+
+  const headers = useMemo(
+    () =>
+      columns.map((path) => {
+        const label = columnLabels?.[path];
+        if (label) return { path, label, typeCode: typeForPath(sd, resourceType, path) };
+        const qualified = `${resourceType}.${path.split("[")[0]!.replace(/\.\d+$/, "")}`;
+        const element = sd ? findElement(sd, qualified) : undefined;
+        return {
+          path,
+          label: headerFromPath(path, element?.short),
+          typeCode: element?.type?.[0]?.code,
+        };
+      }),
+    [columns, columnLabels, sd, resourceType],
+  );
+
+  const renderers: TypeRenderers = { ...defaultTypeRenderers, ...rendererOverrides };
+
+  const toggleSort = (by: string) => {
+    if (!onSortChange) return;
+    const direction: "asc" | "desc" =
+      sort?.by === by && sort.direction === "asc" ? "desc" : "asc";
+    onSortChange({ by, direction });
+  };
+
+  if (resources.length === 0) {
+    return <>{emptyState ?? <p className="text-sm text-slate-500">No results.</p>}</>;
+  }
+
+  return (
+    <div className={className ?? "overflow-x-auto rounded border border-slate-200 bg-white"} data-testid="resource-table">
+      <table className="w-full text-sm">
+        <thead className="border-b border-slate-200 bg-slate-50 text-left">
+          <tr>
+            {headers.map((h) => (
+              <th key={h.path} className="px-3 py-2 font-medium text-slate-600">
+                {onSortChange ? (
+                  <button
+                    type="button"
+                    onClick={() => toggleSort(h.path)}
+                    className="flex items-center gap-1 hover:text-slate-900"
+                  >
+                    {h.label}
+                    {sort?.by === h.path && (
+                      <span aria-hidden className="text-[10px]">
+                        {sort.direction === "asc" ? "▲" : "▼"}
+                      </span>
+                    )}
+                  </button>
+                ) : (
+                  h.label
+                )}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {resources.map((r) => (
+            <tr
+              key={`${r.resourceType}/${r.id}`}
+              className={onRowClick ? "cursor-pointer hover:bg-slate-50" : undefined}
+              onClick={onRowClick ? () => onRowClick(r) : undefined}
+              onKeyDown={
+                onRowClick
+                  ? (e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onRowClick(r);
+                      }
+                    }
+                  : undefined
+              }
+              tabIndex={onRowClick ? 0 : undefined}
+              data-testid="resource-row"
+            >
+              {headers.map((h) => (
+                <Fragment key={h.path}>
+                  <td className="px-3 py-2 align-top">
+                    {renderCell({
+                      resource: r,
+                      path: h.path,
+                      typeCode: h.typeCode,
+                      cellRenderers,
+                      renderers,
+                      onReferenceClick,
+                    })}
+                  </td>
+                </Fragment>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function typeForPath(
+  sd: StructureDefinition | undefined,
+  base: string,
+  path: string,
+): string | undefined {
+  if (!sd) return undefined;
+  // Strip any [index] segments and numeric indices for the SD lookup.
+  const cleaned = path.replace(/\[\d+\]/g, "").replace(/\.\d+$/g, "");
+  const el = findElement(sd, `${base}.${cleaned}`);
+  return el?.type?.[0]?.code;
+}
+
+interface RenderCellParams<T extends Resource> {
+  resource: T;
+  path: string;
+  typeCode: string | undefined;
+  cellRenderers?: Record<string, (r: T) => ReactNode>;
+  renderers: TypeRenderers;
+  onReferenceClick?: (ref: Reference) => void;
+}
+
+function renderCell<T extends Resource>({
+  resource,
+  path,
+  typeCode,
+  cellRenderers,
+  renderers,
+  onReferenceClick,
+}: RenderCellParams<T>): ReactNode {
+  const custom = cellRenderers?.[path];
+  if (custom) return custom(resource);
+
+  const value = getByPath(resource, path);
+  if (value === undefined || value === null || value === "") {
+    return <span className="text-slate-400">—</span>;
+  }
+
+  const ctx: RendererContext = {
+    path,
+    typeCode,
+    ...(onReferenceClick ? { onReferenceClick } : {}),
+  };
+
+  const renderer = typeCode ? renderers[typeCode] : undefined;
+  if (renderer) return <>{renderer(value, ctx)}</>;
+
+  // Fallback for unknown types or plain primitives.
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return <span>{String(value)}</span>;
+  }
+  return (
+    <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
+      {JSON.stringify(value).slice(0, 60)}
+    </code>
+  );
+}

--- a/packages/react-fhir/src/components/index.ts
+++ b/packages/react-fhir/src/components/index.ts
@@ -5,3 +5,4 @@ export * from "./inputs.js";
 export * from "./ResourceEditor.js";
 export * from "./ResourceSearch.js";
 export * from "./ReferencePicker.js";
+export * from "./ResourceTable.js";


### PR DESCRIPTION
Closes #6.

## What's new

`<ResourceTable>` — generic, spec-driven list component. Complements the existing `<ResourceView>` (detail) and `<ResourceSearch>` (filter form) so consumers get the full **browse → filter → detail** trio out of the box.

```tsx
<ResourceTable<Task>
  resources={tasks}
  columns={["status", "priority", "for.display", "authoredOn"]}
  onRowClick={(t) => navigate(`/Task/${t.id}`)}
  sort={sort}
  onSortChange={setSort}
/>
```

## How it works

- **Column paths are dotted FHIR paths.** `getByPath(resource, "code.coding[0].display")` walks the object. Non-indexed segments auto-pick `[0]` to match common FHIRPath expectations; `[idx]` syntax available when you need a specific index.
- **Headers derive from the StructureDefinition's `element.short`** via `useStructureDefinition` (same hook as the view + editor, so bundled core SDs cover HAPI). Override with `columnLabels` prop.
- **Cells use `defaultTypeRenderers`** — HumanName / CodeableConcept / Reference / Quantity all look identical across `<ResourceTable>` and `<ResourceView>`. Pass `renderers` to override per-datatype.
- **Per-column overrides** via `cellRenderers={{ path: (resource) => <YourNode/> }}`.
- **Row click**: mouse + keyboard (tabIndex=0, Enter/Space).
- **Sort**: controlled via `sort` + `onSortChange`; headers become buttons that toggle asc↔desc with an arrow indicator on the active column.
- **Empty state + missing values**: configurable `emptyState`, em-dash placeholder for empty cells.

## Tests

- **`getByPath`**: nested paths, auto-indexing arrays, explicit `[idx]`, missing segments
- **Table**: SD-driven headers, custom `cellRenderers`, `onRowClick`, sort toggle emits direction flip, `emptyState`, missing-value fallback
- **Total: 10 new tests**, 137 library tests passing

## Not in this PR

- `<ColumnPicker>` with localStorage persistence — the issue mentions it as a nice-to-have. Intentional split: this PR delivers the core table, a small follow-up PR adds the picker. Keeps review scope tight.
- Demo app wiring — an optional follow-up adds a "Table view" toggle on the Patient index to dogfood it.

## Test plan
- [x] `pnpm -r test:run` + `pnpm -r typecheck` clean
- [ ] After merge: a consumer building a Tasks/Goals tracker can drop this in and get a working, sortable table in ~5 lines
- [ ] Optional demo-wiring follow-up adds a table variant to PatientListPage