### PR TITLE
feat(demo): per-patient compartment counts on the Patient list row

### DIFF
--- a/apps/demo/e2e/patient-row-counts.screenshot.spec.ts
+++ b/apps/demo/e2e/patient-row-counts.screenshot.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Patient list row counts", () => {
+  test("each row shows compartment counts for that patient", async ({ page }) => {
+    await page.goto("/Patient");
+    await expect(page.getByRole("heading", { name: /patients/i })).toBeVisible();
+
+    // Ada Lovelace's row has the fixture-populated compartment. Expected
+    // counts per fixtures.ts: Conditions 2, MedicationRequests 2,
+    // AllergyIntolerance 1, Observations 3, Procedures 1, Encounters 2,
+    // Immunizations 1.
+    const adaRow = page.getByTestId("patient-row").filter({ hasText: "Ada Lovelace" });
+    const counts = adaRow.getByTestId("patient-row-counts");
+    await expect(counts).toBeVisible();
+    await expect(counts).toContainText(/Cond\s+2/);
+    await expect(counts).toContainText(/Meds\s+2/);
+    await expect(counts).toContainText(/Allg\s+1/);
+    await expect(counts).toContainText(/Obs\s+3/);
+    await expect(counts).toContainText(/Proc\s+1/);
+    await expect(counts).toContainText(/Enc\s+2/);
+    await expect(counts).toContainText(/Imm\s+1/);
+
+    await page.screenshot({
+      path: "../../screenshots/15-patient-list-row-counts.png",
+      fullPage: true,
+    });
+  });
+});

--- a/apps/demo/src/components/PatientRowCounts.tsx
+++ b/apps/demo/src/components/PatientRowCounts.tsx
@@ -1,0 +1,77 @@
+import { useSearch } from "@fhir-place/react-fhir";
+import type { Resource } from "fhir/r4";
+import { PATIENT_COMPARTMENT } from "../compartment.js";
+
+/**
+ * Short label per compartment resource type for tight inline layouts (e.g.
+ * the Patient list row). Keeps each chip narrow enough that all 7 fit on a
+ * phone-width row without wrapping heavily.
+ */
+const SHORT_LABEL: Record<string, string> = {
+  Condition: "Cond",
+  MedicationRequest: "Meds",
+  AllergyIntolerance: "Allg",
+  Observation: "Obs",
+  Procedure: "Proc",
+  Encounter: "Enc",
+  Immunization: "Imm",
+};
+
+interface PatientRowCountsProps {
+  patientId: string;
+}
+
+/**
+ * Compact dot-separated row showing the number of compartment resources
+ * (Condition / MedicationRequest / … ) for a single patient. One `_summary=
+ * count` search fires per type; results cache so they're cheap on re-render.
+ *
+ * Rendered inline within a Patient list row. Keep visually lightweight:
+ * dimmed zero counts, small font, single-line layout that wraps when needed.
+ */
+export function PatientRowCounts({ patientId }: PatientRowCountsProps) {
+  return (
+    <span
+      data-testid="patient-row-counts"
+      className="flex flex-wrap gap-x-2 gap-y-0.5 text-[11px] text-slate-500"
+    >
+      {PATIENT_COMPARTMENT.map((section, i) => (
+        <CountChip
+          key={section.resourceType}
+          patientId={patientId}
+          resourceType={section.resourceType}
+          label={SHORT_LABEL[section.resourceType] ?? section.resourceType}
+          leading={i > 0}
+        />
+      ))}
+    </span>
+  );
+}
+
+interface CountChipProps {
+  patientId: string;
+  resourceType: string;
+  label: string;
+  leading: boolean;
+}
+
+function CountChip({ patientId, resourceType, label, leading }: CountChipProps) {
+  const { data, isLoading } = useSearch<Resource>(resourceType, {
+    patient: patientId,
+    _summary: "count",
+    _count: 0,
+  });
+  const count = data?.total;
+  const display = isLoading ? "…" : count ?? "?";
+  const muted = count === 0;
+
+  return (
+    <span
+      data-testid={`patient-row-count-${resourceType}`}
+      className={muted ? "text-slate-300" : undefined}
+    >
+      {leading && <span className="mr-2 text-slate-300">·</span>}
+      {label} <span className="font-mono tabular-nums">{display}</span>
+    </span>
+  );
+}

--- a/apps/demo/src/pages/PatientListPage.tsx
+++ b/apps/demo/src/pages/PatientListPage.tsx
@@ -3,6 +3,7 @@ import type { Patient } from "fhir/r4";
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import type { SearchParams } from "@fhir-place/react-fhir";
+import { PatientRowCounts } from "../components/PatientRowCounts.js";
 
 const formatName = (p: Patient): string => {
   const n = p.name?.[0];
@@ -71,13 +72,16 @@ export function PatientListPage() {
           <li key={p.id} data-testid="patient-row">
             <Link
               to={`/Patient/${p.id}`}
-              className="flex items-baseline justify-between gap-4 px-4 py-3 hover:bg-slate-50"
+              className="flex flex-col gap-1 px-4 py-3 hover:bg-slate-50"
             >
-              <span className="font-medium text-slate-900">{formatName(p)}</span>
-              <span className="text-xs text-slate-500">
-                {p.gender ?? "—"} · {p.birthDate ?? "—"} ·{" "}
-                <code className="rounded bg-slate-100 px-1 py-0.5">{p.id}</code>
-              </span>
+              <div className="flex items-baseline justify-between gap-4">
+                <span className="font-medium text-slate-900">{formatName(p)}</span>
+                <span className="text-xs text-slate-500">
+                  {p.gender ?? "—"} · {p.birthDate ?? "—"} ·{" "}
+                  <code className="rounded bg-slate-100 px-1 py-0.5">{p.id}</code>
+                </span>
+              </div>
+              {p.id && <PatientRowCounts patientId={p.id} />}
             </Link>
           </li>
         ))}


### PR DESCRIPTION
## Summary

Adds a compact per-row count of compartment resources (Cond · Meds · Allg · Obs · Proc · Enc · Imm) on the Patient index page. Each count is a `_summary=count&_count=0` search scoped to that patient, matching the pattern already used by `PatientCompartmentLinks` on the detail page.

## Files

- `apps/demo/src/components/PatientRowCounts.tsx` — new compact chip row per patient
- `apps/demo/src/pages/PatientListPage.tsx` — stacked row layout: existing name/gender/DOB line stays on top, counts line sits below
- `apps/demo/e2e/patient-row-counts.screenshot.spec.ts` — Playwright screenshot test asserting Ada's fixture counts

## Layout choice

Short labels (Cond, Meds, Allg, Obs, Proc, Enc, Imm) so all 7 compartment types fit on one line at phone width. Dot separators, tabular-nums for the numbers, dimmed zero counts.

## Performance note

This fires **N patients × 7 types** HTTP requests on initial load (e.g. 20 patients × 7 = 140 requests on first page load against HAPI). TanStack Query caches/dedupes, and `_summary=count` asks the server for just the total (no entries, cheap), but it's still chatty. If this becomes a problem we can:

1. Batch-resolve counts via a single Bundle search (`_type=Condition,MedicationRequest,...&patient=<id>`) — HAPI supports this
2. Add an intersection-observer so counts only fire when a row scrolls into view
3. Gate on an opt-in toggle

Leaving as-is for now since the user asked for per-type counts explicitly; will file a follow-up issue if perf bites.

## Test plan

- [x] `pnpm -r typecheck` — clean
- [x] `pnpm -r test:run` — 180 library + 15 demo tests pass
- [ ] After merge: check the live HAPI demo's Patient list on phone; confirm counts appear for the patients that HAPI serves. Unfamiliar HAPI patients will show zeros (expected — compartment is empty).

https://claude.ai/code/session_019twK96zFjzdpqwXEEjdCb8

---
_Generated by [Claude Code](https://claude.ai/code/session_019twK96zFjzdpqwXEEjdCb8)_