### PR TITLE
fix(ResourceTable): resolve choice-type cells (Observation.valueQuantity etc.) to their renderers

### DIFF
--- a/packages/react-fhir/src/components/ResourceTable.test.tsx
+++ b/packages/react-fhir/src/components/ResourceTable.test.tsx
@@ -1,8 +1,9 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { Patient, StructureDefinition } from "fhir/r4";
+import type { Observation, Patient, StructureDefinition } from "fhir/r4";
 import { describe, expect, it, vi } from "vitest";
+import { ObservationStructureDefinition } from "../structure/core/Observation.js";
 import { FetchFhirClient } from "../client/FetchFhirClient.js";
 import { FhirClientProvider } from "../hooks/FhirClientProvider.js";
 import { getByPath, ResourceTable } from "./ResourceTable.js";
@@ -157,6 +158,36 @@ describe("ResourceTable", () => {
       { wrapper: wrap() },
     );
     expect(screen.getByTestId("empty")).toBeInTheDocument();
+  });
+
+  it("dispatches choice-typed cells (valueQuantity) to the Quantity renderer", () => {
+    const observation: Observation = {
+      resourceType: "Observation",
+      id: "o1",
+      status: "final",
+      code: { text: "Heart rate" },
+      valueQuantity: {
+        value: 72,
+        unit: "beats/minute",
+        system: "http://unitsofmeasure.org",
+        code: "/min",
+      },
+    };
+    render(
+      <ResourceTable<Observation>
+        resources={[observation]}
+        columns={["code.text", "valueQuantity"]}
+        columnLabels={{ "code.text": "Observation", valueQuantity: "Value" }}
+        structureDefinition={ObservationStructureDefinition}
+      />,
+      { wrapper: wrap() },
+    );
+    const row = screen.getByTestId("resource-row");
+    // Renders via QuantityRenderer ("72 beats/minute"), not raw JSON.
+    expect(within(row).getByText(/72/)).toBeInTheDocument();
+    expect(within(row).getByText(/beats\/minute/)).toBeInTheDocument();
+    expect(within(row).queryByText(/unitsofmeasure\.org/)).not.toBeInTheDocument();
+    expect(within(row).queryByText(/"value":/)).not.toBeInTheDocument();
   });
 
   it("falls back to a friendly dash for missing cell values", () => {

--- a/packages/react-fhir/src/components/ResourceTable.tsx
+++ b/packages/react-fhir/src/components/ResourceTable.tsx
@@ -1,7 +1,7 @@
 import type { Reference, Resource, StructureDefinition } from "fhir/r4";
 import { Fragment, useMemo, type ReactNode } from "react";
 import { useStructureDefinition } from "../hooks/queries.js";
-import { findElement } from "../structure/walker.js";
+import { findChoiceVariant, findElement } from "../structure/walker.js";
 import {
   defaultTypeRenderers,
   type RendererContext,
@@ -195,8 +195,14 @@ function typeForPath(
   if (!sd) return undefined;
   // Strip any [index] segments and numeric indices for the SD lookup.
   const cleaned = path.replace(/\[\d+\]/g, "").replace(/\.\d+$/g, "");
-  const el = findElement(sd, `${base}.${cleaned}`);
-  return el?.type?.[0]?.code;
+  const fullPath = `${base}.${cleaned}`;
+  const el = findElement(sd, fullPath);
+  if (el?.type?.[0]?.code) return el.type[0].code;
+  // The path may be a materialised choice variant (e.g. `valueQuantity` for
+  // `Observation.value[x]`) — resolve via the choice element so cells like the
+  // Observation Value column dispatch to the Quantity renderer rather than the
+  // JSON fallback.
+  return findChoiceVariant(sd, fullPath)?.typeCode;
 }
 
 interface RenderCellParams<T extends Resource> {

--- a/packages/react-fhir/src/structure/walker.test.ts
+++ b/packages/react-fhir/src/structure/walker.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, it } from "vitest";
 import { PatientStructureDefinition } from "../../test/fixtures/StructureDefinition-Patient.js";
 import {
   directChildren,
+  findChoiceVariant,
   findElement,
   isPrimitive,
   walkObject,
   walkResource,
 } from "./walker.js";
+import { ObservationStructureDefinition } from "../structure/core/Observation.js";
 
 const patient: Patient = {
   resourceType: "Patient",
@@ -47,6 +49,43 @@ describe("findElement", () => {
 
   it("returns undefined for unknown paths", () => {
     expect(findElement(PatientStructureDefinition, "Patient.wat")).toBeUndefined();
+  });
+});
+
+describe("findChoiceVariant", () => {
+  it("resolves a materialised value[x] variant to its choice element + type", () => {
+    const v = findChoiceVariant(
+      ObservationStructureDefinition,
+      "Observation.valueQuantity",
+    );
+    expect(v?.element.path).toBe("Observation.value[x]");
+    expect(v?.typeCode).toBe("Quantity");
+  });
+
+  it("resolves a multi-word type code (CodeableConcept) on a choice element", () => {
+    const v = findChoiceVariant(
+      ObservationStructureDefinition,
+      "Observation.valueCodeableConcept",
+    );
+    expect(v?.typeCode).toBe("CodeableConcept");
+  });
+
+  it("resolves a choice variant nested inside a backbone element", () => {
+    const v = findChoiceVariant(
+      ObservationStructureDefinition,
+      "Observation.component.valueQuantity",
+    );
+    expect(v?.element.path).toBe("Observation.component.value[x]");
+    expect(v?.typeCode).toBe("Quantity");
+  });
+
+  it("returns undefined when no sibling [x] element exists", () => {
+    expect(
+      findChoiceVariant(ObservationStructureDefinition, "Observation.valueWat"),
+    ).toBeUndefined();
+    expect(
+      findChoiceVariant(PatientStructureDefinition, "Patient.gender"),
+    ).toBeUndefined();
   });
 });
 

--- a/packages/react-fhir/src/structure/walker.ts
+++ b/packages/react-fhir/src/structure/walker.ts
@@ -60,6 +60,41 @@ export function findElement(
   return elements(sd).find((e) => e.path === path);
 }
 
+/**
+ * Resolve a materialised choice variant (e.g. `Observation.valueQuantity`) back
+ * to its `[x]` element and the matching type code. Returns undefined when no
+ * sibling `[x]` element matches the leaf segment.
+ *
+ * Handles the case where consumers (StructureDefinition column configs, etc.)
+ * pass paths in the JSON-key form rather than the spec form.
+ */
+export function findChoiceVariant(
+  sd: StructureDefinition,
+  path: string,
+): { element: ElementDefinition; typeCode: string } | undefined {
+  const lastDot = path.lastIndexOf(".");
+  if (lastDot === -1) return undefined;
+  const parentPath = path.slice(0, lastDot);
+  const leaf = path.slice(lastDot + 1);
+  // Walk every uppercase boundary in the leaf so that multi-word base names
+  // (`onsetAge`, `medicationCodeableConcept`) and multi-word type codes
+  // (`SampledData`) both resolve.
+  for (let i = 1; i < leaf.length; i++) {
+    if (leaf[i] !== leaf[i]!.toUpperCase()) continue;
+    const base = leaf.slice(0, i);
+    const variantCap = leaf.slice(i);
+    const choiceElement = findElement(sd, `${parentPath}.${base}[x]`);
+    if (!choiceElement) continue;
+    const matched = choiceElement.type?.find(
+      (t) => t.code && capitalize(t.code) === variantCap,
+    );
+    if (matched?.code) {
+      return { element: choiceElement, typeCode: matched.code };
+    }
+  }
+  return undefined;
+}
+
 const isArrayCardinality = (el: ElementDefinition): boolean => {
   const max = el.max;
   if (!max) return false;


### PR DESCRIPTION
Closes #57.

## Summary

`ResourceTable` was rendering choice-typed columns (e.g. `Observation.valueQuantity`) as raw JSON in the live demo, because `typeForPath` looked up `Observation.valueQuantity` directly in the StructureDefinition — but R4 only defines `Observation.value[x]`. The miss left `typeCode` undefined, so the cell fell through to `JSON.stringify(value).slice(0, 60)` and the Observations table showed:

```
{"value":86,"unit":"beats/minute","system":"http://unitsofmeasure.org","code":"/min"}
```

instead of `86 beats/minute`. Visible in `screenshots/03-patient-detail.png`.

## Fix

- New `findChoiceVariant(sd, path)` in `structure/walker.ts` maps a materialised choice path (`Observation.valueQuantity`, `Observation.component.valueQuantity`, `MedicationRequest.medicationCodeableConcept`, etc.) back to the `[x]` element + matching type code.
- `typeForPath` in `ResourceTable.tsx` now falls back to `findChoiceVariant` when the direct lookup misses. Cells dispatch to the existing `Quantity` / `CodeableConcept` / `Period` / etc. renderers — no new renderer code, just routing.

## Test plan

- [x] `pnpm --filter @fhir-place/react-fhir test --run` — 224/224 pass (was 219; +5 new)
- [x] `pnpm -r typecheck` — clean
- [x] New `walker.test.ts` cases: Quantity variant, multi-word type code (CodeableConcept), backbone-nested variant (`component.valueQuantity`), negative case (no matching `[x]`)
- [x] New `ResourceTable.test.tsx` case: an Observation with `valueQuantity` renders `72 beats/minute`, **not** raw JSON
- [ ] Manual verification on the deployed demo after merge: open a Patient detail page, confirm Observations table shows formatted Quantity values

## Non-goals

- Other choice-type leakage (e.g. polymorphic Reference targets) — this PR only handles `[x]` materialised variants.
- Mobile layout for compartment tables — separate issue (#60).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WG9e1n3DVKadZaEzZpBVFH)_