### PR TITLE
ci: nightly live-site Playwright monitor with auto-issue creation

### DIFF
--- a/.github/workflows/live-site-monitor.yml
+++ b/.github/workflows/live-site-monitor.yml
@@ -1,0 +1,159 @@
+name: Live site monitor
+
+# Hits the deployed GitHub Pages demo with Playwright on a nightly cron and
+# files (or comments on) GitHub issues for each failed test. Designed to
+# catch real-world breakage that local MSW e2e tests can't see — HAPI flakes,
+# Pages routing, prod-only data shapes.
+
+on:
+  schedule:
+    # 06:30 UTC nightly. After typical CI deploys, before the workday.
+    - cron: "30 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: live-site-monitor
+  cancel-in-progress: false
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @fhir-place/demo exec playwright install --with-deps chromium webkit
+
+      - name: Run live-site Playwright suite
+        id: live
+        run: pnpm --filter @fhir-place/demo exec playwright test --config=playwright.live.config.ts
+        continue-on-error: true
+
+      - name: Upload Playwright artifacts
+        if: steps.live.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-live-${{ github.run_id }}
+          path: |
+            apps/demo/playwright-report-live
+            apps/demo/test-results
+          if-no-files-found: ignore
+
+      - name: File / update GitHub issues for failed tests
+        if: steps.live.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const resultsPath = path.join(
+              process.env.GITHUB_WORKSPACE,
+              'apps/demo/test-results/live-results.json',
+            );
+            if (!fs.existsSync(resultsPath)) {
+              core.warning('No live-results.json — Playwright crashed before writing results.');
+              return;
+            }
+            const report = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+
+            // Walk the Playwright JSON tree and yield { title, projectName,
+            // error, location } for every failed test.
+            const failed = [];
+            const walk = (suites = [], parent = '') => {
+              for (const suite of suites) {
+                const here = parent ? `${parent} > ${suite.title}` : suite.title;
+                for (const spec of suite.specs ?? []) {
+                  for (const t of spec.tests ?? []) {
+                    const lastResult = (t.results ?? []).slice(-1)[0];
+                    if (lastResult && lastResult.status !== 'passed' && lastResult.status !== 'skipped') {
+                      failed.push({
+                        title: spec.title,
+                        suite: here,
+                        project: t.projectName,
+                        error: (lastResult.error?.message ?? lastResult.errors?.[0]?.message ?? '').slice(0, 4_000),
+                        file: spec.file,
+                        line: spec.line,
+                      });
+                    }
+                  }
+                }
+                walk(suite.suites, here);
+              }
+            };
+            walk(report.suites);
+
+            if (failed.length === 0) {
+              core.info('Playwright reported failure but no failed tests found in JSON. Skipping issue creation.');
+              return;
+            }
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // Group by spec title — same test failing across projects becomes
+            // one issue with a list of affected projects.
+            const grouped = new Map();
+            for (const f of failed) {
+              const key = f.title;
+              if (!grouped.has(key)) grouped.set(key, { title: key, projects: [], error: f.error, file: f.file, line: f.line });
+              grouped.get(key).projects.push(f.project);
+            }
+
+            for (const g of grouped.values()) {
+              const issueTitle = `[live-monitor] ${g.title}`;
+              const body = [
+                `**Failed in run:** ${runUrl}`,
+                `**Affected projects:** ${g.projects.join(', ')}`,
+                `**Source:** \`${g.file}:${g.line}\``,
+                '',
+                '**Error:**',
+                '```',
+                g.error || '(no error message captured)',
+                '```',
+                '',
+                'Screenshots, traces, and the HTML report are attached to the workflow run as the `playwright-live-' + context.runId + '` artifact.',
+                '',
+                '_This issue was opened automatically by `.github/workflows/live-site-monitor.yml`. If the test passes on a future run, this issue will be commented on, not closed — close it manually once the underlying bug is fixed._',
+              ].join('\n');
+
+              // Dedupe: search for an open issue with the same title.
+              const existing = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${issueTitle}"`,
+                per_page: 5,
+              });
+              const match = existing.data.items.find((i) => i.title === issueTitle);
+
+              if (match) {
+                core.info(`Adding comment to existing issue #${match.number}: ${issueTitle}`);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: match.number,
+                  body: `Failed again in ${runUrl}\n\n\`\`\`\n${g.error || '(no error)'}\n\`\`\``,
+                });
+              } else {
+                core.info(`Creating issue: ${issueTitle}`);
+                await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: issueTitle,
+                  body,
+                  labels: ['bug', 'live-monitor'],
+                });
+              }
+            }
+
+      - name: Fail the job if any tests failed
+        if: steps.live.outcome == 'failure'
+        run: exit 1

--- a/apps/demo/e2e-live/smoke.spec.ts
+++ b/apps/demo/e2e-live/smoke.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Live-site smoke tests. Run nightly by `.github/workflows/live-site-monitor.yml`
+ * against the deployed demo, hitting real HAPI. Failures auto-file GitHub
+ * issues — keep test names short and stable so the dedupe logic
+ * (`[live-monitor] <test name>`) works.
+ *
+ * Tests should be data-shape tolerant — HAPI is a shared public server, the
+ * specific patients there change. Assert structure and behavior, not literal
+ * data values. Skip rather than fail if the prerequisite data isn't there.
+ */
+
+const consoleErrors: string[] = [];
+
+test.beforeEach(async ({ page }, testInfo) => {
+  consoleErrors.length = 0;
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(`pageerror: ${err.message}`));
+  testInfo.annotations.push({ type: "live-url", description: testInfo.title });
+});
+
+test("home redirects to Patient list and renders", async ({ page }) => {
+  const response = await page.goto("/");
+  expect(response?.status(), "home should respond 2xx").toBeLessThan(400);
+  await expect(page.getByRole("heading", { name: /patients/i })).toBeVisible();
+});
+
+test("Patient list shows at least one row", async ({ page }) => {
+  await page.goto("/Patient");
+  await expect(page.getByRole("heading", { name: /patients/i })).toBeVisible();
+  const rows = page.getByTestId("patient-row");
+  await expect(rows.first()).toBeVisible({ timeout: 30_000 });
+  expect(await rows.count()).toBeGreaterThan(0);
+});
+
+test("Patient detail page renders without an error wall", async ({ page }) => {
+  await page.goto("/Patient");
+  const firstRow = page.getByTestId("patient-row").first();
+  await expect(firstRow).toBeVisible({ timeout: 30_000 });
+  await firstRow.click();
+
+  // Detail pages render a Patient resource view + compartment chips.
+  await expect(page.getByText(/^Patient/i).first()).toBeVisible();
+  // No red error wall: assert "Failed to" / "Could not resolve" don't appear.
+  const errorBanner = page.getByText(
+    /failed to load|could not resolve structuredefinition|Cannot read properties of/i,
+  );
+  await expect(errorBanner).toHaveCount(0);
+});
+
+test("Patient detail shows compartment chips", async ({ page }) => {
+  await page.goto("/Patient");
+  await page.getByTestId("patient-row").first().click();
+  // The chip nav is rendered for every Patient detail page (counts may be 0).
+  await expect(page.getByTestId("compartment-links")).toBeVisible({
+    timeout: 30_000,
+  });
+});
+
+test("ResourceSearch documentation is clipped (no Multiple Resources dump)", async ({
+  page,
+}) => {
+  await page.goto("/Patient");
+  // Open the search form (visible inline on the list).
+  await expect(page.getByTestId("resource-search")).toBeVisible();
+  // No field on this page should display the literal "Multiple Resources:"
+  // dumped directly from SearchParameter.documentation.
+  await expect(page.getByText(/^Multiple Resources:/)).toHaveCount(0);
+});
+
+test("no console errors on the Patient list", async ({ page }) => {
+  await page.goto("/Patient");
+  await expect(page.getByRole("heading", { name: /patients/i })).toBeVisible();
+  // Wait for any async errors to surface.
+  await page.waitForTimeout(2_000);
+  // GitHub Pages 404 fallback rendering is OK; React/runtime errors are not.
+  const fatal = consoleErrors.filter(
+    (m) => !/favicon|net::ERR_BLOCKED_BY_CLIENT|MockServiceWorker/.test(m),
+  );
+  expect(fatal, fatal.join("\n")).toHaveLength(0);
+});

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -11,7 +11,8 @@
     "test:run": "vitest run",
     "typecheck": "tsc --noEmit",
     "e2e": "playwright test",
-    "e2e:screenshot": "playwright test --project=screenshots"
+    "e2e:screenshot": "playwright test --project=screenshots",
+    "e2e:live": "playwright test --config=playwright.live.config.ts"
   },
   "dependencies": {
     "@fhir-place/react-fhir": "workspace:*",

--- a/apps/demo/playwright.live.config.ts
+++ b/apps/demo/playwright.live.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright configuration for the live-site monitor: hits the deployed
+ * GitHub Pages demo (no local dev server). Used by the
+ * `.github/workflows/live-site-monitor.yml` cron job which then opens GitHub
+ * issues for any failing tests.
+ *
+ * Override the target URL with `LIVE_SITE_BASE_URL` if you ever move the
+ * demo (e.g. to a custom domain).
+ */
+const baseURL =
+  process.env.LIVE_SITE_BASE_URL ??
+  "https://samsuffolksperoni.github.io/fhir-place/";
+
+export default defineConfig({
+  testDir: "./e2e-live",
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  // One worker — live HAPI is a shared public server; don't hammer it.
+  workers: 1,
+  fullyParallel: false,
+  retries: 1,
+  reporter: [
+    ["list"],
+    ["json", { outputFile: "test-results/live-results.json" }],
+    ["html", { outputFolder: "playwright-report-live", open: "never" }],
+  ],
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium-desktop",
+      use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 800 } },
+    },
+    {
+      name: "iphone",
+      use: { ...devices["iPhone 14"] },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Adds a nightly Playwright job that runs against the deployed GitHub Pages demo (real HAPI, not MSW) and **auto-files GitHub issues for any failures**. Catches the class of bugs local MSW e2e tests can't see — HAPI flakes, Pages routing, prod-only data variance, deep-link 404s.

## How it works

1. **Schedule**: cron `30 6 * * *` (06:30 UTC nightly) + `workflow_dispatch` so you can tap "Run workflow" from the Actions tab.
2. **Tests**: `apps/demo/e2e-live/smoke.spec.ts` — 6 specs covering home redirect, Patient list, detail page (no error wall), compartment chips, search-doc clipping (#43), and console errors. Run on `chromium-desktop` + `iPhone 14`.
3. **Auto-issue creation** (via `actions/github-script`):
   - Parses Playwright's JSON reporter output
   - Groups failures by test title (same test failing across both projects → one issue with both project names listed)
   - **Dedupe**: searches for an open issue titled `[live-monitor] <test name>` before creating. Matches get a comment, no match gets a new issue with labels `bug`, `live-monitor`.
   - Issue links to the workflow run + the uploaded `playwright-report-live-<run-id>` artifact (screenshots, traces, video on failure).
   - **Issues are not auto-closed on subsequent passing runs** — that's a human signal that the bug was actually fixed.

## Permissions

`issues: write`, `contents: read`. Default `GITHUB_TOKEN` covers both.

## Files

- `.github/workflows/live-site-monitor.yml` — workflow + auto-issue script
- `apps/demo/playwright.live.config.ts` — separate config; no webServer, points at `https://samsuffolksperoni.github.io/fhir-place/`
- `apps/demo/e2e-live/smoke.spec.ts` — 6 data-shape-tolerant smoke tests
- `apps/demo/package.json` — adds `e2e:live` script

## Test plan

- [x] `pnpm -r typecheck` — clean
- [x] `pnpm -r test:run` — 180 + 15 unit tests pass
- [ ] After merge: tap "Run workflow" on the **Actions** tab → "Live site monitor" → "Run workflow" to validate the first run. **Expected on this run**: smoke tests should mostly pass, but issue #47 ("GitHub Pages deep links return HTTP 404") may surface as a failed test if the test attempts a direct deep-link load — that's the system working as intended (real bug → real auto-filed issue).

## Local debugging

```sh
pnpm --filter @fhir-place/demo e2e:live
```

Override target with `LIVE_SITE_BASE_URL` env var.

## Out of scope

- Synthea/HAPI rich data fixtures for local MSW (option 1 from the earlier discussion). Defer — option 3 covers the same surface area more honestly by exercising the real site.

https://claude.ai/code/session_019twK96zFjzdpqwXEEjdCb8

---
_Generated by [Claude Code](https://claude.ai/code/session_019twK96zFjzdpqwXEEjdCb8)_