### PR TITLE
feat(components): date picker for date search params + bundled R4 ValueSets for token dropdowns

### DIFF
--- a/packages/react-fhir/src/components/ResourceSearch.date.test.tsx
+++ b/packages/react-fhir/src/components/ResourceSearch.date.test.tsx
@@ -1,0 +1,103 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { CapabilityStatement } from "fhir/r4";
+import { describe, expect, it, vi } from "vitest";
+import { FetchFhirClient } from "../client/FetchFhirClient.js";
+import { FhirClientProvider } from "../hooks/FhirClientProvider.js";
+import { ResourceSearch } from "./ResourceSearch.js";
+
+const cap: CapabilityStatement = {
+  resourceType: "CapabilityStatement",
+  status: "active",
+  date: "2024-01-01",
+  kind: "instance",
+  fhirVersion: "4.0.1",
+  format: ["json"],
+  rest: [
+    {
+      mode: "server",
+      resource: [
+        {
+          type: "Patient",
+          searchParam: [
+            { name: "birthdate", type: "date", documentation: "Date of birth" },
+            { name: "name", type: "string" },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const wrap = (ui: React.ReactElement) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const client = new FetchFhirClient({ baseUrl: "https://fhir.example.test/fhir" });
+  return render(
+    <QueryClientProvider client={qc}>
+      <FhirClientProvider client={client}>{ui}</FhirClientProvider>
+    </QueryClientProvider>,
+  );
+};
+
+describe("ResourceSearch — date search fields", () => {
+  it("renders a native date picker + prefix selector for date params", () => {
+    wrap(<ResourceSearch resourceType="Patient" capabilityStatement={cap} />);
+    const dateInput = screen.getByLabelText("birthdate") as HTMLInputElement;
+    // HTML5 date inputs register as role=textbox in jsdom; assert `type=date` explicitly.
+    expect(dateInput.getAttribute("type")).toBe("date");
+    // Prefix selector with every FHIR prefix option.
+    const prefix = screen.getByRole("combobox", { name: "birthdate prefix" });
+    const options = within(prefix).getAllByRole("option");
+    expect(options.map((o) => (o as HTMLOptionElement).value)).toEqual(
+      ["", "eq", "ne", "lt", "le", "gt", "ge", "ap"],
+    );
+  });
+
+  it("emits plain date when no prefix is chosen", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    wrap(
+      <ResourceSearch
+        resourceType="Patient"
+        capabilityStatement={cap}
+        onSubmit={onSubmit}
+      />,
+    );
+    const dateInput = screen.getByLabelText("birthdate") as HTMLInputElement;
+    fireEvent.change(dateInput, { target: { value: "2024-01-15" } });
+    await user.click(screen.getByRole("button", { name: /search/i }));
+    expect(onSubmit).toHaveBeenCalledWith({ birthdate: "2024-01-15" });
+  });
+
+  it("prefixes the date when a prefix is selected", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    wrap(
+      <ResourceSearch
+        resourceType="Patient"
+        capabilityStatement={cap}
+        onSubmit={onSubmit}
+      />,
+    );
+    const dateInput = screen.getByLabelText("birthdate") as HTMLInputElement;
+    fireEvent.change(dateInput, { target: { value: "2024-01-15" } });
+    await user.selectOptions(screen.getByRole("combobox", { name: "birthdate prefix" }), "ge");
+    await user.click(screen.getByRole("button", { name: /search/i }));
+    expect(onSubmit).toHaveBeenCalledWith({ birthdate: "ge2024-01-15" });
+  });
+
+  it("rehydrates the prefix + date from an initial value like 'lt2020-05-01'", () => {
+    wrap(
+      <ResourceSearch
+        resourceType="Patient"
+        capabilityStatement={cap}
+        initialParams={{ birthdate: "lt2020-05-01" }}
+      />,
+    );
+    const dateInput = screen.getByLabelText("birthdate") as HTMLInputElement;
+    const prefix = screen.getByRole("combobox", { name: "birthdate prefix" }) as HTMLSelectElement;
+    expect(dateInput.value).toBe("2020-05-01");
+    expect(prefix.value).toBe("lt");
+  });
+});

--- a/packages/react-fhir/src/components/ResourceSearch.test.tsx
+++ b/packages/react-fhir/src/components/ResourceSearch.test.tsx
@@ -84,8 +84,10 @@ describe("ResourceSearch", () => {
       />,
     );
     // name, identifier, birthdate, gender, organization, address-city, phone, _id
+    // birthdate is a date input (role is not textbox), so textbox count is 7.
     const fields = screen.getAllByRole("textbox");
-    expect(fields.length).toBe(8);
+    expect(fields.length).toBe(7);
+    expect(screen.getByLabelText("birthdate")).toBeInTheDocument();
     expect(screen.getAllByPlaceholderText(/code or system\|code/i).length).toBeGreaterThan(0);
   });
 
@@ -149,7 +151,8 @@ describe("ResourceSearch", () => {
     );
     expect(screen.getAllByRole("textbox").length).toBe(3);
     await user.click(screen.getByRole("button", { name: /show.*more parameters/i }));
-    expect(screen.getAllByRole("textbox").length).toBe(8);
+    // birthdate is a date input, not a textbox — so 7 textboxes after expand.
+    expect(screen.getAllByRole("textbox").length).toBe(7);
   });
 
   it("shows a friendly message when no params are advertised", () => {

--- a/packages/react-fhir/src/components/ResourceSearch.tsx
+++ b/packages/react-fhir/src/components/ResourceSearch.tsx
@@ -207,6 +207,9 @@ function SearchField({ base, param, value, onChange }: SearchFieldProps): ReactN
       <TokenSearchField base={base} param={param} value={value} onChange={onChange} />
     );
   }
+  if (param.type === "date") {
+    return <DateSearchField param={param} value={value} onChange={onChange} />;
+  }
   return fieldWrapper(
     <input
       type={inputType(param.type)}
@@ -277,6 +280,75 @@ function TokenSearchField({ base, param, value, onChange }: SearchFieldProps): R
         </option>
       ))}
     </select>,
+    param,
+  );
+}
+
+/* ---------- date ---------- */
+
+type DatePrefix = "eq" | "ne" | "lt" | "le" | "gt" | "ge" | "ap";
+
+interface DatePrefixOption {
+  value: DatePrefix | "";
+  label: string;
+  title: string;
+}
+
+const DATE_PREFIXES: DatePrefixOption[] = [
+  { value: "", label: "=", title: "equals (default)" },
+  { value: "eq", label: "=", title: "equals" },
+  { value: "ne", label: "≠", title: "not equal" },
+  { value: "lt", label: "<", title: "less than" },
+  { value: "le", label: "≤", title: "less than or equal" },
+  { value: "gt", label: ">", title: "greater than" },
+  { value: "ge", label: "≥", title: "greater than or equal" },
+  { value: "ap", label: "~", title: "approximately" },
+];
+
+interface DateSearchFieldProps {
+  param: CapabilityStatementRestResourceSearchParam;
+  value: string;
+  onChange: (v: string) => void;
+}
+
+/**
+ * FHIR date search field: a prefix selector (eq/ne/lt/gt/ge/le/ap) paired with
+ * a native date picker. Parses the incoming `value` so the two controls stay
+ * in sync with whatever the parent holds — e.g. `ge2024-01-01` splits into
+ * prefix="ge" + date="2024-01-01".
+ */
+function DateSearchField({ param, value, onChange }: DateSearchFieldProps): ReactNode {
+  const match = value.match(/^(eq|ne|lt|le|gt|ge|ap)?(\d{4}-\d{2}-\d{2})?$/);
+  const prefix = (match?.[1] ?? "") as DatePrefix | "";
+  const date = match?.[2] ?? "";
+
+  const commit = (nextPrefix: string, nextDate: string) => {
+    if (!nextDate) return onChange("");
+    onChange(`${nextPrefix}${nextDate}`);
+  };
+
+  return fieldWrapper(
+    <div className="flex gap-1">
+      <select
+        aria-label={`${param.name} prefix`}
+        value={prefix}
+        onChange={(e) => commit(e.target.value, date)}
+        className="rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
+      >
+        {DATE_PREFIXES.map((p) => (
+          <option key={`${p.value}-${p.label}`} value={p.value} title={p.title}>
+            {p.label}
+          </option>
+        ))}
+      </select>
+      <input
+        type="date"
+        aria-label={param.name}
+        value={date}
+        onChange={(e) => commit(prefix, e.target.value)}
+        className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
+      />
+    </div>,
     param,
   );
 }

--- a/packages/react-fhir/src/components/ResourceSearch.tsx
+++ b/packages/react-fhir/src/components/ResourceSearch.tsx
@@ -3,8 +3,15 @@ import type {
   CapabilityStatement,
 } from "fhir/r4";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { useCapabilities } from "../hooks/queries.js";
+import {
+  useCapabilities,
+  useStructureDefinition,
+  useValueSet,
+} from "../hooks/queries.js";
 import type { SearchParams } from "../client/types.js";
+import { bindingFor, codesFromValueSet } from "../structure/binding.js";
+import { elementPathForSearchParam } from "../structure/searchBinding.js";
+import { findElement } from "../structure/walker.js";
 
 export interface ResourceSearchProps {
   resourceType: string;
@@ -130,6 +137,7 @@ export function ResourceSearch(props: ResourceSearchProps) {
         {visible.map((p) => (
           <SearchField
             key={p.name}
+            base={resourceType}
             param={p}
             value={values[p.name!] ?? ""}
             onChange={(v) => setParam(p.name!, v)}
@@ -172,34 +180,104 @@ export function ResourceSearch(props: ResourceSearchProps) {
 }
 
 interface SearchFieldProps {
+  base: string;
   param: CapabilityStatementRestResourceSearchParam;
   value: string;
   onChange: (v: string) => void;
 }
 
-function SearchField({ param, value, onChange }: SearchFieldProps): ReactNode {
-  return (
-    <label className="block">
-      <span className="mb-1 flex items-baseline justify-between gap-2">
-        <span className="text-xs font-medium text-slate-600">{param.name}</span>
-        <span className="text-[10px] uppercase text-slate-400">
-          {param.type}
-        </span>
+const fieldWrapper = (children: ReactNode, param: CapabilityStatementRestResourceSearchParam): ReactNode => (
+  <label className="block">
+    <span className="mb-1 flex items-baseline justify-between gap-2">
+      <span className="text-xs font-medium text-slate-600">{param.name}</span>
+      <span className="text-[10px] uppercase text-slate-400">{param.type}</span>
+    </span>
+    {children}
+    {param.documentation && (
+      <span className="mt-0.5 block text-[11px] text-slate-400">
+        {param.documentation}
       </span>
+    )}
+  </label>
+);
+
+function SearchField({ base, param, value, onChange }: SearchFieldProps): ReactNode {
+  if (param.type === "token") {
+    return (
+      <TokenSearchField base={base} param={param} value={value} onChange={onChange} />
+    );
+  }
+  return fieldWrapper(
+    <input
+      type={inputType(param.type)}
+      aria-label={param.name}
+      placeholder={inputPlaceholder(param.type)}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
+    />,
+    param,
+  );
+}
+
+/**
+ * Token search field: look up the bound ValueSet via the spec (convention
+ * mapping name → element → binding) and render a <select> when available.
+ * Falls back to a plain text input when the binding can't be resolved or when
+ * the ValueSet is too large to enumerate in a dropdown.
+ */
+function TokenSearchField({ base, param, value, onChange }: SearchFieldProps): ReactNode {
+  const elementPath = elementPathForSearchParam(param, base);
+  const { data: sd } = useStructureDefinition(base, { enabled: Boolean(elementPath) });
+  const element = elementPath && sd ? findElement(sd, elementPath) : undefined;
+  const { valueSet: valueSetUrl } = bindingFor(element);
+  const { data: vs, isLoading } = useValueSet(valueSetUrl);
+  const codes = codesFromValueSet(vs);
+
+  const fallbackInput = (
+    <input
+      type="text"
+      aria-label={param.name}
+      placeholder={inputPlaceholder(param.type)}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
+    />
+  );
+
+  if (valueSetUrl && isLoading) {
+    return fieldWrapper(
       <input
-        type={inputType(param.type)}
+        type="text"
         aria-label={param.name}
-        placeholder={inputPlaceholder(param.type)}
         value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
-      />
-      {param.documentation && (
-        <span className="mt-0.5 block text-[11px] text-slate-400">
-          {param.documentation}
-        </span>
-      )}
-    </label>
+        readOnly
+        placeholder="Loading value set…"
+        className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm"
+      />,
+      param,
+    );
+  }
+
+  if (codes.length === 0 || codes.length > 100) {
+    return fieldWrapper(fallbackInput, param);
+  }
+
+  return fieldWrapper(
+    <select
+      aria-label={param.name}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
+    >
+      <option value="">—</option>
+      {codes.map((c) => (
+        <option key={c.code} value={c.code}>
+          {c.display ? `${c.display} (${c.code})` : c.code}
+        </option>
+      ))}
+    </select>,
+    param,
   );
 }
 

--- a/packages/react-fhir/src/hooks/queries.ts
+++ b/packages/react-fhir/src/hooks/queries.ts
@@ -15,6 +15,7 @@ import type {
   ValueSet,
 } from "fhir/r4";
 import type { FhirClient, SearchParams } from "../client/types.js";
+import { coreValueSet } from "../structure/core/valuesets.js";
 import { resolveStructureDefinition } from "../structure/resolve.js";
 import { useFhirClient } from "./FhirClientProvider.js";
 
@@ -122,10 +123,13 @@ export function useStructureDefinition(
 /**
  * Resolves a ValueSet by canonical URL.
  *
- * Prefers `ValueSet/$expand?url={canonical}` when supported so we get a
- * server-computed enumeration of codes; falls back to `ValueSet?url={canonical}`
- * + the first matching resource so consumers can locally expand
- * `compose.include[].concept[]` via {@link codesFromValueSet}.
+ * Three-step fallback so dropdowns work against every server:
+ *   1. `ValueSet/$expand?url={canonical}` — server-computed enumeration
+ *   2. `ValueSet?url={canonical}` + the first matching resource — consumers
+ *      can locally expand via {@link codesFromValueSet}
+ *   3. Library-bundled core R4 ValueSet (administrative-gender,
+ *      observation-status, task-status, etc.) — keeps dropdowns populated
+ *      even when the server serves nothing terminology-related
  */
 export function useValueSet(
   canonical: string | undefined,
@@ -136,25 +140,33 @@ export function useValueSet(
     queryKey: fhirQueryKeys.valueSet(client.baseUrl, canonical ?? ""),
     queryFn: async ({ signal }) => {
       const url = canonical!;
-      // Try $expand first — returns an already-flattened ValueSet.
+      // 1. $expand
       try {
         return await client.request<ValueSet>({
           path: `/ValueSet/$expand?url=${encodeURIComponent(url)}`,
           signal,
         });
       } catch {
-        // Fall back to the raw definition; caller can local-expand.
+        // fall through
+      }
+      // 2. search by url
+      try {
         const bundle = await client.search<ValueSet>(
           "ValueSet",
           { url },
           { signal },
         );
         const hit = bundle.entry?.[0]?.resource;
-        if (!hit) {
-          throw new Error(`ValueSet ${url} not found on this server`);
-        }
-        return hit;
+        if (hit) return hit;
+      } catch {
+        // fall through
       }
+      // 3. bundled fallback
+      const bundled = coreValueSet(url);
+      if (bundled) return bundled;
+      throw new Error(
+        `ValueSet ${url} could not be resolved from this server and is not bundled in the library`,
+      );
     },
     enabled: Boolean(canonical),
     staleTime: 24 * 60 * 60_000,

--- a/packages/react-fhir/src/structure/core/index.ts
+++ b/packages/react-fhir/src/structure/core/index.ts
@@ -1,4 +1,5 @@
 import type { StructureDefinition } from "fhir/r4";
+export { coreValueSet, coreValueSets, bundledValueSetUrls } from "./valuesets.js";
 
 /**
  * Returns the library's bundled R4 core StructureDefinition for a resource

--- a/packages/react-fhir/src/structure/core/valuesets.test.ts
+++ b/packages/react-fhir/src/structure/core/valuesets.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { codesFromValueSet } from "../binding.js";
+import { bundledValueSetUrls, coreValueSet, coreValueSets } from "./valuesets.js";
+
+describe("bundled core ValueSets", () => {
+  it("returns undefined for an unknown canonical URL", () => {
+    expect(coreValueSet("http://example.org/unknown")).toBeUndefined();
+    expect(coreValueSet(undefined)).toBeUndefined();
+  });
+
+  it("bundles administrative-gender with the four spec values", () => {
+    const vs = coreValueSet("http://hl7.org/fhir/ValueSet/administrative-gender");
+    expect(vs).toBeDefined();
+    const codes = codesFromValueSet(vs);
+    expect(codes.map((c) => c.code)).toEqual(["male", "female", "other", "unknown"]);
+    expect(codes.every((c) => c.system === "http://hl7.org/fhir/administrative-gender")).toBe(true);
+  });
+
+  it("bundles observation-status with the 8 spec values", () => {
+    const vs = coreValueSet("http://hl7.org/fhir/ValueSet/observation-status");
+    expect(vs).toBeDefined();
+    const codes = codesFromValueSet(vs).map((c) => c.code);
+    expect(codes).toContain("registered");
+    expect(codes).toContain("final");
+    expect(codes).toContain("entered-in-error");
+    expect(codes.length).toBe(8);
+  });
+
+  it("bundles task-status with 'in-progress' included", () => {
+    const codes = codesFromValueSet(
+      coreValueSet("http://hl7.org/fhir/ValueSet/task-status"),
+    );
+    expect(codes.map((c) => c.code)).toContain("in-progress");
+  });
+
+  it("exposes every bundled URL via bundledValueSetUrls", () => {
+    expect(bundledValueSetUrls.length).toBeGreaterThanOrEqual(13);
+    for (const url of bundledValueSetUrls) {
+      expect(coreValueSet(url)).toBeDefined();
+    }
+    // Internal Map and the URL list agree.
+    expect(new Set(bundledValueSetUrls)).toEqual(new Set(coreValueSets.keys()));
+  });
+
+  it("every bundled ValueSet produces at least one code", () => {
+    for (const url of bundledValueSetUrls) {
+      const codes = codesFromValueSet(coreValueSet(url));
+      expect(codes.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/react-fhir/src/structure/core/valuesets.ts
+++ b/packages/react-fhir/src/structure/core/valuesets.ts
@@ -1,0 +1,210 @@
+import type { ValueSet } from "fhir/r4";
+
+/**
+ * Bundled R4 core ValueSets — served from memory when the target FHIR server
+ * can't resolve them via `$expand` or `?url=...`. These are the fixed,
+ * non-extensible enumerations from the FHIR spec itself, so they can't drift.
+ *
+ * Ships as a Map keyed by canonical URL so consumers (and `useValueSet`) can
+ * look them up in one step. Each entry is already in "expanded" form so
+ * `codesFromValueSet` reads them without further transformation.
+ */
+
+const mk = (
+  url: string,
+  codes: Array<{ code: string; display?: string }>,
+  system: string,
+): ValueSet => ({
+  resourceType: "ValueSet",
+  status: "active",
+  url,
+  expansion: {
+    identifier: "bundled",
+    timestamp: "2024-01-01T00:00:00Z",
+    contains: codes.map((c) => ({ system, code: c.code, display: c.display })),
+  },
+});
+
+export const coreValueSets: Map<string, ValueSet> = new Map(
+  (
+    [
+      mk(
+        "http://hl7.org/fhir/ValueSet/administrative-gender",
+        [
+          { code: "male", display: "Male" },
+          { code: "female", display: "Female" },
+          { code: "other", display: "Other" },
+          { code: "unknown", display: "Unknown" },
+        ],
+        "http://hl7.org/fhir/administrative-gender",
+      ),
+      mk(
+        "http://hl7.org/fhir/ValueSet/observation-status",
+        [
+          { code: "registered", display: "Registered" },
+          { code: "preliminary", display: "Preliminary" },
+          { code: "final", display: "Final" },
+          { code: "amended", display: "Amended" },
+          { code: "corrected", display: "Corrected" },
+          { code: "cancelled", display: "Cancelled" },
+          { code: "entered-in-error", display: "Entered in Error" },
+          { code: "unknown", display: "Unknown" },
+        ],
+        "http://hl7.org/fhir/observation-status",
+      ),
+      mk(
+        "http://hl7.org/fhir/ValueSet/condition-clinical",
+        [
+          { code: "active", display: "Active" },
+          { code: "recurrence", display: "Recurrence" },
+          { code: "relapse", display: "Relapse" },
+          { code: "inactive", display: "Inactive" },
+          { code: "remission", display: "Remission" },
+          { code: "resolved", display: "Resolved" },
+        ],
+        "http://terminology.hl7.org/CodeSystem/condition-clinical",
+      ),
+      mk(
+        "http://hl7.org/fhir/ValueSet/condition-ver-status",
+        [
+          { code: "unconfirmed", display: "Unconfirmed" },
+          { code: "provisional", display: "Provisional" },
+          { code: "differential", display: "Differential" },
+          { code: "confirmed", display: "Confirmed" },
+          { code: "refuted", display: "Refuted" },
+          { code: "entered-in-error", display: "Entered in Error" },
+        ],
+        "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+      ),
+      mk(
+        "http://hl7.org/fhir/ValueSet/task-status",
+        [
+          { code: "draft", display: "Draft" },
+          { code: "requested", display: "Requested" },
+          { code: "received", display: "Received" },
+          { code: "accepted", display: "Accepted" },
+          { code: "rejected", display: "Rejected" },
+          { code: "ready", display: "Ready" },
+          { code: "cancelled", display: "Cancelled" },
+          { code: "in-progress", display: "In Progress" },
+          { code: "on-hold", display: "On Hold" },
+          { code: "failed", display: "Failed" },
+          { code: "completed", display: "Completed" },
+          { code: "entered-in-error", display: "Entered in Error" },
+        ],
+        "http://hl7.org/fhir/task-status",
+      ),
+      mk(
+        "http://hl7.org/fhir/ValueSet/goal-status",
+        [
+          { code: "proposed", display: "Proposed" },
+          { code: "planned", display: "Planned" },
+          { code: "accepted", display: "Accepted" },
+          { code: "active", display: "Active" },
+          { code: "on-hold", display: "On Hold" },
+          { code: "completed", display: "Completed" },
+          { code: "cancelled", display: "Cancelled" },
+          { code: "entered-in-error", display: "Entered in Error" },
+          { code: "rejected", display: "Rejected" },
+        ],
+        "http://hl7.org/fhir/goal-status",
+      ),
+      mk(
+        "http://hl7.org/fhir/ValueSet/medicationrequest-status",
+        [
+          { code: "active", display: "Active" },
+          { code: "on-hold", display: "On Hold" },
+          { code: "cancelled", display: "Cancelled" },
+          { code: "completed", display: "Completed" },
+          { code: "entered-in-error", display: "Entered in Error" },
+          { code: "stopped", display: "Stopped" },
+          { code: "draft", display: "Draft" },
+          { code: "unknown", display: "Unknown" },
+        ],
+        "http://hl7.org/fhir/CodeSystem/medicationrequest-status",
+      ),
+      mk(
+        "http://hl7.org/fhir/ValueSet/encounter-status",
+        [
+          { code: "planned", display: "Planned" },
+          { code: "arrived", display: "Arrived" },
+          { code: "triaged", display: "Triaged" },
+          { code: "in-progress", display: "In Progress" },
+          { code: "onleave", display: "On Leave" },
+          { code: "finished", display: "Finished" },
+          { code: "cancelled", display: "Cancelled" },
+          { code: "entered-in-error", display: "Entered in Error" },
+          { code: "unknown", display: "Unknown" },
+        ],
+        "http://hl7.org/fhir/encounter-status",
+      ),
+      mk(
+        "http://hl7.org/fhir/ValueSet/allergyintolerance-clinical",
+        [
+          { code: "active", display: "Active" },
+          { code: "inactive", display: "Inactive" },
+          { code: "resolved", display: "Resolved" },
+        ],
+        "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+      ),
+      mk(
+        "http://hl7.org/fhir/ValueSet/allergyintolerance-verification",
+        [
+          { code: "unconfirmed", display: "Unconfirmed" },
+          { code: "confirmed", display: "Confirmed" },
+          { code: "refuted", display: "Refuted" },
+          { code: "entered-in-error", display: "Entered in Error" },
+        ],
+        "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+      ),
+      mk(
+        "http://hl7.org/fhir/ValueSet/request-intent",
+        [
+          { code: "proposal", display: "Proposal" },
+          { code: "plan", display: "Plan" },
+          { code: "directive", display: "Directive" },
+          { code: "order", display: "Order" },
+          { code: "original-order", display: "Original Order" },
+          { code: "reflex-order", display: "Reflex Order" },
+          { code: "filler-order", display: "Filler Order" },
+          { code: "instance-order", display: "Instance Order" },
+          { code: "option", display: "Option" },
+        ],
+        "http://hl7.org/fhir/request-intent",
+      ),
+      mk(
+        "http://hl7.org/fhir/ValueSet/request-priority",
+        [
+          { code: "routine", display: "Routine" },
+          { code: "urgent", display: "Urgent" },
+          { code: "asap", display: "ASAP" },
+          { code: "stat", display: "STAT" },
+        ],
+        "http://hl7.org/fhir/request-priority",
+      ),
+      mk(
+        "http://hl7.org/fhir/ValueSet/publication-status",
+        [
+          { code: "draft", display: "Draft" },
+          { code: "active", display: "Active" },
+          { code: "retired", display: "Retired" },
+          { code: "unknown", display: "Unknown" },
+        ],
+        "http://hl7.org/fhir/publication-status",
+      ),
+    ] as const
+  ).map((vs): [string, ValueSet] => [vs.url!, vs]),
+);
+
+/**
+ * Returns the library's bundled copy of a R4 core ValueSet by canonical URL,
+ * or `undefined` if we don't ship one. Used by `useValueSet` as a last-resort
+ * fallback when the server can't resolve it.
+ */
+export function coreValueSet(canonical: string | undefined): ValueSet | undefined {
+  if (!canonical) return undefined;
+  return coreValueSets.get(canonical);
+}
+
+/** Canonical URLs the library ships bundled ValueSets for. */
+export const bundledValueSetUrls = Array.from(coreValueSets.keys());

--- a/packages/react-fhir/src/structure/searchBinding.test.ts
+++ b/packages/react-fhir/src/structure/searchBinding.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { elementPathForSearchParam, kebabToCamel } from "./searchBinding.js";
+
+describe("kebabToCamel", () => {
+  it("converts kebab-case to camelCase", () => {
+    expect(kebabToCamel("address-city")).toBe("addressCity");
+    expect(kebabToCamel("clinical-status")).toBe("clinicalStatus");
+    expect(kebabToCamel("a-b-c")).toBe("aBC");
+  });
+
+  it("leaves single-word names untouched", () => {
+    expect(kebabToCamel("name")).toBe("name");
+    expect(kebabToCamel("status")).toBe("status");
+  });
+
+  it("preserves leading underscores on FHIR result-params", () => {
+    expect(kebabToCamel("_id")).toBe("_id");
+    expect(kebabToCamel("_count")).toBe("_count");
+  });
+});
+
+describe("elementPathForSearchParam", () => {
+  it("maps single-word params onto {base}.{name}", () => {
+    expect(elementPathForSearchParam({ name: "status" }, "Observation")).toBe(
+      "Observation.status",
+    );
+    expect(elementPathForSearchParam({ name: "gender" }, "Patient")).toBe(
+      "Patient.gender",
+    );
+  });
+
+  it("converts kebab to camel when building the path", () => {
+    expect(
+      elementPathForSearchParam({ name: "clinical-status" }, "Condition"),
+    ).toBe("Condition.clinicalStatus");
+    expect(
+      elementPathForSearchParam({ name: "address-city" }, "Patient"),
+    ).toBe("Patient.addressCity");
+  });
+
+  it("returns undefined for FHIR meta params that don't map to an element", () => {
+    expect(elementPathForSearchParam({ name: "_id" }, "Patient")).toBeUndefined();
+    expect(elementPathForSearchParam({ name: "_lastUpdated" }, "Patient")).toBeUndefined();
+  });
+
+  it("returns undefined for chained or modified params", () => {
+    expect(
+      elementPathForSearchParam({ name: "patient.name" }, "Observation"),
+    ).toBeUndefined();
+    expect(
+      elementPathForSearchParam({ name: "identifier:contains" }, "Patient"),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for empty / missing name", () => {
+    expect(elementPathForSearchParam({ name: "" }, "Patient")).toBeUndefined();
+    expect(
+      elementPathForSearchParam({ name: undefined as unknown as string }, "Patient"),
+    ).toBeUndefined();
+  });
+});

--- a/packages/react-fhir/src/structure/searchBinding.ts
+++ b/packages/react-fhir/src/structure/searchBinding.ts
@@ -1,0 +1,29 @@
+import type { CapabilityStatementRestResourceSearchParam } from "fhir/r4";
+
+/**
+ * kebab-to-camel: "address-city" → "addressCity", "clinical-status" → "clinicalStatus".
+ * Leaves single-word params untouched ("name" → "name") and preserves leading
+ * underscores used by FHIR search-result-parameters ("_id" → "_id").
+ */
+export function kebabToCamel(name: string): string {
+  if (!name) return name;
+  if (name.startsWith("_")) return name; // _id, _count, etc.
+  return name.replace(/-([a-z])/g, (_, c) => (c as string).toUpperCase());
+}
+
+/**
+ * Best-effort resolution of a SearchParameter to the FHIR element path it
+ * targets. Good enough for ~80% of R4 core search params without needing to
+ * fetch the full `SearchParameter` resource. Returns `undefined` for params
+ * that can't be mapped by convention (e.g. "_id", chained, or composite).
+ */
+export function elementPathForSearchParam(
+  param: Pick<CapabilityStatementRestResourceSearchParam, "name">,
+  base: string,
+): string | undefined {
+  const name = param.name;
+  if (!name) return undefined;
+  if (name.startsWith("_")) return undefined;
+  if (name.includes(".") || name.includes(":")) return undefined; // chained / modified
+  return `${base}.${kebabToCamel(name)}`;
+}


### PR DESCRIPTION
Two spec-driven upgrades to the `<ResourceSearch>` UX, plus a library-level fallback that makes both features work even on servers that don't expose terminology.

## 1. Date pickers for `date` search params

Before:

```
[  YYYY-MM-DD  (prefix eq/ne/lt/gt/ge/le/ap)  ]
```

After:

```
[= ▾][  📅 2024-01-15  ]
```

- Prefix selector cycles through the FHIR prefixes (`eq / ne / lt / le / gt / ge / ap`) using familiar symbols (`= ≠ < ≤ > ≥ ~`) with tooltip titles.
- Native `<input type="date">` for the date itself — proper mobile date picker on phones.
- Parser rehydrates values like `ge2024-01-01` back into prefix + date when the form is initialised from URL params / app state.
- Emits a plain date when no prefix, a prefixed string when one is set.

## 2. Dropdowns for token params with spec-defined ValueSets

Before (from your mobile screenshot):

```
gender  [TOKEN]
[ code or system|code ]
```

After:

```
gender  [TOKEN]
[ — | Male (male) | Female (female) | Other (other) | Unknown (unknown) ]
```

How this works, end-to-end:
1. `TokenSearchField` (rescued from PR #21 — see note below) derives the element (`Patient.gender`) from the search param name by convention.
2. Reads `element.binding.valueSet` from the StructureDefinition.
3. `useValueSet` fetches the ValueSet. Now with a **third fallback**: if both `$expand` and `?url=` queries fail on the server, we return the library's bundled copy.
4. Renders a `<select>` when the ValueSet is 1–100 codes; size-capped so huge code systems like LOINC stay as free-text.

## Bundled R4 core ValueSets

New file `structure/core/valuesets.ts` ships 13 non-extensible R4 ValueSets — exactly the ones the spec fixes and therefore safe to bundle:

- `administrative-gender`, `publication-status`, `request-intent`, `request-priority`
- `observation-status`, `task-status`, `goal-status`, `encounter-status`
- `medicationrequest-status`
- `condition-clinical`, `condition-ver-status`
- `allergyintolerance-clinical`, `allergyintolerance-verification`

Each is already in `expansion.contains` form so `codesFromValueSet` reads them without further work. Exposed via `coreValueSet(canonical)` + `bundledValueSetUrls` from the library.

## Rescue note: PR #21

PR #21 ("ResourceSearch token fields auto-populate from ValueSet binding") was merged into its base branch `claude/issue-4-valueset` rather than `main`. When that base eventually merged, PR #21's changes weren't in the merge. This PR cherry-picks PR #21's commit onto main, so the `TokenSearchField` + `structure/searchBinding.ts` work is finally live.

## Tests

- **6 new ValueSet bundle tests** — spot-check `administrative-gender`, `observation-status`, `task-status`, every URL round-trips, every bundle produces at least one code
- **4 new date-picker tests** — renders prefix + date, emits plain date without prefix, emits prefixed date with prefix, rehydrates existing `lt2020-05-01`
- Cherry-picked **8 token binding tests** from #21
- Existing 9 ResourceSearch tests updated for new textbox count (date is now an `<input type="date">` which testing-library doesn't classify as role=textbox)
- **Total 159 library tests passing** (up from 132 on current main)

## What visitors see after merge + Pages redeploy

- Patient search on the live demo:
  - **`gender`** → dropdown of the 4 administrative-gender codes (even though HAPI can't resolve the ValueSet — served from the bundle)
  - **`birthdate`** → prefix selector + date picker

## Test plan
- [x] `pnpm -r test:run` — 159 tests pass
- [x] `pnpm -r typecheck` clean
- [ ] After merge + Pages redeploy: screenshot matches the description above
- [ ] On mobile: date picker triggers the OS native picker (iOS / Android)

---
_Generated by [Claude Code](https://claude.ai/code/session_019twK96zFjzdpqwXEEjdCb8)_