### PR TITLE
fix(ResourceSearch): Clear button should also reset the active search

### DIFF
--- a/packages/react-fhir/src/components/ResourceSearch.test.tsx
+++ b/packages/react-fhir/src/components/ResourceSearch.test.tsx
@@ -124,20 +124,25 @@ describe("ResourceSearch", () => {
     expect(last).toEqual({ name: "ab" });
   });
 
-  it("Clear empties the form and emits {} via onChange", async () => {
+  it("Clear empties the form and emits {} via onChange + onSubmit", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
+    const onSubmit = vi.fn();
     wrap(
       <ResourceSearch
         resourceType="Patient"
         capabilityStatement={cap}
         onChange={onChange}
+        onSubmit={onSubmit}
         initialParams={{ name: "smith" }}
       />,
     );
     expect(screen.getByDisplayValue("smith")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /clear/i }));
     expect(onChange.mock.calls.at(-1)?.[0]).toEqual({});
+    // Clear must also re-submit so the parent's active query resets without a
+    // second Search click.
+    expect(onSubmit).toHaveBeenCalledWith({});
   });
 
   it("starts with only `initialVisible` params and toggles Show more", async () => {

--- a/packages/react-fhir/src/components/ResourceSearch.tsx
+++ b/packages/react-fhir/src/components/ResourceSearch.tsx
@@ -164,7 +164,13 @@ export function ResourceSearch(props: ResourceSearchProps) {
         <div className="flex gap-2">
           <button
             type="button"
-            onClick={() => setValues({})}
+            onClick={() => {
+              setValues({});
+              // Clear is a "wipe and reload" affordance: also fire onSubmit so
+              // the parent's active query resets without requiring a second
+              // click on Search.
+              onSubmit?.({});
+            }}
             className="rounded border border-slate-300 bg-white px-3 py-1 text-sm text-slate-700 hover:bg-slate-50"
           >
             Clear


### PR DESCRIPTION
Closes #61.

## Summary

`Clear` only emptied the controlled form state via `setValues({})`. The parent's last submitted params were unchanged, so filtered results stayed on screen until the user also clicked Search. Now Clear fires `onSubmit?.({})` so the active query resets in one click.

## Test plan

- [x] Updated `ResourceSearch.test.tsx` covers the new behaviour: Clear fires both `onChange({})` and `onSubmit({})`
- [x] `pnpm --filter @fhir-place/react-fhir test --run ResourceSearch` — 13/13 pass
- [ ] Manual verification on the deployed demo: filter, click Clear, list returns to unfiltered state without a second click on Search

---
_Generated by [Claude Code](https://claude.ai/code/session_01WG9e1n3DVKadZaEzZpBVFH)_