### PR TITLE
feat(ResourceTable): responsive card-stack layout for phone-width viewports

### DIFF
--- a/apps/demo/e2e/responsive-table.screenshot.spec.ts
+++ b/apps/demo/e2e/responsive-table.screenshot.spec.ts
@@ -1,0 +1,70 @@
+import { devices, expect, test } from "@playwright/test";
+
+test.describe("ResourceTable — responsive layouts", () => {
+  test.beforeEach(async ({ page }) => {
+    // Force the table view so the responsive switch is exercised on the
+    // Patient list (which is the easiest live-data surface for the test).
+    await page.addInitScript(() => {
+      window.localStorage.setItem("fhir-place-demo-patient-layout", "table");
+    });
+  });
+
+  test("desktop viewport renders the <table> layout", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/Patient");
+    await expect(page.getByTestId("resource-table-table")).toBeVisible();
+    // Card layout is in the DOM but hidden by `sm:hidden` at this width.
+    await expect(page.getByTestId("resource-table-cards")).toBeHidden();
+  });
+
+  test("phone viewport renders the card-stack layout instead of a clipped table", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ ...devices["iPhone 14"] });
+    const page = await context.newPage();
+    await page.addInitScript(() => {
+      window.localStorage.setItem("fhir-place-demo-patient-layout", "table");
+    });
+    await page.goto("/Patient");
+
+    // Card layout is the visible one on phone.
+    const cards = page.getByTestId("resource-table-cards");
+    await expect(cards).toBeVisible();
+    await expect(page.getByTestId("resource-table-table")).toBeHidden();
+
+    // At least one card with label/value pairs.
+    const card = page.getByTestId("resource-row-card").first();
+    await expect(card).toBeVisible();
+    // Column header labels render as field labels in the card.
+    await expect(card.getByText(/Name/)).toBeVisible();
+    await expect(card.getByText(/Gender/)).toBeVisible();
+
+    // No body horizontal scroll: scrollWidth should equal clientWidth (or be close).
+    const overflow = await page.evaluate(() => {
+      const el = document.documentElement;
+      return el.scrollWidth - el.clientWidth;
+    });
+    expect(overflow).toBeLessThanOrEqual(2);
+
+    await page.screenshot({
+      path: "../../screenshots/16-patient-table-mobile-cards.png",
+      fullPage: true,
+    });
+    await context.close();
+  });
+
+  test("clicking a card navigates to the detail page (parity with table row click)", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ ...devices["iPhone 14"] });
+    const page = await context.newPage();
+    await page.addInitScript(() => {
+      window.localStorage.setItem("fhir-place-demo-patient-layout", "table");
+    });
+    await page.goto("/Patient");
+    await page.getByTestId("resource-row-card").first().click();
+    await expect(page).toHaveURL(/\/Patient\/[^/]+$/);
+    await expect(page.getByTestId("resource-view")).toBeVisible();
+    await context.close();
+  });
+});

--- a/packages/react-fhir/src/components/ResourceTable.test.tsx
+++ b/packages/react-fhir/src/components/ResourceTable.test.tsx
@@ -83,6 +83,10 @@ describe("ResourceTable", () => {
         resources={patients}
         columns={["name", "gender", "birthDate"]}
         structureDefinition={sd}
+        // Pin to the table layout — auto mode renders BOTH layouts in
+        // jsdom (no CSS), which would duplicate every label / value text
+        // node and break the count-based assertions below.
+        layout="table"
       />,
       { wrapper: wrap() },
     );
@@ -108,6 +112,7 @@ describe("ResourceTable", () => {
           name: (p) => <span data-testid="custom-name">{p.id}</span>,
         }}
         structureDefinition={sd}
+        layout="table"
       />,
       { wrapper: wrap() },
     );
@@ -205,5 +210,120 @@ describe("ResourceTable", () => {
     expect(within(row).getByText("—")).toBeInTheDocument();
     // Gender present → renders via code renderer
     expect(within(row).getByText("other")).toBeInTheDocument();
+  });
+
+  describe("responsive layouts", () => {
+    it("auto layout (default) renders both a table and a card stack", () => {
+      render(
+        <ResourceTable<Patient>
+          resources={patients}
+          columns={["name", "gender"]}
+          structureDefinition={sd}
+        />,
+        { wrapper: wrap() },
+      );
+      expect(screen.getByTestId("resource-table-table")).toBeInTheDocument();
+      expect(screen.getByTestId("resource-table-cards")).toBeInTheDocument();
+      // jsdom doesn't apply CSS, so both layouts are in the DOM. Existing
+      // unit tests counting `resource-row` still see only the table rows.
+      expect(screen.getAllByTestId("resource-row")).toHaveLength(2);
+      expect(screen.getAllByTestId("resource-row-card")).toHaveLength(2);
+    });
+
+    it('layout="table" omits the card stack entirely', () => {
+      render(
+        <ResourceTable<Patient>
+          resources={patients}
+          columns={["name", "gender"]}
+          structureDefinition={sd}
+          layout="table"
+        />,
+        { wrapper: wrap() },
+      );
+      expect(screen.getByTestId("resource-table-table")).toBeInTheDocument();
+      expect(screen.queryByTestId("resource-table-cards")).not.toBeInTheDocument();
+      expect(screen.queryAllByTestId("resource-row-card")).toHaveLength(0);
+    });
+
+    it('layout="cards" omits the table entirely', () => {
+      render(
+        <ResourceTable<Patient>
+          resources={patients}
+          columns={["name", "gender"]}
+          structureDefinition={sd}
+          layout="cards"
+        />,
+        { wrapper: wrap() },
+      );
+      expect(screen.queryByTestId("resource-table-table")).not.toBeInTheDocument();
+      expect(screen.getByTestId("resource-table-cards")).toBeInTheDocument();
+      expect(screen.getAllByTestId("resource-row-card")).toHaveLength(2);
+      // No table rows.
+      expect(screen.queryAllByTestId("resource-row")).toHaveLength(0);
+    });
+
+    it("renders each card as a label/value list and dispatches the same renderers", () => {
+      render(
+        <ResourceTable<Patient>
+          resources={patients}
+          columns={["name", "gender", "birthDate"]}
+          structureDefinition={sd}
+          layout="cards"
+        />,
+        { wrapper: wrap() },
+      );
+      const card = screen.getAllByTestId("resource-row-card")[0]!;
+      // Labels (column headers) + values render side by side in the dl.
+      expect(within(card).getByText("Name")).toBeInTheDocument();
+      expect(within(card).getByText(/Ada Lovelace/)).toBeInTheDocument();
+      expect(within(card).getByText("Gender")).toBeInTheDocument();
+      expect(within(card).getByText("female")).toBeInTheDocument();
+      expect(within(card).getByText("Birth Date")).toBeInTheDocument();
+      expect(within(card).getByText("1815-12-10")).toBeInTheDocument();
+    });
+
+    it("card rows are keyboard-clickable when onRowClick is set", async () => {
+      const onRowClick = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <ResourceTable<Patient>
+          resources={patients}
+          columns={["name"]}
+          structureDefinition={sd}
+          layout="cards"
+          onRowClick={onRowClick}
+        />,
+        { wrapper: wrap() },
+      );
+      const card = screen.getAllByTestId("resource-row-card")[1]!;
+      card.focus();
+      expect(card.tabIndex).toBe(0);
+      await user.keyboard("{Enter}");
+      expect(onRowClick).toHaveBeenCalledWith(patients[1]);
+    });
+
+    it("dispatches choice-typed cells (valueQuantity) the same way in card layout", () => {
+      const observation: Observation = {
+        resourceType: "Observation",
+        id: "o1",
+        status: "final",
+        code: { text: "Heart rate" },
+        valueQuantity: { value: 86, unit: "beats/minute" },
+      };
+      render(
+        <ResourceTable<Observation>
+          resources={[observation]}
+          columns={["code.text", "valueQuantity"]}
+          columnLabels={{ "code.text": "Observation", valueQuantity: "Value" }}
+          structureDefinition={ObservationStructureDefinition}
+          layout="cards"
+        />,
+        { wrapper: wrap() },
+      );
+      const card = screen.getByTestId("resource-row-card");
+      expect(within(card).getByText(/86/)).toBeInTheDocument();
+      expect(within(card).getByText(/beats\/minute/)).toBeInTheDocument();
+      expect(within(card).queryByText(/"value":/)).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/react-fhir/src/components/ResourceTable.tsx
+++ b/packages/react-fhir/src/components/ResourceTable.tsx
@@ -13,6 +13,8 @@ export interface ResourceTableSort {
   direction: "asc" | "desc";
 }
 
+export type ResourceTableLayout = "auto" | "table" | "cards";
+
 export interface ResourceTableProps<T extends Resource = Resource> {
   resources: T[];
   /** Dotted FHIR paths to show as columns, e.g. `["status", "code.text", "subject.display"]`. */
@@ -33,6 +35,15 @@ export interface ResourceTableProps<T extends Resource = Resource> {
   renderers?: TypeRenderers;
   /** Click handler for Reference cells. */
   onReferenceClick?: (ref: Reference) => void;
+  /**
+   * Layout mode:
+   * - `"auto"` (default) — renders both layouts and switches via Tailwind's
+   *   `sm:` breakpoint: card stack below 640px, table at and above. The
+   *   columns and cell renderers are shared.
+   * - `"table"` — always table (the pre-#60 behaviour).
+   * - `"cards"` — always card stack (useful for embeds in narrow sidebars).
+   */
+  layout?: ResourceTableLayout;
   className?: string;
 }
 
@@ -71,6 +82,12 @@ export function getByPath(obj: unknown, path: string): unknown {
  * Generic table driven by the StructureDefinition's datatype metadata. Cells
  * format using the same `defaultTypeRenderers` map as `<ResourceView>`, so a
  * CodeableConcept in a table cell and in a detail page render identically.
+ *
+ * `layout="auto"` (default) renders a desktop `<table>` and a mobile card
+ * stack side-by-side, switching via Tailwind's `sm:` breakpoint. Below 640px
+ * each row becomes a label / value list — column squeeze and clipped values
+ * (e.g. `Observation.valueQuantity`) on phone-width viewports were the
+ * motivation for #60.
  */
 export function ResourceTable<T extends Resource = Resource>({
   resources,
@@ -84,6 +101,7 @@ export function ResourceTable<T extends Resource = Resource>({
   structureDefinition,
   renderers: rendererOverrides,
   onReferenceClick,
+  layout = "auto",
   className,
 }: ResourceTableProps<T>) {
   const resourceType = resources[0]?.resourceType ?? "";
@@ -119,55 +137,127 @@ export function ResourceTable<T extends Resource = Resource>({
     return <>{emptyState ?? <p className="text-sm text-slate-500">No results.</p>}</>;
   }
 
+  // Tailwind classes that gate each layout. `auto` renders both DOM trees
+  // and the breakpoint hides one — keeps the JS simple (no resize listeners,
+  // no SSR hydration mismatches) at the cost of a tiny extra DOM. Pinned
+  // modes skip the other layout entirely so jsdom unit tests don't see
+  // duplicated nodes.
+  const renderTable = layout !== "cards";
+  const renderCards = layout !== "table";
+  const tableVisibility = layout === "auto" ? "hidden sm:block" : "";
+  const cardsVisibility = layout === "auto" ? "block sm:hidden" : "";
+
   return (
-    <div className={className ?? "overflow-x-auto rounded border border-slate-200 bg-white"} data-testid="resource-table">
-      <table className="w-full text-sm">
-        <thead className="border-b border-slate-200 bg-slate-50 text-left">
-          <tr>
-            {headers.map((h) => (
-              <th key={h.path} className="px-3 py-2 font-medium text-slate-600">
-                {onSortChange ? (
-                  <button
-                    type="button"
-                    onClick={() => toggleSort(h.path)}
-                    className="flex items-center gap-1 hover:text-slate-900"
-                  >
-                    {h.label}
-                    {sort?.by === h.path && (
-                      <span aria-hidden className="text-[10px]">
-                        {sort.direction === "asc" ? "▲" : "▼"}
-                      </span>
-                    )}
-                  </button>
-                ) : (
-                  h.label
-                )}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-slate-100">
-          {resources.map((r) => (
-            <tr
-              key={`${r.resourceType}/${r.id}`}
-              className={onRowClick ? "cursor-pointer hover:bg-slate-50" : undefined}
-              onClick={onRowClick ? () => onRowClick(r) : undefined}
-              onKeyDown={
-                onRowClick
-                  ? (e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        onRowClick(r);
+    <div className={className ?? "rounded border border-slate-200 bg-white"} data-testid="resource-table">
+      {/* Desktop / opt-in table layout */}
+      {renderTable && (
+      <div
+        className={`${tableVisibility} overflow-x-auto`}
+        data-testid="resource-table-table"
+      >
+        <table className="w-full text-sm">
+          <thead className="border-b border-slate-200 bg-slate-50 text-left">
+            <tr>
+              {headers.map((h) => (
+                <th key={h.path} className="px-3 py-2 font-medium text-slate-600">
+                  {onSortChange ? (
+                    <button
+                      type="button"
+                      onClick={() => toggleSort(h.path)}
+                      className="flex items-center gap-1 hover:text-slate-900"
+                    >
+                      {h.label}
+                      {sort?.by === h.path && (
+                        <span aria-hidden className="text-[10px]">
+                          {sort.direction === "asc" ? "▲" : "▼"}
+                        </span>
+                      )}
+                    </button>
+                  ) : (
+                    h.label
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {resources.map((r) => (
+              <tr
+                key={`${r.resourceType}/${r.id}`}
+                className={onRowClick ? "cursor-pointer hover:bg-slate-50" : undefined}
+                onClick={onRowClick ? () => onRowClick(r) : undefined}
+                onKeyDown={
+                  onRowClick
+                    ? (e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          onRowClick(r);
+                        }
                       }
+                    : undefined
+                }
+                tabIndex={onRowClick ? 0 : undefined}
+                data-testid="resource-row"
+              >
+                {headers.map((h) => (
+                  <Fragment key={h.path}>
+                    <td className="px-3 py-2 align-top">
+                      {renderCell({
+                        resource: r,
+                        path: h.path,
+                        typeCode: h.typeCode,
+                        cellRenderers,
+                        renderers,
+                        onReferenceClick,
+                      })}
+                    </td>
+                  </Fragment>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      )}
+
+      {/* Narrow / mobile card-stack layout. Distinct testid (`resource-row-card`)
+          so jsdom unit tests counting `resource-row`s still see only the
+          table rows in `auto` mode (Tailwind's `hidden` doesn't remove DOM,
+          and jsdom doesn't apply CSS). */}
+      {renderCards && (
+      <ul
+        className={`${cardsVisibility} divide-y divide-slate-200`}
+        data-testid="resource-table-cards"
+      >
+        {resources.map((r) => (
+          <li
+            key={`${r.resourceType}/${r.id}`}
+            className={
+              onRowClick
+                ? "cursor-pointer p-3 hover:bg-slate-50 focus-within:bg-slate-50"
+                : "p-3"
+            }
+            onClick={onRowClick ? () => onRowClick(r) : undefined}
+            onKeyDown={
+              onRowClick
+                ? (e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onRowClick(r);
                     }
-                  : undefined
-              }
-              tabIndex={onRowClick ? 0 : undefined}
-              data-testid="resource-row"
-            >
+                  }
+                : undefined
+            }
+            tabIndex={onRowClick ? 0 : undefined}
+            data-testid="resource-row-card"
+          >
+            <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
               {headers.map((h) => (
                 <Fragment key={h.path}>
-                  <td className="px-3 py-2 align-top">
+                  <dt className="text-xs font-medium text-slate-500">
+                    {h.label}
+                  </dt>
+                  <dd className="break-words">
                     {renderCell({
                       resource: r,
                       path: h.path,
@@ -176,13 +266,14 @@ export function ResourceTable<T extends Resource = Resource>({
                       renderers,
                       onReferenceClick,
                     })}
-                  </td>
+                  </dd>
                 </Fragment>
               ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+            </dl>
+          </li>
+        ))}
+      </ul>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #60.

## Summary

Compartment tables (Observations, Encounters, Immunizations) clipped on phone-width viewports — `Value` column unreadable, `Effective Date Time` squeezed, no horizontal-scroll affordance. See `screenshots/04-patient-detail-mobile.png`.

* New `layout?: "auto" | "table" | "cards"` prop on `<ResourceTable>` (default `"auto"`).
* `"auto"` renders both a desktop `<table>` and a mobile card stack; Tailwind's `sm:` (640px) breakpoint hides whichever doesn't fit. CSS-only switch — no resize listeners, no SSR hydration mismatches.
* Cards are a label/value `<dl>` reusing the same `renderCell` logic and `defaultTypeRenderers` map as the table, so a `valueQuantity` formats as `86 beats/minute` in both layouts.
* Card rows preserve keyboard + click parity (tabIndex=0, Enter/Space fires `onRowClick`).
* `"table"` and `"cards"` skip the other layout entirely — useful when consumers want a pinned mode (narrow sidebar embeds, desktop-only screens).

## Test plan

* [x] `pnpm --filter @fhir-place/react-fhir test:run` — **230 passing** (was 222). 6 new tests cover auto/table/cards modes, card-layout cell rendering with the choice-variant `valueQuantity` path, and card keyboard navigation.
* [x] `pnpm --filter @fhir-place/react-fhir typecheck`
* [x] `pnpm --filter @fhir-place/react-fhir build`
* [x] `pnpm --filter @fhir-place/demo typecheck` + build (331.51 kB, was 330.05 kB; +1.5 KB for the dual layout)
* [x] New Playwright spec `responsive-table.screenshot.spec.ts`:
    * Desktop viewport renders the table; cards hidden
    * iPhone 14 viewport renders cards; table hidden; no horizontal page scroll; header labels render as field labels
    * Clicking a card navigates to the detail page (parity with table row click)
* [ ] Live verification once merged (screenshot 16-patient-table-mobile-cards.png replaces the clipped 04-patient-detail-mobile.png)

## Test-id strategy

Cards use `data-testid="resource-row-card"` (distinct from `resource-row` on table rows). Reason: jsdom doesn't apply CSS, so in `auto` mode both layouts share the DOM. Existing tests counting `resource-row` continue to see only the table rows, no churn. Two existing tests were updated to explicitly pass `layout="table"` because they assert text counts that would double in `auto` mode.

## Non-goals

* Per-column priority hiding ("show this column on tablet only") — keep all columns visible in card mode; opinionated decisions belong to consumers via custom layouts.
* Column drag-and-drop reordering on cards.
* Bigger redesign of the compartment section header / chip nav — separate concern.

https://claude.ai/code/session_01TgwNnfZJdFDzXN5JjrEi72

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgwNnfZJdFDzXN5JjrEi72)_