### PR TITLE
fix(demo): surface delete failures inline in ResourceDetailPage

### DIFF
--- a/apps/demo/e2e/delete-error.spec.ts
+++ b/apps/demo/e2e/delete-error.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Delete failure handling", () => {
+  test("server-side delete failure surfaces inline in the confirm panel", async ({
+    page,
+  }) => {
+    // Intercept any DELETE on /Patient/<id> and respond 409 with an
+    // OperationOutcome — mirrors what HAPI returns when a resource has
+    // referencing children that block deletion.
+    await page.route(/\/Patient\/[^?]+$/, async (route) => {
+      if (route.request().method() !== "DELETE") return route.continue();
+      await route.fulfill({
+        status: 409,
+        contentType: "application/fhir+json",
+        body: JSON.stringify({
+          resourceType: "OperationOutcome",
+          issue: [
+            {
+              severity: "error",
+              code: "conflict",
+              diagnostics: "Patient is referenced by other resources",
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto("/Patient");
+    await page.getByTestId("patient-row").first().click();
+    await page.getByTestId("delete-resource").click();
+    await expect(page.getByTestId("delete-confirm")).toBeVisible();
+    await page.getByTestId("delete-confirm-button").click();
+
+    // Inline error appears, the confirm panel stays open, and the user is
+    // not navigated away.
+    await expect(page.getByTestId("delete-error")).toBeVisible();
+    await expect(page.getByTestId("delete-confirm")).toBeVisible();
+    await expect(page).toHaveURL(/\/Patient\/[^/]+$/);
+  });
+});

--- a/apps/demo/src/pages/ResourceDetailPage.tsx
+++ b/apps/demo/src/pages/ResourceDetailPage.tsx
@@ -29,8 +29,13 @@ export function ResourceDetailPage() {
   };
 
   const handleDelete = async () => {
-    await del.mutateAsync({ type: resourceType, id });
-    navigate(`/${resourceType}`);
+    try {
+      await del.mutateAsync({ type: resourceType, id });
+      navigate(`/${resourceType}`);
+    } catch {
+      // del.error is now populated; the confirm panel renders it inline so
+      // the user can read the server message and retry or cancel.
+    }
   };
 
   return (
@@ -66,6 +71,15 @@ export function ResourceDetailPage() {
           <p className="mb-2 text-red-800">
             Delete {resourceType}/{id}? This cannot be undone.
           </p>
+          {del.isError && (
+            <p
+              role="alert"
+              data-testid="delete-error"
+              className="mb-2 rounded border border-red-300 bg-white p-2 text-xs text-red-800"
+            >
+              {(del.error as Error)?.message ?? "Delete failed"}
+            </p>
+          )}
           <div className="flex gap-2">
             <button
               type="button"


### PR DESCRIPTION
Closes #58.

## Summary

`ResourceDetailPage.handleDelete` previously did `await del.mutateAsync(...)` then navigated. On failure the navigation was skipped (because the await threw) but the user got no feedback — the confirm panel just sat there.

- Wrap the mutation in try/catch so the rejection is handled silently (`del.error` is populated by `useDeleteResource`).
- Render `del.isError` inline inside the confirm panel via a `role="alert"` block (`data-testid="delete-error"`).
- Server message comes from the FhirError thrown by `FetchFhirClient` (which already surfaces `OperationOutcome.diagnostics`).

## Test plan

- [x] `pnpm -r typecheck` — clean
- [x] New Playwright e2e (`apps/demo/e2e/delete-error.spec.ts`) intercepts a DELETE with a 409 OperationOutcome and asserts: inline error appears, confirm panel stays open, user is not navigated away
- [ ] Manual verification: open a Patient detail page, delete with the network throttled to "Offline", confirm the error message appears inline and the panel stays open

## Non-goals

- Generic global toast / notification system. Inline error in the confirm panel is enough for now.
- Auto-retry on transient failures — explicit user action.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WG9e1n3DVKadZaEzZpBVFH)_