### PR TITLE
feat(ResourceTable): card layout on narrow viewports

### DIFF
--- a/packages/react-fhir/src/components/ResourceTable.test.tsx
+++ b/packages/react-fhir/src/components/ResourceTable.test.tsx
@@ -190,6 +190,48 @@ describe("ResourceTable", () => {
     expect(within(row).queryByText(/"value":/)).not.toBeInTheDocument();
   });
 
+  it("renders a card layout on narrow viewports (layout=cards)", () => {
+    render(
+      <ResourceTable<Patient>
+        resources={patients}
+        columns={["name", "gender", "birthDate"]}
+        structureDefinition={sd}
+        layout="cards"
+      />,
+      { wrapper: wrap() },
+    );
+    // Each row is now a list item with a label/value pair per column.
+    const rows = screen.getAllByTestId("resource-row");
+    expect(rows).toHaveLength(2);
+    // Headers don't render in card mode; instead each cell is paired with
+    // its column label inline.
+    expect(within(rows[0]!).getByText("Name")).toBeInTheDocument();
+    expect(within(rows[0]!).getByText("Gender")).toBeInTheDocument();
+    expect(within(rows[0]!).getByText("Birth Date")).toBeInTheDocument();
+    expect(within(rows[0]!).getByText(/Ada Lovelace/)).toBeInTheDocument();
+    // No HTML <table> in the DOM.
+    expect(document.querySelector("table")).toBeNull();
+  });
+
+  it("invokes onRowClick from the card layout via Enter / Space", async () => {
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ResourceTable<Patient>
+        resources={patients}
+        columns={["name"]}
+        onRowClick={onRowClick}
+        structureDefinition={sd}
+        layout="cards"
+      />,
+      { wrapper: wrap() },
+    );
+    const firstRow = screen.getAllByTestId("resource-row")[0]!;
+    firstRow.focus();
+    await user.keyboard("{Enter}");
+    expect(onRowClick).toHaveBeenCalledWith(patients[0]);
+  });
+
   it("falls back to a friendly dash for missing cell values", () => {
     const partial: Patient = { resourceType: "Patient", id: "p3", gender: "other" };
     render(

--- a/packages/react-fhir/src/components/ResourceTable.tsx
+++ b/packages/react-fhir/src/components/ResourceTable.tsx
@@ -1,5 +1,5 @@
 import type { Reference, Resource, StructureDefinition } from "fhir/r4";
-import { Fragment, useMemo, type ReactNode } from "react";
+import { Fragment, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useStructureDefinition } from "../hooks/queries.js";
 import { findChoiceVariant, findElement } from "../structure/walker.js";
 import {
@@ -33,7 +33,30 @@ export interface ResourceTableProps<T extends Resource = Resource> {
   renderers?: TypeRenderers;
   /** Click handler for Reference cells. */
   onReferenceClick?: (ref: Reference) => void;
+  /**
+   * Layout mode. `"auto"` (default) renders the table on viewports ≥ 640px and
+   * a label/value card stack below — clinical tables become readable on mobile
+   * without horizontal scrolling. `"table"` and `"cards"` force the layout.
+   */
+  layout?: "auto" | "table" | "cards";
   className?: string;
+}
+
+const NARROW_QUERY = "(max-width: 639px)";
+
+function useIsNarrow(): boolean {
+  const [narrow, setNarrow] = useState(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia(NARROW_QUERY).matches;
+  });
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia(NARROW_QUERY);
+    const onChange = () => setNarrow(mq.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+  return narrow;
 }
 
 const headerFromPath = (path: string): string => {
@@ -84,8 +107,11 @@ export function ResourceTable<T extends Resource = Resource>({
   structureDefinition,
   renderers: rendererOverrides,
   onReferenceClick,
+  layout = "auto",
   className,
 }: ResourceTableProps<T>) {
+  const isNarrow = useIsNarrow();
+  const useCards = layout === "cards" || (layout === "auto" && isNarrow);
   const resourceType = resources[0]?.resourceType ?? "";
   const sdQuery = useStructureDefinition(resourceType, {
     enabled: !structureDefinition && Boolean(resourceType),
@@ -117,6 +143,63 @@ export function ResourceTable<T extends Resource = Resource>({
 
   if (resources.length === 0) {
     return <>{emptyState ?? <p className="text-sm text-slate-500">No results.</p>}</>;
+  }
+
+  if (useCards) {
+    return (
+      <ul
+        className={
+          className ??
+          "divide-y divide-slate-100 rounded border border-slate-200 bg-white"
+        }
+        data-testid="resource-table"
+      >
+        {resources.map((r) => {
+          const clickProps = onRowClick
+            ? {
+                onClick: () => onRowClick(r),
+                onKeyDown: (e: React.KeyboardEvent) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onRowClick(r);
+                  }
+                },
+                tabIndex: 0,
+                role: "button" as const,
+                className: "cursor-pointer space-y-1 px-3 py-2 hover:bg-slate-50",
+              }
+            : { className: "space-y-1 px-3 py-2" };
+          return (
+            <li
+              key={`${r.resourceType}/${r.id}`}
+              data-testid="resource-row"
+              {...clickProps}
+            >
+              {headers.map((h) => (
+                <div
+                  key={h.path}
+                  className="flex items-baseline justify-between gap-3 text-sm"
+                >
+                  <span className="text-xs font-medium text-slate-500">
+                    {h.label}
+                  </span>
+                  <span className="text-right text-slate-900">
+                    {renderCell({
+                      resource: r,
+                      path: h.path,
+                      typeCode: h.typeCode,
+                      cellRenderers,
+                      renderers,
+                      onReferenceClick,
+                    })}
+                  </span>
+                </div>
+              ))}
+            </li>
+          );
+        })}
+      </ul>
+    );
   }
 
   return (


### PR DESCRIPTION
Closes #60.

## Summary

Compartment tables (Observations, Encounters, Immunizations…) on the mobile Patient detail page were squeezed into 4-column tables that clipped beyond legibility — the Value column was unreadable on the iPhone Playwright project (`screenshots/04-patient-detail-mobile.png`).

- New `layout?: "auto" | "table" | "cards"` prop on `<ResourceTable>` (defaults to `"auto"`).
- `useIsNarrow()` hook reads `matchMedia("(max-width: 639px)")` and re-renders on viewport change. Falls back to `false` when matchMedia is absent (jsdom, SSR), so no test setup change is needed.
- Card layout reuses `renderCell` / `cellRenderers` / `renderers` / `onReferenceClick` / `onRowClick` verbatim — pure presentation change.
- Card rows get `role="button" tabIndex={0}` plus the existing Enter/Space handler, so keyboard nav works the same as the table rows.

## Test plan

- [x] `pnpm -r typecheck` — clean
- [x] `pnpm --filter @fhir-place/react-fhir test --run` — 226/226 pass (was 224, +2 new)
- [x] New tests in `ResourceTable.test.tsx`:
  - `layout="cards"` renders one `<li data-testid="resource-row">` per resource with inline label/value pairs and no `<table>` in the DOM
  - Enter on a focused card row fires `onRowClick`
- [ ] Manual verification on the deployed demo (iPhone viewport): open a Patient detail page → Observations renders as cards with `Value: 72 beats/minute` etc., Encounters and Immunizations follow suit, no horizontal scroll

## Composes with

- #62 (already merged) — choice-typed cells now render via `Quantity` etc., so the card Value field shows `72 beats/minute` instead of raw JSON.

## Non-goals

- Per-column priority hiding (e.g. "show this column on tablet only") — keep all columns visible in card mode.
- Mobile redesign of the compartment section header / chip nav — separate concern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WG9e1n3DVKadZaEzZpBVFH)_