### PR TITLE
feat(demo): sync PatientListPage search params to the URL

### DIFF
--- a/apps/demo/e2e/patient-search-url.spec.ts
+++ b/apps/demo/e2e/patient-search-url.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Patient search URL sync", () => {
+  test("submitting a search updates the URL with the active filters", async ({
+    page,
+  }) => {
+    await page.goto("/Patient");
+    const search = page.getByTestId("resource-search");
+    await search.getByRole("textbox", { name: "given" }).fill("Alan");
+    await search.getByRole("button", { name: "Search" }).click();
+
+    await expect(page.getByTestId("patient-row")).toHaveCount(1);
+    await expect(page).toHaveURL(/\/Patient\?.*given=Alan/);
+  });
+
+  test("loading a URL with a filter pre-fills the form and applies it", async ({
+    page,
+  }) => {
+    await page.goto("/Patient?given=Alan");
+
+    const search = page.getByTestId("resource-search");
+    await expect(search).toBeVisible();
+    await expect(search.getByRole("textbox", { name: "given" })).toHaveValue(
+      "Alan",
+    );
+    await expect(page.getByTestId("patient-row")).toHaveCount(1);
+    await expect(page.getByTestId("patient-row")).toContainText(
+      "Alan Mathison Turing",
+    );
+  });
+});

--- a/apps/demo/src/pages/PatientListPage.tsx
+++ b/apps/demo/src/pages/PatientListPage.tsx
@@ -5,8 +5,8 @@ import {
   useInfiniteSearch,
 } from "@fhir-place/react-fhir";
 import type { Patient } from "fhir/r4";
-import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import type { SearchParams } from "@fhir-place/react-fhir";
 import { PatientRowCounts } from "../components/PatientRowCounts.js";
 
@@ -36,12 +36,34 @@ const readLayout = (): Layout => {
 };
 
 export function PatientListPage() {
-  const [params, setParams] = useState<SearchParams>({ _count: 20 });
+  const [searchParams, setSearchParams] = useSearchParams();
+  // Initial params come from the URL so reload / share keeps the active
+  // filter. `_count` is a non-user pagination knob and stays out of the URL.
+  const initialFilters = useMemo(
+    () => Object.fromEntries(searchParams),
+    // Read once on mount; subsequent changes flow through the form, not the
+    // URL. Re-deriving on every URL change would clobber in-progress edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+  const [params, setParams] = useState<SearchParams>({
+    _count: 20,
+    ...initialFilters,
+  });
   const [layout, setLayout] = useState<Layout>(readLayout);
   const [columns, setColumns] = useState<string[]>(() =>
     TABLE_COLUMNS.map((c) => c.path),
   );
   const navigate = useNavigate();
+
+  const onSearchSubmit = (next: SearchParams) => {
+    setParams({ _count: 20, ...next });
+    const stringified: Record<string, string> = {};
+    for (const [k, v] of Object.entries(next)) {
+      if (v !== undefined && v !== null && v !== "") stringified[k] = String(v);
+    }
+    setSearchParams(stringified, { replace: true });
+  };
   const {
     data,
     isLoading,
@@ -89,7 +111,8 @@ export function PatientListPage() {
         resourceType="Patient"
         initialVisible={6}
         priorityParams={["name", "family", "given", "gender", "birthdate", "address-city"]}
-        onSubmit={(p) => setParams({ _count: 20, ...p })}
+        initialParams={initialFilters}
+        onSubmit={onSearchSubmit}
       />
 
       <div className="flex items-center justify-between gap-2">


### PR DESCRIPTION
Closes #59.

## Summary

Filters were stored only in local React state, so reload / share dropped the active search and the URL never reflected what the user was looking at.

- Read initial filters from the URL via `useSearchParams`.
- Push the submitted set back via `setSearchParams({ ..., replace: true })` so back-button noise is minimised.
- Pass `initialParams` into `<ResourceSearch>` so the form pre-fills on first paint.
- `_count` and other non-user pagination knobs stay out of the address bar.
- Composes cleanly with PR #63 (Clear → `onSubmit({})` → URL params wiped).

## Test plan

- [x] `pnpm -r typecheck` — clean
- [x] New Playwright e2e (`apps/demo/e2e/patient-search-url.spec.ts`):
  - submit "given=Alan" → URL becomes `/Patient?...given=Alan`
  - load `/Patient?given=Alan` directly → form is pre-filled, list filters to Alan Mathison Turing
- [ ] Manual verification: filter on the live demo, copy URL into a new tab, confirm the same filtered view loads

## Non-goals

- Same treatment for `ResourceIndexPage` (already half-uses `useSearchParams` for `?patient=`). Open follow-up if useful.
- Putting `_count` / `_sort` / layout / column visibility in the URL — they belong in localStorage (already done for layout / columns).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WG9e1n3DVKadZaEzZpBVFH)_