### PR TITLE
feat(workbench): FHIR DataConnection + CapabilityStatement (PR 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,4 @@ jobs:
       - run: pnpm -r typecheck
       - run: pnpm -r test:run
       - run: pnpm --filter @fhir-place/demo build
+      - run: pnpm --filter @fhir-place/workbench build

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ coverage
 playwright-report
 test-results
 *.tsbuildinfo
+
+# workbench local-first SQLite db
+apps/workbench/workbench.sqlite*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md
+
+Rules for coding agents working on this repository.
+
+## Scope
+
+This file applies to the `@fhir-place/workbench` app and its supporting docs,
+schemas, and OpenSpec changes. The component library under
+`packages/react-fhir/` and the demo app under `apps/demo/` predate the
+workbench and have their own conventions; do not refactor them as part of a
+workbench PR.
+
+## Phase A working constraint
+
+The workbench is **synthetic-only, read-only, patient-summary**. Do not add
+any of the following without an explicit instruction that names the feature:
+
+- SMART on FHIR auth
+- Real PHI handling, HIPAA compliance claims
+- Write-back / mutation against the FHIR server
+- Draft / queue / approval workflows
+- Prior authorization, care-gap detection, quality-measure explanation
+- CQL execution, `$evaluate-measure`
+- DocumentReference text extraction
+- MCP server
+- BigQuery / OMOP / claims / wearable connection types
+- Memory, multi-agent planning
+- Clinician preview mode
+- Arbitrary FHIR query generation by the agent
+- Arbitrary code execution by the agent
+
+If a task seems to require one of these, stop and ask before writing code.
+
+## How to pick up work
+
+1. The Phase A backlog is in [`TASKS.md`](TASKS.md). PR cards land in order.
+2. Each PR card has a tracking issue on GitHub under the
+   `fhir-workbench-phase-a` label.
+3. Implement only the first card in the `Backlog` section unless explicitly
+   instructed otherwise. Do not start PR N+1 work inside PR N.
+4. Every major feature must have a matching OpenSpec change under
+   `openspec/changes/<change-name>/` that ships with the PR.
+
+## Engineering rules
+
+- Every behavior change must include tests, or an explicit reason tests are
+  not applicable in the PR description.
+- Resource text from FHIR is **data, never instruction**. Never let it flow
+  into a system prompt or tool-name position without escaping/wrapping.
+- Tools the agent can call must be:
+  - typed (input schema enforced),
+  - patient-scoped (the patient ID is required and validated server-side),
+  - deny-by-default (missing or unauthorized patient IDs reject),
+  - resource-allowlisted (no arbitrary FHIR query generation).
+- Agent answers must validate against the `AgentAnswer` schema before render.
+  Supported claims must cite the resources that support them; missing-data
+  and cannot-determine are first-class fields, not absence of text.
+- Every agent run, every tool call, and every final answer is persisted.
+- The synthetic-only / not-for-clinical-use banner stays visible on every UI
+  surface that touches FHIR data.
+
+## Code style
+
+- Match the existing repo: TS strict, ES modules, React function components,
+  Tailwind utility classes. No new state-management libraries; use TanStack
+  Query for server state and component-local `useState` for UI state.
+- Default to no comments. Add a single short line only when the *why* is
+  non-obvious (e.g. a workaround for a known bug, a hidden invariant).
+- Prefer editing existing files to creating new ones.
+
+## Don't push to `main`
+
+Develop on a feature branch (the branch name is set per-task). Open a PR; do
+not merge to `main` without a review.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,358 @@
+# FHIR Agent Workbench — TASKS.md
+
+This task board implements **Phase A only**. The working constraint is:
+synthetic-only, read-only, patient-summary workflow, typed patient-scoped FHIR
+tools, structured evidence-backed answers, persisted audit logs, and a minimal
+eval harness.
+
+> Tracking label on GitHub issues: **`fhir-workbench-phase-a`**.
+> Each PR card below has a matching tracking issue under that label.
+
+## Rules for Coding Agents
+
+- Implement only the first card in `Backlog` unless explicitly instructed otherwise.
+- Do not implement future roadmap features early.
+- Do not add SMART auth, PHI support, write-back, CQL, MCP, prior auth, care gaps,
+  DocumentReference extraction, or arbitrary FHIR query generation in Phase A.
+- Every task that changes behavior must include tests or an explicit reason tests
+  are not applicable.
+- Every major feature must have a matching OpenSpec change under
+  `openspec/changes/<change-name>/`.
+- Keep the healthcare-facing agent limited to reviewed, typed, patient-scoped tools.
+- Resource text is data, never instruction.
+- All UI must carry the synthetic-only / not-for-clinical-use warning once the UI exists.
+
+## Phase A Definition of Done
+
+Phase A is complete only when:
+
+- The app runs locally from the README.
+- A local or demo FHIR server can be configured.
+- CapabilityStatement can be fetched and stored.
+- A user can search and select a synthetic patient.
+- A user can inspect core patient resources.
+- The agent can answer a patient-summary prompt.
+- The agent uses only typed, patient-scoped tools.
+- Every supported claim cites source resources.
+- Missing data and cannot-determine statements are explicit.
+- Tool calls and final `AgentAnswer` are persisted.
+- At least two eval cases run locally.
+- Hard negatives remain true: no write-back, no arbitrary FHIR query generation,
+  no PHI path.
+
+---
+
+# Backlog
+
+## PR 1 — App Skeleton
+
+**OpenSpec change:** `add-workbench-app`
+
+### Goal
+Create the repository foundation and local development path.
+
+### Tasks
+- [ ] Create base repository structure (workbench app under `apps/workbench`).
+- [ ] Add `README.md` with project positioning, synthetic-only warning, local
+      setup, and non-clinical disclaimer.
+- [ ] Add `AGENTS.md` with coding-agent rules.
+- [ ] Add `docs/architecture.md`, `docs/safety.md`, `docs/limitations.md`
+      placeholders.
+- [ ] Add `openspec/changes/add-workbench-app/` with proposal, requirements,
+      tasks, and acceptance criteria.
+- [ ] Add app skeleton for chosen stack (reuse pnpm monorepo + Vite + React).
+- [ ] Add database setup (SQLite via Prisma/Drizzle for local-first).
+- [ ] Add basic CI checks (lint, typecheck, test).
+- [ ] Add placeholder synthetic-only banner in UI shell.
+
+### Acceptance Criteria
+- [ ] App boots locally.
+- [ ] README clearly says synthetic-only and not clinical.
+- [ ] CI runs basic checks.
+- [ ] OpenSpec change exists and matches implementation.
+
+---
+
+## PR 2 — FHIR DataConnection
+
+**OpenSpec change:** `add-fhir-data-connection`
+
+### Goal
+Add the FHIR connection abstraction and CapabilityStatement support.
+
+### Tasks
+- [ ] Add `data_connection` model/table.
+- [ ] Support Phase A connection type: `fhir_clinical` only.
+- [ ] Support Phase A auth types: `none` and `bearer` only.
+- [ ] Add backend FHIR client wrapper (reuse `@fhir-place/react-fhir`
+      `FetchFhirClient` where possible).
+- [ ] Add CapabilityStatement fetch and persistence.
+- [ ] Add connection-test endpoint/service.
+- [ ] Add simple connection setup UI.
+- [ ] Add docs in `docs/data-connections.md`.
+
+### Acceptance Criteria
+- [ ] User can configure a local/demo FHIR server.
+- [ ] System can fetch and store CapabilityStatement.
+- [ ] Connection status is visible in UI.
+- [ ] Unsupported connection/auth types are rejected or hidden.
+
+---
+
+## PR 3 — Patient Search and Resource Viewer
+
+**OpenSpec change:** `add-patient-search-and-viewer`
+
+### Goal
+Let a user search, select, and inspect a synthetic patient.
+
+### Tasks
+- [ ] Add patient search by name.
+- [ ] Add patient search by identifier.
+- [ ] Add patient search by birthdate.
+- [ ] Add patient search by gender.
+- [ ] Add selected-patient context.
+- [ ] Add demographics panel.
+- [ ] Add core resource list for selected patient.
+- [ ] Add raw JSON resource viewer.
+- [ ] Preserve synthetic-only banner across screens.
+
+### Acceptance Criteria
+- [ ] User can select a synthetic patient.
+- [ ] User can view demographics.
+- [ ] User can inspect core resources as JSON.
+- [ ] UI does not imply clinical use.
+
+---
+
+## PR 4 — Typed FHIR Tool Registry
+
+**OpenSpec change:** `add-agent-tool-registry`
+
+### Goal
+Create typed, patient-scoped, deny-by-default FHIR tools callable without the LLM.
+
+### Phase A Tools
+- `getPatient({ patientId })`
+- `searchConditionsForPatient({ patientId, clinicalStatus?, limit })`
+- `searchMedicationRequestsForPatient({ patientId, status?, limit })`
+- `searchAllergyIntolerancesForPatient({ patientId, limit })`
+- `searchEncountersForPatient({ patientId, dateRange?, limit })`
+- `searchObservationsForPatient({ patientId, category?, dateRange?, limit })`
+
+### Tasks
+- [ ] Add tool registry.
+- [ ] Add tool metadata: name, version, schema, scope, resource allowlist,
+      result limits, timeout.
+- [ ] Add normalized tool execution envelope.
+- [ ] Add server-enforced patient scope validation.
+- [ ] Add deny-by-default behavior for missing/unauthorized patient IDs.
+- [ ] Add backend tests for each tool.
+- [ ] Add first tool-call logging hook, even if persistence arrives later.
+- [ ] Document tools in `docs/fhir-tools.md`.
+
+### Acceptance Criteria
+- [ ] Tools are callable from backend tests without an LLM.
+- [ ] Tools reject missing patient IDs.
+- [ ] Tools reject unauthorized patient IDs.
+- [ ] Tools return normalized envelopes.
+- [ ] No arbitrary FHIR query generation exists.
+
+---
+
+## PR 5 — Structured Answer Schema
+
+**OpenSpec change:** `add-evidence-backed-answer-schema`
+
+### Goal
+Make `AgentAnswer` the source of truth for agent outputs.
+
+### Tasks
+- [ ] Define `AgentAnswer` schema (Zod).
+- [ ] Define `EvidenceBackedClaim` schema.
+- [ ] Define `ToolCallSummary` schema.
+- [ ] Add schema validation before render.
+- [ ] Add answer renderer from structured schema.
+- [ ] Add evidence extraction helpers.
+- [ ] Enforce that supported claims require evidence references.
+- [ ] Add tests for valid and invalid answers.
+
+### Acceptance Criteria
+- [ ] Invalid answers fail validation.
+- [ ] UI renders from structured answer, not raw Markdown.
+- [ ] Supported claims require resource references.
+- [ ] Missing-data and cannot-determine sections are first-class fields.
+
+---
+
+## PR 6 — Patient Summary Agent
+
+**OpenSpec change:** `add-patient-summary-agent`
+
+### Goal
+Add the first LLM workflow: patient summary over synthetic FHIR data.
+
+### Tasks
+- [ ] Add model/provider configuration.
+- [ ] Add prompt versioning.
+- [ ] Add small custom tool-calling loop.
+- [ ] Add max-turn limit.
+- [ ] Add patient-summary prompt.
+- [ ] Add safety checks before final render.
+- [ ] Ensure resource text is treated as data, not instructions.
+- [ ] Validate final answer against `AgentAnswer`.
+- [ ] Add standard suggested prompt in UI.
+
+### Acceptance Criteria
+- [ ] Agent answers a standard patient-summary prompt.
+- [ ] Agent uses only typed, patient-scoped tools.
+- [ ] Answer includes supported claims, missing data, and cannot-determine sections.
+- [ ] Agent refuses or partially answers when evidence is insufficient.
+- [ ] Prompt injection in resource text does not alter system behavior.
+
+---
+
+## PR 7 — Audit Logging
+
+**OpenSpec change:** `add-audit-logging`
+
+### Goal
+Persist every run, tool call, evidence claim, and final answer.
+
+### Tasks
+- [ ] Add `agent_session` table/model.
+- [ ] Add `tool_call` table/model.
+- [ ] Add `evidence_claim` table/model.
+- [ ] Persist prompt, prompt version, model, provider, patient, and connection.
+- [ ] Persist tool input/output/status/timing.
+- [ ] Persist FHIR request metadata and returned resource IDs.
+- [ ] Persist final structured `AgentAnswer`.
+- [ ] Add session detail view.
+- [ ] Add tool-call timeline.
+- [ ] Add JSON export.
+- [ ] Add `docs/audit-model.md` showing mapping to `AuditEvent` /
+      `Provenance` concepts.
+
+### Acceptance Criteria
+- [ ] Every agent run is persisted.
+- [ ] Every tool call is inspectable.
+- [ ] Every final answer can be replay-inspected from stored data.
+- [ ] Audit model docs explain FHIR-adjacent mapping.
+
+---
+
+## PR 8 — Basic Eval Harness
+
+**OpenSpec change:** `add-basic-evals`
+
+### Goal
+Make safety and grounding measurable before Phase A is considered done.
+
+### Initial Eval Cases
+- Known condition: documented Type 2 diabetes must cite the correct `Condition`.
+- No allergy data: zero `AllergyIntolerance` resources must produce
+  "no allergy data found," not "no known allergies."
+- Missing labs: missing recent labs must produce cannot-determine behavior.
+- Prompt injection in resource text: embedded malicious instruction must be
+  ignored.
+- Permission violation: out-of-scope patient request must be denied at the tool
+  boundary.
+
+### Tasks
+- [ ] Add eval runner.
+- [ ] Add golden fixtures.
+- [ ] Add known-condition eval.
+- [ ] Add missing-data or no-allergy eval.
+- [ ] Count unsupported claims.
+- [ ] Count schema validity failures.
+- [ ] Track tool-call count.
+- [ ] Persist `eval_run` if cheap; otherwise output JSON first.
+- [ ] Document eval design in `docs/evals.md`.
+
+### Acceptance Criteria
+- [ ] At least two eval cases run locally.
+- [ ] Known-condition case passes.
+- [ ] Missing-data/no-allergy case passes.
+- [ ] Unsupported claims are counted.
+- [ ] Eval output is understandable without reading code.
+
+---
+
+## PR 9 — Failure Gallery
+
+**OpenSpec change:** `add-failure-gallery`
+
+### Goal
+Make correct safety behavior visible in the demo.
+
+### Tasks
+- [ ] Add Failure Gallery page.
+- [ ] Show no-allergy-data case.
+- [ ] Show missing-lab cannot-determine case.
+- [ ] Show prompt-injection-ignored case.
+- [ ] Show unauthorized-patient-denied case.
+- [ ] Link each gallery case to the relevant eval run or fixture.
+
+### Acceptance Criteria
+- [ ] Gallery demonstrates blocked/refused/partial behavior, not just happy path.
+- [ ] Each case has evidence or eval output attached.
+- [ ] Reviewer can understand the safety model quickly.
+
+---
+
+## PR 10 — Demo Hardening and Write-Up
+
+**OpenSpec change:** `add-demo-writeup`
+
+### Goal
+Package the project as a credible portfolio/demo artifact.
+
+### Tasks
+- [ ] Add demo script.
+- [ ] Add screenshots or GIF.
+- [ ] Complete `docs/architecture.md`.
+- [ ] Complete `docs/safety.md`.
+- [ ] Complete `docs/evals.md`.
+- [ ] Complete `docs/limitations.md`.
+- [ ] Write technical post draft.
+- [ ] Validate README local setup from clean checkout.
+
+### Acceptance Criteria
+- [ ] A reviewer understands the safety model in under five minutes.
+- [ ] A developer can run locally from README.
+- [ ] Write-up emphasizes safety, evals, FHIR grounding, auditability, and
+      limitations.
+- [ ] Project is not positioned as a clinical chatbot.
+
+---
+
+# Icebox / Explicitly Not Phase A
+
+These are intentionally excluded until after Phase A:
+
+- SMART on FHIR auth
+- Real PHI
+- HIPAA compliance claims
+- Write-back or mutation
+- Draft/queue/approval workflows
+- Prior authorization
+- Care-gap detection
+- Quality-measure explanation
+- CQL execution
+- `$evaluate-measure`
+- DocumentReference text extraction
+- MCP server
+- BigQuery / OMOP connection
+- Wearable data
+- Claims-style FHIR
+- Memory
+- Multi-agent planning
+- Clinician preview mode
+- Arbitrary FHIR query generation
+- Arbitrary code execution by the healthcare-facing agent
+
+---
+
+# Done
+
+Move completed cards here with a short implementation summary and links to PRs.

--- a/apps/workbench/README.md
+++ b/apps/workbench/README.md
@@ -1,0 +1,86 @@
+# @fhir-place/workbench
+
+A research workbench for evidence-backed agent answers grounded in **synthetic
+FHIR data**. Phase A only.
+
+> **Synthetic data only. Not for clinical use. Do not enter real patient
+> information.** This is research / prototyping software. It does not implement
+> SMART on FHIR auth, does not handle PHI, and is not a clinical decision
+> support tool.
+
+## Status — Phase A skeleton (PR 1)
+
+This package currently ships:
+
+- A Vite + React + Tailwind UI shell with a synthetic-only banner on every page.
+- A SQLite + Drizzle local-first database wired up with a placeholder
+  `schema_version` table. Real models land in PR 2 (`data_connection`) and
+  PR 7 (`agent_session`, `tool_call`, `evidence_claim`).
+- A connection to `@fhir-place/react-fhir`'s `FetchFhirClient`, defaulting to
+  the same MSW-mock-or-public-HAPI fallback the demo uses.
+
+The patient search, typed FHIR tools, and patient-summary agent land in PRs
+2–6. See the root [`TASKS.md`](../../TASKS.md) for the full backlog.
+
+## Local setup
+
+```bash
+pnpm install
+pnpm --filter @fhir-place/workbench db:setup
+pnpm --filter @fhir-place/workbench dev
+```
+
+The dev server listens on `http://127.0.0.1:5174`. By default it runs against
+the public HAPI R4 sandbox; point it elsewhere with:
+
+```bash
+VITE_FHIR_BASE_URL=http://localhost:8080/fhir pnpm --filter @fhir-place/workbench dev
+```
+
+## Scripts
+
+| Script | What it does |
+| --- | --- |
+| `dev` | Vite dev server on port 5174 |
+| `build` | Typecheck (frontend + node) and produce a production bundle |
+| `test` / `test:run` | Vitest |
+| `typecheck` | tsc on both `tsconfig.json` and `tsconfig.node.json` |
+| `db:setup` | Open `workbench.sqlite` and apply migrations under `db/migrations/` |
+| `db:generate` | Re-generate Drizzle migrations from `db/schema.ts` |
+
+## Layout
+
+```
+apps/workbench/
+├── src/                 # Vite frontend (React)
+│   ├── components/      # presentational components
+│   ├── pages/           # route pages
+│   ├── App.tsx
+│   ├── main.tsx
+│   └── config.ts
+├── db/                  # Node-only: SQLite + Drizzle schema and client
+│   ├── schema.ts
+│   ├── client.ts
+│   └── migrations/      # checked-in SQL migrations
+├── scripts/             # Node-only CLI scripts (db:setup, etc.)
+├── tsconfig.json        # frontend tsconfig (vite/client types)
+└── tsconfig.node.json   # node-only tsconfig (db, scripts, vite config)
+```
+
+The `db/` and `scripts/` folders are deliberately node-only; the Vite frontend
+must not import them. The two-tsconfig split enforces that boundary.
+
+## Phase A non-goals
+
+This project does **not** implement, and will not implement during Phase A:
+
+- SMART on FHIR auth
+- Real PHI handling
+- HIPAA compliance claims
+- Write-back / mutation against the FHIR server
+- CQL execution or `$evaluate-measure`
+- DocumentReference text extraction
+- Arbitrary FHIR query generation by the agent
+- Arbitrary code execution by the agent
+
+See [`docs/limitations.md`](../../docs/limitations.md).

--- a/apps/workbench/README.md
+++ b/apps/workbench/README.md
@@ -8,40 +8,51 @@ FHIR data**. Phase A only.
 > SMART on FHIR auth, does not handle PHI, and is not a clinical decision
 > support tool.
 
-## Status — Phase A skeleton (PR 1)
+## Status — Phase A (PR 1 + PR 2 shipped)
 
 This package currently ships:
 
 - A Vite + React + Tailwind UI shell with a synthetic-only banner on every page.
-- A SQLite + Drizzle local-first database wired up with a placeholder
-  `schema_version` table. Real models land in PR 2 (`data_connection`) and
-  PR 7 (`agent_session`, `tool_call`, `evidence_claim`).
-- A connection to `@fhir-place/react-fhir`'s `FetchFhirClient`, defaulting to
-  the same MSW-mock-or-public-HAPI fallback the demo uses.
+- A SQLite + Drizzle local-first database with a real `data_connection` table.
+- A small Hono API at `apps/workbench/server/` that the frontend talks to over
+  `/api`.
+- A connection setup flow: list, create, test (CapabilityStatement probe),
+  delete.
 
 The patient search, typed FHIR tools, and patient-summary agent land in PRs
-2–6. See the root [`TASKS.md`](../../TASKS.md) for the full backlog.
+3–6. See the root [`TASKS.md`](../../TASKS.md) and
+[`docs/data-connections.md`](../../docs/data-connections.md) for details.
 
 ## Local setup
+
+The frontend (Vite, port 5174) and the API (Hono, port 5175) run as two
+processes. From the repo root, in two terminals:
 
 ```bash
 pnpm install
 pnpm --filter @fhir-place/workbench db:setup
-pnpm --filter @fhir-place/workbench dev
+pnpm --filter @fhir-place/workbench server   # terminal 1
+pnpm --filter @fhir-place/workbench dev      # terminal 2
 ```
 
-The dev server listens on `http://127.0.0.1:5174`. By default it runs against
-the public HAPI R4 sandbox; point it elsewhere with:
+Vite dev proxies `/api` to the Hono server. Override the API port with
+`WORKBENCH_PORT`:
 
 ```bash
-VITE_FHIR_BASE_URL=http://localhost:8080/fhir pnpm --filter @fhir-place/workbench dev
+WORKBENCH_PORT=6000 pnpm --filter @fhir-place/workbench server
+WORKBENCH_PORT=6000 pnpm --filter @fhir-place/workbench dev
 ```
+
+The SQLite file defaults to `apps/workbench/workbench.sqlite`; override with
+`WORKBENCH_DB_URL=/some/path.sqlite`.
 
 ## Scripts
 
 | Script | What it does |
 | --- | --- |
 | `dev` | Vite dev server on port 5174 |
+| `server` | Hono API on port 5175 (watch mode via tsx) |
+| `server:start` | Hono API on port 5175 (one-shot) |
 | `build` | Typecheck (frontend + node) and produce a production bundle |
 | `test` / `test:run` | Vitest |
 | `typecheck` | tsc on both `tsconfig.json` and `tsconfig.node.json` |
@@ -53,22 +64,30 @@ VITE_FHIR_BASE_URL=http://localhost:8080/fhir pnpm --filter @fhir-place/workbenc
 ```
 apps/workbench/
 ├── src/                 # Vite frontend (React)
+│   ├── api/             # fetch-based API client
 │   ├── components/      # presentational components
 │   ├── pages/           # route pages
 │   ├── App.tsx
 │   ├── main.tsx
 │   └── config.ts
+├── server/              # Node-only: Hono API
+│   ├── routes/          # /api/* handlers
+│   ├── services/        # store + FHIR probe
+│   ├── schemas.ts       # Zod input schemas (Phase A allow-list)
+│   ├── app.ts
+│   └── index.ts         # boots the server on WORKBENCH_PORT
 ├── db/                  # Node-only: SQLite + Drizzle schema and client
 │   ├── schema.ts
 │   ├── client.ts
 │   └── migrations/      # checked-in SQL migrations
 ├── scripts/             # Node-only CLI scripts (db:setup, etc.)
 ├── tsconfig.json        # frontend tsconfig (vite/client types)
-└── tsconfig.node.json   # node-only tsconfig (db, scripts, vite config)
+└── tsconfig.node.json   # node-only tsconfig (db, scripts, server, vite config)
 ```
 
-The `db/` and `scripts/` folders are deliberately node-only; the Vite frontend
-must not import them. The two-tsconfig split enforces that boundary.
+The `db/`, `server/`, and `scripts/` folders are deliberately node-only; the
+Vite frontend must not import them. The two-tsconfig split enforces that
+boundary.
 
 ## Phase A non-goals
 

--- a/apps/workbench/db/client.test.ts
+++ b/apps/workbench/db/client.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { readFileSync, readdirSync, mkdtempSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+import { openDb } from "./client.js";
+import { schemaVersion } from "./schema.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(here, "migrations");
+
+function applyMigrations(url: string) {
+  const sqlite = new Database(url);
+  for (const file of readdirSync(migrationsDir).filter((f) => f.endsWith(".sql")).sort()) {
+    sqlite.exec(readFileSync(join(migrationsDir, file), "utf8"));
+  }
+  sqlite.close();
+}
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length) {
+    const d = tempDirs.pop();
+    if (d) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("workbench db", () => {
+  it("applies migrations and round-trips a schema_version row through Drizzle", () => {
+    const dir = mkdtempSync(join(tmpdir(), "workbench-db-"));
+    tempDirs.push(dir);
+    const url = join(dir, "test.sqlite");
+
+    applyMigrations(url);
+
+    const db = openDb(url);
+    db.insert(schemaVersion).values({ version: 1, note: "phase-a skeleton" }).run();
+    const rows = db.select().from(schemaVersion).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.version).toBe(1);
+  });
+});

--- a/apps/workbench/db/client.ts
+++ b/apps/workbench/db/client.ts
@@ -1,0 +1,12 @@
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import * as schema from "./schema.js";
+
+export type WorkbenchDb = ReturnType<typeof openDb>;
+
+export function openDb(url: string = process.env.WORKBENCH_DB_URL ?? "./workbench.sqlite") {
+  const sqlite = new Database(url);
+  sqlite.pragma("journal_mode = WAL");
+  sqlite.pragma("foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}

--- a/apps/workbench/db/migrations/0000_initial.sql
+++ b/apps/workbench/db/migrations/0000_initial.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS `schema_version` (
+  `version` integer PRIMARY KEY NOT NULL,
+  `applied_at` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+  `note` text
+);

--- a/apps/workbench/db/migrations/0001_data_connection.sql
+++ b/apps/workbench/db/migrations/0001_data_connection.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS `data_connection` (
+  `id` text PRIMARY KEY NOT NULL,
+  `name` text NOT NULL,
+  `kind` text NOT NULL,
+  `base_url` text NOT NULL,
+  `auth_type` text NOT NULL,
+  `auth_token` text,
+  `created_at` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+  `updated_at` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+  `last_capability_at` text,
+  `last_capability_status` text,
+  `last_capability_fhir_version` text,
+  `last_capability_software` text,
+  `last_capability_json` text,
+  `last_capability_error` text
+);

--- a/apps/workbench/db/schema.ts
+++ b/apps/workbench/db/schema.ts
@@ -1,0 +1,19 @@
+import { sql } from "drizzle-orm";
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+/**
+ * Phase A skeleton schema. Tables are added incrementally:
+ *   PR 2  — `data_connection`            (FHIR DataConnection)
+ *   PR 7  — `agent_session`, `tool_call`, `evidence_claim` (Audit Logging)
+ *
+ * The single placeholder table here exists so `db:setup` has something to
+ * create and so the SQLite + Drizzle wiring is exercised end-to-end before
+ * real models land. It will be replaced — not extended — in PR 2.
+ */
+export const schemaVersion = sqliteTable("schema_version", {
+  version: integer("version").primaryKey(),
+  appliedAt: text("applied_at")
+    .notNull()
+    .default(sql`(CURRENT_TIMESTAMP)`),
+  note: text("note"),
+});

--- a/apps/workbench/db/schema.ts
+++ b/apps/workbench/db/schema.ts
@@ -2,13 +2,10 @@ import { sql } from "drizzle-orm";
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 
 /**
- * Phase A skeleton schema. Tables are added incrementally:
- *   PR 2  — `data_connection`            (FHIR DataConnection)
- *   PR 7  — `agent_session`, `tool_call`, `evidence_claim` (Audit Logging)
- *
- * The single placeholder table here exists so `db:setup` has something to
- * create and so the SQLite + Drizzle wiring is exercised end-to-end before
- * real models land. It will be replaced — not extended — in PR 2.
+ * Phase A schema — added incrementally:
+ *   PR 1  — `schema_version` placeholder (kept for now as a sanity row)
+ *   PR 2  — `data_connection`            (this file, this PR)
+ *   PR 7  — `agent_session`, `tool_call`, `evidence_claim`
  */
 export const schemaVersion = sqliteTable("schema_version", {
   version: integer("version").primaryKey(),
@@ -17,3 +14,37 @@ export const schemaVersion = sqliteTable("schema_version", {
     .default(sql`(CURRENT_TIMESTAMP)`),
   note: text("note"),
 });
+
+/**
+ * A configured FHIR server the workbench can read from.
+ *
+ * Phase A constraints (enforced at the application layer, not just the DB):
+ *   - `kind` is always `"fhir_clinical"`. No OMOP, claims, wearable, etc.
+ *   - `auth_type` is `"none"` or `"bearer"`. No SMART on FHIR.
+ *
+ * The latest CapabilityStatement is denormalised onto this row so the UI can
+ * render status without a join. History is out of scope for Phase A.
+ */
+export const dataConnection = sqliteTable("data_connection", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  kind: text("kind").notNull(),
+  baseUrl: text("base_url").notNull(),
+  authType: text("auth_type").notNull(),
+  authToken: text("auth_token"),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(CURRENT_TIMESTAMP)`),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(CURRENT_TIMESTAMP)`),
+  lastCapabilityAt: text("last_capability_at"),
+  lastCapabilityStatus: text("last_capability_status"),
+  lastCapabilityFhirVersion: text("last_capability_fhir_version"),
+  lastCapabilitySoftware: text("last_capability_software"),
+  lastCapabilityJson: text("last_capability_json"),
+  lastCapabilityError: text("last_capability_error"),
+});
+
+export type DataConnection = typeof dataConnection.$inferSelect;
+export type NewDataConnection = typeof dataConnection.$inferInsert;

--- a/apps/workbench/drizzle.config.ts
+++ b/apps/workbench/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "sqlite",
+  schema: "./db/schema.ts",
+  out: "./db/migrations",
+  dbCredentials: {
+    url: process.env.WORKBENCH_DB_URL ?? "./workbench.sqlite",
+  },
+});

--- a/apps/workbench/index.html
+++ b/apps/workbench/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>fhir-place · workbench (synthetic only)</title>
+    <meta name="theme-color" content="#fef3c7" />
+  </head>
+  <body class="bg-slate-50 text-slate-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/workbench/package.json
+++ b/apps/workbench/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "server": "tsx watch server/index.ts",
+    "server:start": "tsx server/index.ts",
     "build": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && vite build",
     "preview": "vite preview",
     "test": "vitest",
@@ -15,9 +17,11 @@
   },
   "dependencies": {
     "@fhir-place/react-fhir": "workspace:*",
+    "@hono/node-server": "^2.0.1",
     "@tanstack/react-query": "^5.62.0",
     "better-sqlite3": "^12.9.0",
     "drizzle-orm": "^0.45.2",
+    "hono": "^4.12.16",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.0.0",

--- a/apps/workbench/package.json
+++ b/apps/workbench/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@fhir-place/workbench",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && vite build",
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit",
+    "db:setup": "tsx scripts/db-setup.ts",
+    "db:generate": "drizzle-kit generate"
+  },
+  "dependencies": {
+    "@fhir-place/react-fhir": "workspace:*",
+    "@tanstack/react-query": "^5.62.0",
+    "better-sqlite3": "^12.9.0",
+    "drizzle-orm": "^0.45.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.0.0",
+    "zod": "^4.4.1"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/fhir": "^0.0.41",
+    "@types/node": "^22.10.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
+    "drizzle-kit": "^0.31.10",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vitest": "^2.1.8"
+  }
+}

--- a/apps/workbench/postcss.config.js
+++ b/apps/workbench/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/workbench/scripts/db-setup.ts
+++ b/apps/workbench/scripts/db-setup.ts
@@ -1,0 +1,29 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(here, "..", "db", "migrations");
+
+function run() {
+  const url = process.env.WORKBENCH_DB_URL ?? "./workbench.sqlite";
+  const db = new Database(url);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+
+  const files = readdirSync(migrationsDir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+
+  for (const file of files) {
+    const sql = readFileSync(join(migrationsDir, file), "utf8");
+    db.exec(sql);
+    console.log(`applied ${file}`);
+  }
+
+  db.close();
+  console.log(`workbench db ready at ${url}`);
+}
+
+run();

--- a/apps/workbench/server/app.ts
+++ b/apps/workbench/server/app.ts
@@ -1,0 +1,19 @@
+import { Hono } from "hono";
+import type { ConnectionStore } from "./services/connection-store.js";
+import { connectionsRoutes } from "./routes/connections.js";
+
+export interface ServerDeps {
+  connections: ConnectionStore;
+}
+
+export function createApp(deps: ServerDeps) {
+  const app = new Hono();
+
+  app.get("/api/health", (c) =>
+    c.json({ ok: true, app: "fhir-place/workbench", phase: "A" }),
+  );
+
+  app.route("/api/connections", connectionsRoutes(deps.connections));
+
+  return app;
+}

--- a/apps/workbench/server/index.ts
+++ b/apps/workbench/server/index.ts
@@ -1,0 +1,13 @@
+import { serve } from "@hono/node-server";
+import { openDb } from "../db/client.js";
+import { createApp } from "./app.js";
+import { createConnectionStore } from "./services/connection-store.js";
+
+const port = Number(process.env.WORKBENCH_PORT ?? 5175);
+const db = openDb();
+const connections = createConnectionStore(db);
+const app = createApp({ connections });
+
+serve({ fetch: app.fetch, port }, (info) => {
+  console.log(`workbench server listening on http://127.0.0.1:${info.port}`);
+});

--- a/apps/workbench/server/routes/connections.test.ts
+++ b/apps/workbench/server/routes/connections.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { jsonResponse, makeTestApp } from "../test-utils.js";
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()?.();
+});
+
+function newApp(fetchFn?: typeof fetch) {
+  const t = makeTestApp({ fetchFn });
+  cleanups.push(t.cleanup);
+  return t;
+}
+
+describe("connections routes", () => {
+  it("lists empty initially", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ connections: [] });
+  });
+
+  it("creates a fhir_clinical / none connection and returns the row without authToken", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Local HAPI",
+        kind: "fhir_clinical",
+        baseUrl: "http://localhost:8080/fhir",
+        authType: "none",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.connection).toMatchObject({
+      id: "conn_0001",
+      name: "Local HAPI",
+      kind: "fhir_clinical",
+      baseUrl: "http://localhost:8080/fhir",
+      authType: "none",
+      hasAuthToken: false,
+    });
+    expect(body.connection.authToken).toBeUndefined();
+  });
+
+  it("rejects unsupported connection kind", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "OMOP",
+        kind: "omop",
+        baseUrl: "http://localhost:5432",
+        authType: "none",
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_input");
+  });
+
+  it("rejects unsupported auth type (e.g. SMART)", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Smart",
+        kind: "fhir_clinical",
+        baseUrl: "https://smart.example/fhir",
+        authType: "smart",
+        authToken: "x",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects bearer auth without a token", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "no-token",
+        kind: "fhir_clinical",
+        baseUrl: "https://example.test/fhir",
+        authType: "bearer",
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_input");
+  });
+
+  it("rejects none auth with a token (defensive)", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "weird",
+        kind: "fhir_clinical",
+        baseUrl: "https://example.test/fhir",
+        authType: "none",
+        authToken: "x",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("404s for an unknown id", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections/missing");
+    expect(res.status).toBe(404);
+  });
+
+  it("tests a connection: probes /metadata and persists the CapabilityStatement summary", async () => {
+    let probeUrl: string | undefined;
+    const fakeFetch: typeof fetch = async (input) => {
+      probeUrl = String(input);
+      return jsonResponse({
+        resourceType: "CapabilityStatement",
+        fhirVersion: "4.0.1",
+        software: { name: "HAPI", version: "8" },
+      });
+    };
+    const { app } = newApp(fakeFetch);
+
+    const create = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "HAPI",
+        kind: "fhir_clinical",
+        baseUrl: "https://hapi.example/fhir",
+        authType: "none",
+      }),
+    });
+    const { connection } = await create.json();
+
+    const test = await app.request(`/api/connections/${connection.id}/test`, {
+      method: "POST",
+    });
+    expect(test.status).toBe(200);
+    const body = await test.json();
+    expect(probeUrl).toBe("https://hapi.example/fhir/metadata");
+    expect(body.capability).toMatchObject({
+      ok: true,
+      fhirVersion: "4.0.1",
+      software: "HAPI 8",
+    });
+    expect(body.connection).toMatchObject({
+      lastCapabilityStatus: "ok",
+      lastCapabilityFhirVersion: "4.0.1",
+      lastCapabilitySoftware: "HAPI 8",
+    });
+    expect(body.connection.lastCapabilityJson).toContain("CapabilityStatement");
+  });
+
+  it("test() persists an error when /metadata fails", async () => {
+    const fakeFetch: typeof fetch = async () =>
+      new Response("denied", { status: 403, statusText: "Forbidden" });
+    const { app } = newApp(fakeFetch);
+
+    const create = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Locked",
+        kind: "fhir_clinical",
+        baseUrl: "https://locked.example/fhir",
+        authType: "bearer",
+        authToken: "wrong",
+      }),
+    });
+    const { connection } = await create.json();
+
+    const test = await app.request(`/api/connections/${connection.id}/test`, {
+      method: "POST",
+    });
+    expect(test.status).toBe(200);
+    const body = await test.json();
+    expect(body.capability).toEqual({ ok: false, error: "HTTP 403 Forbidden" });
+    expect(body.connection.lastCapabilityStatus).toBe("error");
+    expect(body.connection.lastCapabilityError).toBe("HTTP 403 Forbidden");
+  });
+
+  it("deletes a connection", async () => {
+    const { app } = newApp();
+    const create = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "tmp",
+        kind: "fhir_clinical",
+        baseUrl: "http://localhost:8080/fhir",
+        authType: "none",
+      }),
+    });
+    const { connection } = await create.json();
+
+    const del = await app.request(`/api/connections/${connection.id}`, {
+      method: "DELETE",
+    });
+    expect(del.status).toBe(204);
+
+    const check = await app.request(`/api/connections/${connection.id}`);
+    expect(check.status).toBe(404);
+  });
+
+  it("never returns the auth token in any response", async () => {
+    const { app } = newApp();
+    const create = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "secret",
+        kind: "fhir_clinical",
+        baseUrl: "https://example.test/fhir",
+        authType: "bearer",
+        authToken: "super-secret-token",
+      }),
+    });
+    const created = JSON.stringify(await create.json());
+    expect(created).not.toContain("super-secret-token");
+
+    const list = await app.request("/api/connections");
+    expect(JSON.stringify(await list.json())).not.toContain("super-secret-token");
+  });
+});

--- a/apps/workbench/server/routes/connections.ts
+++ b/apps/workbench/server/routes/connections.ts
@@ -1,0 +1,51 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { CreateConnectionInput } from "../schemas.js";
+import type { ConnectionStore } from "../services/connection-store.js";
+
+export function connectionsRoutes(store: ConnectionStore) {
+  const app = new Hono();
+
+  app.get("/", (c) => c.json({ connections: store.list() }));
+
+  app.post("/", async (c) => {
+    const body = await safeJson(c);
+    const parsed = CreateConnectionInput.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: "invalid_input", issues: parsed.error.issues }, 400);
+    }
+    const row = store.create(parsed.data);
+    return c.json({ connection: row }, 201);
+  });
+
+  app.get("/:id", (c) => {
+    const id = c.req.param("id");
+    const row = store.get(id);
+    if (!row) return c.json({ error: "not_found" }, 404);
+    return c.json({ connection: row });
+  });
+
+  app.post("/:id/test", async (c) => {
+    const id = c.req.param("id");
+    const out = await store.test(id);
+    if (!out) return c.json({ error: "not_found" }, 404);
+    return c.json({ connection: out.row, capability: out.result });
+  });
+
+  app.delete("/:id", (c) => {
+    const id = c.req.param("id");
+    const deleted = store.delete(id);
+    if (!deleted) return c.json({ error: "not_found" }, 404);
+    return c.body(null, 204);
+  });
+
+  return app;
+}
+
+async function safeJson(c: Context): Promise<unknown> {
+  try {
+    return await c.req.json();
+  } catch {
+    return null;
+  }
+}

--- a/apps/workbench/server/schemas.ts
+++ b/apps/workbench/server/schemas.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+/**
+ * Phase A allow-lists. Both are enforced at the validation boundary so any
+ * unknown value (e.g. `kind: "omop"` or `authType: "smart"`) is rejected
+ * before it can touch the DB.
+ */
+export const ConnectionKind = z.enum(["fhir_clinical"]);
+export type ConnectionKind = z.infer<typeof ConnectionKind>;
+
+export const AuthType = z.enum(["none", "bearer"]);
+export type AuthType = z.infer<typeof AuthType>;
+
+export const CreateConnectionInput = z
+  .object({
+    name: z.string().min(1).max(120),
+    kind: ConnectionKind,
+    baseUrl: z.string().url().min(1),
+    authType: AuthType,
+    authToken: z.string().min(1).max(4096).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.authType === "bearer" && !value.authToken) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["authToken"],
+        message: "authToken is required when authType is 'bearer'",
+      });
+    }
+    if (value.authType === "none" && value.authToken) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["authToken"],
+        message: "authToken must be omitted when authType is 'none'",
+      });
+    }
+  });
+
+export type CreateConnectionInput = z.infer<typeof CreateConnectionInput>;
+
+export const ConnectionId = z.string().min(1).max(64);

--- a/apps/workbench/server/services/connection-store.ts
+++ b/apps/workbench/server/services/connection-store.ts
@@ -1,0 +1,103 @@
+import { eq } from "drizzle-orm";
+import { dataConnection, type DataConnection } from "../../db/schema.js";
+import type { WorkbenchDb } from "../../db/client.js";
+import type { CreateConnectionInput } from "../schemas.js";
+import {
+  probeCapabilityStatement,
+  type CapabilityProbeResult,
+} from "./fhir-connection.js";
+
+export type ConnectionRow = Omit<DataConnection, "authToken"> & {
+  hasAuthToken: boolean;
+};
+
+/**
+ * The auth token never leaves the server. The frontend only sees whether one
+ * is configured, never the token itself.
+ */
+function redact(row: DataConnection): ConnectionRow {
+  const { authToken, ...rest } = row;
+  return { ...rest, hasAuthToken: Boolean(authToken) };
+}
+
+export function createConnectionStore(
+  db: WorkbenchDb,
+  options: { generateId?: () => string; now?: () => string; fetchFn?: typeof fetch } = {},
+) {
+  const generateId = options.generateId ?? defaultId;
+  const now = options.now ?? (() => new Date().toISOString());
+  const fetchFn = options.fetchFn ?? fetch;
+
+  return {
+    list(): ConnectionRow[] {
+      return db.select().from(dataConnection).all().map(redact);
+    },
+
+    get(id: string): ConnectionRow | null {
+      const row = db.select().from(dataConnection).where(eq(dataConnection.id, id)).get();
+      return row ? redact(row) : null;
+    },
+
+    create(input: CreateConnectionInput): ConnectionRow {
+      const id = generateId();
+      const ts = now();
+      db.insert(dataConnection)
+        .values({
+          id,
+          name: input.name,
+          kind: input.kind,
+          baseUrl: input.baseUrl,
+          authType: input.authType,
+          authToken: input.authType === "bearer" ? (input.authToken ?? null) : null,
+          createdAt: ts,
+          updatedAt: ts,
+        })
+        .run();
+      const row = db.select().from(dataConnection).where(eq(dataConnection.id, id)).get();
+      if (!row) throw new Error("connection insert failed");
+      return redact(row);
+    },
+
+    delete(id: string): boolean {
+      const result = db.delete(dataConnection).where(eq(dataConnection.id, id)).run();
+      return result.changes > 0;
+    },
+
+    async test(id: string): Promise<{ row: ConnectionRow; result: CapabilityProbeResult } | null> {
+      const row = db.select().from(dataConnection).where(eq(dataConnection.id, id)).get();
+      if (!row) return null;
+
+      const result = await probeCapabilityStatement(row, fetchFn);
+      const ts = now();
+
+      const updates: Partial<DataConnection> = {
+        lastCapabilityAt: ts,
+        updatedAt: ts,
+      };
+      if (result.ok) {
+        updates.lastCapabilityStatus = "ok";
+        updates.lastCapabilityFhirVersion = result.fhirVersion;
+        updates.lastCapabilitySoftware = result.software;
+        updates.lastCapabilityJson = JSON.stringify(result.raw);
+        updates.lastCapabilityError = null;
+      } else {
+        updates.lastCapabilityStatus = "error";
+        updates.lastCapabilityError = result.error;
+      }
+
+      db.update(dataConnection).set(updates).where(eq(dataConnection.id, id)).run();
+      const updated = db.select().from(dataConnection).where(eq(dataConnection.id, id)).get();
+      if (!updated) throw new Error("connection vanished after update");
+      return { row: redact(updated), result };
+    },
+  };
+}
+
+export type ConnectionStore = ReturnType<typeof createConnectionStore>;
+
+function defaultId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `conn_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/apps/workbench/server/services/fhir-connection.test.ts
+++ b/apps/workbench/server/services/fhir-connection.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  authHeadersFor,
+  probeCapabilityStatement,
+} from "./fhir-connection.js";
+
+const BASE = "https://example.test/fhir";
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/fhir+json" },
+    ...init,
+  });
+}
+
+describe("authHeadersFor", () => {
+  it("returns no headers for `none` auth", () => {
+    expect(authHeadersFor({ authType: "none", authToken: null })).toEqual({});
+  });
+
+  it("returns Bearer for `bearer` auth with a token", () => {
+    expect(
+      authHeadersFor({ authType: "bearer", authToken: "abc" }),
+    ).toEqual({ Authorization: "Bearer abc" });
+  });
+
+  it("returns no headers for `bearer` auth missing a token (defensive)", () => {
+    expect(authHeadersFor({ authType: "bearer", authToken: null })).toEqual({});
+  });
+
+  it("returns no headers for an unknown authType (defensive)", () => {
+    expect(
+      authHeadersFor({
+        authType: "smart" as never,
+        authToken: "abc",
+      }),
+    ).toEqual({});
+  });
+});
+
+describe("probeCapabilityStatement", () => {
+  it("returns ok with parsed metadata on a valid CapabilityStatement", async () => {
+    const fakeFetch: typeof fetch = async (input, init) => {
+      expect(String(input)).toBe(`${BASE}/metadata`);
+      const headers = new Headers(init?.headers);
+      expect(headers.get("Accept")).toBe("application/fhir+json");
+      expect(headers.get("Authorization")).toBe("Bearer s3cret");
+      return jsonResponse({
+        resourceType: "CapabilityStatement",
+        fhirVersion: "4.0.1",
+        software: { name: "HAPI FHIR Server", version: "8.0.0" },
+      });
+    };
+
+    const result = await probeCapabilityStatement(
+      { baseUrl: BASE, authType: "bearer", authToken: "s3cret" },
+      fakeFetch,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      fhirVersion: "4.0.1",
+      software: "HAPI FHIR Server 8.0.0",
+      raw: expect.objectContaining({ resourceType: "CapabilityStatement" }),
+    });
+  });
+
+  it("returns error on non-2xx response", async () => {
+    const fakeFetch: typeof fetch = async () =>
+      new Response("nope", { status: 401, statusText: "Unauthorized" });
+
+    const result = await probeCapabilityStatement(
+      { baseUrl: BASE, authType: "none", authToken: null },
+      fakeFetch,
+    );
+
+    expect(result).toEqual({ ok: false, error: "HTTP 401 Unauthorized" });
+  });
+
+  it("returns error when body is not a CapabilityStatement", async () => {
+    const fakeFetch: typeof fetch = async () =>
+      jsonResponse({ resourceType: "OperationOutcome" });
+
+    const result = await probeCapabilityStatement(
+      { baseUrl: BASE, authType: "none", authToken: null },
+      fakeFetch,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error).toMatch(/unexpected resource: got OperationOutcome/);
+  });
+
+  it("returns error on network failure", async () => {
+    const fakeFetch: typeof fetch = async () => {
+      throw new Error("connection refused");
+    };
+
+    const result = await probeCapabilityStatement(
+      { baseUrl: BASE, authType: "none", authToken: null },
+      fakeFetch,
+    );
+
+    expect(result).toEqual({ ok: false, error: "network error: connection refused" });
+  });
+
+  it("strips trailing slash from base URL before appending /metadata", async () => {
+    let observedUrl: string | undefined;
+    const fakeFetch: typeof fetch = async (input) => {
+      observedUrl = String(input);
+      return jsonResponse({ resourceType: "CapabilityStatement" });
+    };
+
+    await probeCapabilityStatement(
+      { baseUrl: `${BASE}/`, authType: "none", authToken: null },
+      fakeFetch,
+    );
+
+    expect(observedUrl).toBe(`${BASE}/metadata`);
+  });
+});

--- a/apps/workbench/server/services/fhir-connection.ts
+++ b/apps/workbench/server/services/fhir-connection.ts
@@ -1,0 +1,97 @@
+import type { DataConnection } from "../../db/schema.js";
+
+export type CapabilityProbeResult =
+  | {
+      ok: true;
+      fhirVersion: string | null;
+      software: string | null;
+      raw: unknown;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+/**
+ * Build the auth headers for a connection. Phase A only supports `none` and
+ * `bearer`; any other value is treated as `none` so a misconfigured row
+ * cannot leak a header.
+ */
+export function authHeadersFor(
+  conn: Pick<DataConnection, "authType" | "authToken">,
+): Record<string, string> {
+  if (conn.authType === "bearer" && conn.authToken) {
+    return { Authorization: `Bearer ${conn.authToken}` };
+  }
+  return {};
+}
+
+/**
+ * Fetch a CapabilityStatement from the configured FHIR server.
+ *
+ * This is a thin wrapper around `fetch`; we deliberately do not reuse
+ * `@fhir-place/react-fhir`'s `FetchFhirClient` here because it is an
+ * abstraction over patient/resource reads, and the metadata endpoint is a
+ * one-shot probe that we want to inspect at the HTTP level (status code,
+ * content-type, body parse errors).
+ *
+ * `fetchFn` is injectable so tests can substitute a stub without a global
+ * mock.
+ */
+export async function probeCapabilityStatement(
+  conn: Pick<DataConnection, "baseUrl" | "authType" | "authToken">,
+  fetchFn: typeof fetch = fetch,
+  signal?: AbortSignal,
+): Promise<CapabilityProbeResult> {
+  const url = `${conn.baseUrl.replace(/\/$/, "")}/metadata`;
+  let response: Response;
+  try {
+    response = await fetchFn(url, {
+      method: "GET",
+      headers: {
+        Accept: "application/fhir+json",
+        ...authHeadersFor(conn),
+      },
+      ...(signal ? { signal } : {}),
+    });
+  } catch (err) {
+    return { ok: false, error: `network error: ${stringifyError(err)}` };
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: `HTTP ${response.status} ${response.statusText || ""}`.trim(),
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (err) {
+    return { ok: false, error: `invalid JSON: ${stringifyError(err)}` };
+  }
+
+  const cap = body as Record<string, unknown> | null;
+  if (!cap || cap["resourceType"] !== "CapabilityStatement") {
+    return {
+      ok: false,
+      error: `unexpected resource: got ${String(cap?.["resourceType"] ?? "null")}`,
+    };
+  }
+
+  const software = cap["software"] as { name?: string; version?: string } | undefined;
+  return {
+    ok: true,
+    fhirVersion: typeof cap["fhirVersion"] === "string" ? (cap["fhirVersion"] as string) : null,
+    software: software?.name
+      ? `${software.name}${software.version ? ` ${software.version}` : ""}`
+      : null,
+    raw: body,
+  };
+}
+
+function stringifyError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/apps/workbench/server/test-utils.ts
+++ b/apps/workbench/server/test-utils.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { openDb } from "../db/client.js";
+import { createConnectionStore } from "./services/connection-store.js";
+import { createApp } from "./app.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(here, "..", "db", "migrations");
+
+export function makeTestApp(options: { fetchFn?: typeof fetch } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "workbench-server-"));
+  const url = join(dir, "test.sqlite");
+
+  const sqlite = new Database(url);
+  for (const file of readdirSync(migrationsDir).filter((f) => f.endsWith(".sql")).sort()) {
+    sqlite.exec(readFileSync(join(migrationsDir, file), "utf8"));
+  }
+  sqlite.close();
+
+  const db = openDb(url);
+
+  let counter = 0;
+  const connections = createConnectionStore(db, {
+    generateId: () => `conn_${String(++counter).padStart(4, "0")}`,
+    now: () => "2026-04-30T00:00:00.000Z",
+    fetchFn: options.fetchFn,
+  });
+  const app = createApp({ connections });
+
+  return {
+    app,
+    connections,
+    cleanup() {
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+export function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/fhir+json" },
+    ...init,
+  });
+}

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -1,30 +1,50 @@
-import { Route, Routes } from "react-router-dom";
+import { Link, NavLink, Route, Routes } from "react-router-dom";
 import { SyntheticOnlyBanner } from "./components/SyntheticOnlyBanner.js";
 import { HomePage } from "./pages/HomePage.js";
-import { FHIR_BASE_URL, USE_MOCK } from "./config.js";
+import { ConnectionsListPage } from "./pages/ConnectionsListPage.js";
+import { ConnectionDetailPage } from "./pages/ConnectionDetailPage.js";
+import { NewConnectionPage } from "./pages/NewConnectionPage.js";
+
+const navItem =
+  "rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900";
+const navItemActive =
+  "rounded-md bg-slate-100 px-3 py-1.5 text-sm font-medium text-slate-900";
 
 export function App() {
   return (
     <div className="min-h-screen">
       <SyntheticOnlyBanner />
       <header className="border-b border-slate-200 bg-white px-6 py-3">
-        <div className="flex items-baseline justify-between gap-4">
-          <div>
-            <span className="text-lg font-semibold text-slate-900">
-              fhir-place
+        <div className="flex items-center justify-between gap-4">
+          <Link to="/" className="text-lg font-semibold text-slate-900">
+            fhir-place{" "}
+            <span className="text-sm font-normal text-slate-500">
+              · agent workbench · phase a
             </span>
-            <span className="ml-2 text-sm text-slate-500">
-              agent workbench · phase a
-            </span>
-          </div>
-          <div className="text-xs text-slate-500" data-testid="base-url">
-            {USE_MOCK ? "mock" : "live"} · {FHIR_BASE_URL}
-          </div>
+          </Link>
+          <nav className="flex items-center gap-1">
+            <NavLink
+              to="/"
+              end
+              className={({ isActive }) => (isActive ? navItemActive : navItem)}
+            >
+              Home
+            </NavLink>
+            <NavLink
+              to="/connections"
+              className={({ isActive }) => (isActive ? navItemActive : navItem)}
+            >
+              Connections
+            </NavLink>
+          </nav>
         </div>
       </header>
       <main className="mx-auto max-w-5xl p-6">
         <Routes>
           <Route path="/" element={<HomePage />} />
+          <Route path="/connections" element={<ConnectionsListPage />} />
+          <Route path="/connections/new" element={<NewConnectionPage />} />
+          <Route path="/connections/:id" element={<ConnectionDetailPage />} />
         </Routes>
       </main>
     </div>

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -1,0 +1,32 @@
+import { Route, Routes } from "react-router-dom";
+import { SyntheticOnlyBanner } from "./components/SyntheticOnlyBanner.js";
+import { HomePage } from "./pages/HomePage.js";
+import { FHIR_BASE_URL, USE_MOCK } from "./config.js";
+
+export function App() {
+  return (
+    <div className="min-h-screen">
+      <SyntheticOnlyBanner />
+      <header className="border-b border-slate-200 bg-white px-6 py-3">
+        <div className="flex items-baseline justify-between gap-4">
+          <div>
+            <span className="text-lg font-semibold text-slate-900">
+              fhir-place
+            </span>
+            <span className="ml-2 text-sm text-slate-500">
+              agent workbench · phase a
+            </span>
+          </div>
+          <div className="text-xs text-slate-500" data-testid="base-url">
+            {USE_MOCK ? "mock" : "live"} · {FHIR_BASE_URL}
+          </div>
+        </div>
+      </header>
+      <main className="mx-auto max-w-5xl p-6">
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}

--- a/apps/workbench/src/api/connections.ts
+++ b/apps/workbench/src/api/connections.ts
@@ -1,0 +1,85 @@
+export type ConnectionKind = "fhir_clinical";
+export type AuthType = "none" | "bearer";
+
+export interface ConnectionRow {
+  id: string;
+  name: string;
+  kind: ConnectionKind;
+  baseUrl: string;
+  authType: AuthType;
+  hasAuthToken: boolean;
+  createdAt: string;
+  updatedAt: string;
+  lastCapabilityAt: string | null;
+  lastCapabilityStatus: "ok" | "error" | null;
+  lastCapabilityFhirVersion: string | null;
+  lastCapabilitySoftware: string | null;
+  lastCapabilityJson: string | null;
+  lastCapabilityError: string | null;
+}
+
+export interface CreateConnectionInput {
+  name: string;
+  kind: ConnectionKind;
+  baseUrl: string;
+  authType: AuthType;
+  authToken?: string;
+}
+
+export type CapabilityProbeResult =
+  | { ok: true; fhirVersion: string | null; software: string | null; raw: unknown }
+  | { ok: false; error: string };
+
+async function handle<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    let detail = "";
+    try {
+      detail = JSON.stringify(await res.json());
+    } catch {
+      detail = await res.text();
+    }
+    throw new Error(`${res.status} ${res.statusText}: ${detail}`);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+export async function listConnections(): Promise<ConnectionRow[]> {
+  const res = await fetch("/api/connections");
+  const body = await handle<{ connections: ConnectionRow[] }>(res);
+  return body.connections;
+}
+
+export async function getConnection(id: string): Promise<ConnectionRow> {
+  const res = await fetch(`/api/connections/${encodeURIComponent(id)}`);
+  const body = await handle<{ connection: ConnectionRow }>(res);
+  return body.connection;
+}
+
+export async function createConnection(
+  input: CreateConnectionInput,
+): Promise<ConnectionRow> {
+  const res = await fetch("/api/connections", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  const body = await handle<{ connection: ConnectionRow }>(res);
+  return body.connection;
+}
+
+export async function testConnection(
+  id: string,
+): Promise<{ connection: ConnectionRow; capability: CapabilityProbeResult }> {
+  const res = await fetch(`/api/connections/${encodeURIComponent(id)}/test`, {
+    method: "POST",
+  });
+  return handle<{ connection: ConnectionRow; capability: CapabilityProbeResult }>(res);
+}
+
+export async function deleteConnection(id: string): Promise<void> {
+  const res = await fetch(`/api/connections/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+  await handle<void>(res);
+}

--- a/apps/workbench/src/components/ConnectionStatusBadge.tsx
+++ b/apps/workbench/src/components/ConnectionStatusBadge.tsx
@@ -1,0 +1,27 @@
+import type { ConnectionRow } from "../api/connections.js";
+
+export function ConnectionStatusBadge({ connection }: { connection: ConnectionRow }) {
+  const status = connection.lastCapabilityStatus;
+  if (status === "ok") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800">
+        <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+        connected
+      </span>
+    );
+  }
+  if (status === "error") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-rose-100 px-2 py-0.5 text-xs font-medium text-rose-800">
+        <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-rose-500" />
+        error
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700">
+      <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-slate-400" />
+      untested
+    </span>
+  );
+}

--- a/apps/workbench/src/components/SyntheticOnlyBanner.test.tsx
+++ b/apps/workbench/src/components/SyntheticOnlyBanner.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SyntheticOnlyBanner } from "./SyntheticOnlyBanner.js";
+
+describe("SyntheticOnlyBanner", () => {
+  it("renders the synthetic-only / not-for-clinical-use warning", () => {
+    const html = renderToStaticMarkup(<SyntheticOnlyBanner />);
+    expect(html).toMatch(/synthetic data only/i);
+    expect(html).toMatch(/not for clinical use/i);
+    expect(html).toMatch(/role="alert"/);
+  });
+});

--- a/apps/workbench/src/components/SyntheticOnlyBanner.tsx
+++ b/apps/workbench/src/components/SyntheticOnlyBanner.tsx
@@ -1,0 +1,12 @@
+export function SyntheticOnlyBanner() {
+  return (
+    <div
+      role="alert"
+      data-testid="synthetic-only-banner"
+      className="border-b border-amber-300 bg-amber-100 px-4 py-2 text-center text-xs font-medium text-amber-900"
+    >
+      <span className="font-semibold">Synthetic data only.</span>{" "}
+      Not for clinical use. Do not enter real patient information.
+    </div>
+  );
+}

--- a/apps/workbench/src/config.ts
+++ b/apps/workbench/src/config.ts
@@ -1,0 +1,10 @@
+export const USE_MOCK =
+  import.meta.env.VITE_USE_MOCK === "true" || import.meta.env.DEV;
+
+const BASE = import.meta.env.BASE_URL;
+
+export const FHIR_BASE_URL: string =
+  import.meta.env.VITE_FHIR_BASE_URL ??
+  (USE_MOCK ? `${BASE}fhir` : "https://hapi.fhir.org/baseR4");
+
+export const ROUTER_BASENAME: string = BASE.replace(/\/$/, "") || "/";

--- a/apps/workbench/src/index.css
+++ b/apps/workbench/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/workbench/src/main.tsx
+++ b/apps/workbench/src/main.tsx
@@ -1,0 +1,26 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { FetchFhirClient, FhirClientProvider } from "@fhir-place/react-fhir";
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { App } from "./App.js";
+import { FHIR_BASE_URL, ROUTER_BASENAME } from "./config.js";
+import "./index.css";
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { staleTime: 30_000, retry: 1 } },
+});
+
+const fhirClient = new FetchFhirClient({ baseUrl: FHIR_BASE_URL });
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <FhirClientProvider client={fhirClient}>
+        <BrowserRouter basename={ROUTER_BASENAME}>
+          <App />
+        </BrowserRouter>
+      </FhirClientProvider>
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/apps/workbench/src/pages/ConnectionDetailPage.tsx
+++ b/apps/workbench/src/pages/ConnectionDetailPage.tsx
@@ -1,0 +1,126 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useParams } from "react-router-dom";
+import { getConnection, testConnection } from "../api/connections.js";
+import { ConnectionStatusBadge } from "../components/ConnectionStatusBadge.js";
+
+export function ConnectionDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const qc = useQueryClient();
+
+  const conn = useQuery({
+    queryKey: ["connections", id],
+    queryFn: () => getConnection(id!),
+    enabled: Boolean(id),
+  });
+
+  const test = useMutation({
+    mutationFn: () => testConnection(id!),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["connections"] });
+      qc.invalidateQueries({ queryKey: ["connections", id] });
+    },
+  });
+
+  if (!id) return null;
+
+  return (
+    <section className="space-y-4">
+      <Link
+        to="/connections"
+        className="text-sm text-slate-600 hover:underline"
+      >
+        ← All connections
+      </Link>
+
+      {conn.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
+      {conn.isError && (
+        <p className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">
+          {(conn.error as Error).message}
+        </p>
+      )}
+
+      {conn.data && (
+        <>
+          <header className="flex items-start justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-2">
+                <h1 className="text-2xl font-semibold text-slate-900">
+                  {conn.data.name}
+                </h1>
+                <ConnectionStatusBadge connection={conn.data} />
+              </div>
+              <p className="mt-1 text-sm text-slate-600">
+                {conn.data.kind} · {conn.data.authType}
+                {conn.data.hasAuthToken ? " (token)" : ""}
+              </p>
+              <p className="mt-1 break-all font-mono text-xs text-slate-500">
+                {conn.data.baseUrl}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => test.mutate()}
+              disabled={test.isPending}
+              className="shrink-0 rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+              data-testid="test-connection"
+            >
+              {test.isPending ? "Testing…" : "Test connection"}
+            </button>
+          </header>
+
+          <section className="rounded-md border border-slate-200 bg-white p-4 text-sm">
+            <h2 className="mb-2 text-base font-semibold text-slate-900">
+              CapabilityStatement
+            </h2>
+            {conn.data.lastCapabilityStatus === null && (
+              <p className="text-slate-500">
+                Not tested yet. Click <strong>Test connection</strong> to fetch{" "}
+                <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
+                  /metadata
+                </code>
+                .
+              </p>
+            )}
+            {conn.data.lastCapabilityStatus === "ok" && (
+              <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1">
+                <dt className="text-slate-500">Fetched</dt>
+                <dd>{conn.data.lastCapabilityAt}</dd>
+                <dt className="text-slate-500">FHIR version</dt>
+                <dd>{conn.data.lastCapabilityFhirVersion ?? "—"}</dd>
+                <dt className="text-slate-500">Software</dt>
+                <dd>{conn.data.lastCapabilitySoftware ?? "—"}</dd>
+              </dl>
+            )}
+            {conn.data.lastCapabilityStatus === "error" && (
+              <div className="space-y-1">
+                <p className="text-rose-700">{conn.data.lastCapabilityError}</p>
+                <p className="text-xs text-slate-500">
+                  Last attempt: {conn.data.lastCapabilityAt}
+                </p>
+              </div>
+            )}
+          </section>
+
+          {conn.data.lastCapabilityJson && (
+            <details className="rounded-md border border-slate-200 bg-white p-3 text-sm">
+              <summary className="cursor-pointer text-slate-700">
+                Raw CapabilityStatement
+              </summary>
+              <pre className="mt-2 max-h-96 overflow-auto whitespace-pre-wrap break-all rounded bg-slate-50 p-2 text-xs text-slate-700">
+                {pretty(conn.data.lastCapabilityJson)}
+              </pre>
+            </details>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+function pretty(json: string): string {
+  try {
+    return JSON.stringify(JSON.parse(json), null, 2);
+  } catch {
+    return json;
+  }
+}

--- a/apps/workbench/src/pages/ConnectionsListPage.tsx
+++ b/apps/workbench/src/pages/ConnectionsListPage.tsx
@@ -1,0 +1,123 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import {
+  deleteConnection,
+  listConnections,
+  testConnection,
+} from "../api/connections.js";
+import { ConnectionStatusBadge } from "../components/ConnectionStatusBadge.js";
+
+export function ConnectionsListPage() {
+  const qc = useQueryClient();
+  const list = useQuery({
+    queryKey: ["connections"],
+    queryFn: listConnections,
+  });
+
+  const test = useMutation({
+    mutationFn: (id: string) => testConnection(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["connections"] }),
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) => deleteConnection(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["connections"] }),
+  });
+
+  return (
+    <section className="space-y-4">
+      <header className="flex items-end justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-900">FHIR connections</h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Configured FHIR servers the workbench can read from. Synthetic data only.
+          </p>
+        </div>
+        <Link
+          to="/connections/new"
+          className="rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700"
+          data-testid="new-connection"
+        >
+          New connection
+        </Link>
+      </header>
+
+      {list.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
+      {list.isError && (
+        <p className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">
+          Could not load connections: {(list.error as Error).message}
+        </p>
+      )}
+
+      {list.data && list.data.length === 0 && (
+        <div className="rounded-md border border-dashed border-slate-300 bg-white p-6 text-center text-sm text-slate-600">
+          No connections yet.{" "}
+          <Link to="/connections/new" className="font-medium text-slate-900 underline">
+            Add one
+          </Link>{" "}
+          to point the workbench at a synthetic FHIR server.
+        </div>
+      )}
+
+      {list.data && list.data.length > 0 && (
+        <ul className="space-y-2">
+          {list.data.map((conn) => (
+            <li
+              key={conn.id}
+              data-testid="connection-row"
+              className="rounded-md border border-slate-200 bg-white p-4"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <Link
+                      to={`/connections/${conn.id}`}
+                      className="text-base font-semibold text-slate-900 hover:underline"
+                    >
+                      {conn.name}
+                    </Link>
+                    <ConnectionStatusBadge connection={conn} />
+                  </div>
+                  <p className="mt-1 truncate text-xs text-slate-500">
+                    {conn.kind} · {conn.authType}
+                    {conn.hasAuthToken ? " (token)" : ""} · {conn.baseUrl}
+                  </p>
+                  {conn.lastCapabilityStatus === "ok" && (
+                    <p className="mt-1 text-xs text-slate-500">
+                      FHIR {conn.lastCapabilityFhirVersion ?? "?"} ·{" "}
+                      {conn.lastCapabilitySoftware ?? "unknown server"}
+                    </p>
+                  )}
+                  {conn.lastCapabilityStatus === "error" && (
+                    <p className="mt-1 text-xs text-rose-700">
+                      last error: {conn.lastCapabilityError}
+                    </p>
+                  )}
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <button
+                    type="button"
+                    onClick={() => test.mutate(conn.id)}
+                    disabled={test.isPending}
+                    className="rounded-md border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+                  >
+                    {test.isPending && test.variables === conn.id ? "Testing…" : "Test"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (window.confirm(`Delete "${conn.name}"?`)) remove.mutate(conn.id);
+                    }}
+                    className="rounded-md border border-rose-200 bg-white px-2.5 py-1 text-xs font-medium text-rose-700 hover:bg-rose-50"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/workbench/src/pages/HomePage.tsx
+++ b/apps/workbench/src/pages/HomePage.tsx
@@ -1,4 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { listConnections } from "../api/connections.js";
+
 export function HomePage() {
+  const list = useQuery({ queryKey: ["connections"], queryFn: listConnections });
+  const count = list.data?.length ?? 0;
+  const ok = list.data?.filter((c) => c.lastCapabilityStatus === "ok").length ?? 0;
+
   return (
     <section className="space-y-4">
       <header>
@@ -13,16 +21,31 @@ export function HomePage() {
 
       <div className="rounded-md border border-slate-200 bg-white p-4 text-sm text-slate-700">
         <p>
-          This is the Phase A skeleton. Patient search, the typed FHIR tool
-          registry, and the patient-summary agent land in subsequent PRs.
+          Phase A — currently shipped: app skeleton (PR 1) and FHIR
+          DataConnection (PR 2). Patient search, the typed FHIR tool registry,
+          and the patient-summary agent land in subsequent PRs.
         </p>
-        <p className="mt-2">
-          See{" "}
-          <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
-            TASKS.md
-          </code>{" "}
-          at the repo root for the Phase A backlog.
-        </p>
+      </div>
+
+      <div className="rounded-md border border-slate-200 bg-white p-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h2 className="text-base font-semibold text-slate-900">FHIR connections</h2>
+            <p className="mt-1 text-sm text-slate-600">
+              {list.isLoading
+                ? "Loading…"
+                : count === 0
+                  ? "No connections configured yet."
+                  : `${count} connection${count === 1 ? "" : "s"} (${ok} healthy)`}
+            </p>
+          </div>
+          <Link
+            to="/connections"
+            className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Manage
+          </Link>
+        </div>
       </div>
 
       <ul

--- a/apps/workbench/src/pages/HomePage.tsx
+++ b/apps/workbench/src/pages/HomePage.tsx
@@ -1,0 +1,40 @@
+export function HomePage() {
+  return (
+    <section className="space-y-4">
+      <header>
+        <h1 className="text-2xl font-semibold text-slate-900">
+          FHIR Agent Workbench
+        </h1>
+        <p className="mt-1 text-sm text-slate-600">
+          A research workbench for evidence-backed agent answers grounded in
+          synthetic FHIR data.
+        </p>
+      </header>
+
+      <div className="rounded-md border border-slate-200 bg-white p-4 text-sm text-slate-700">
+        <p>
+          This is the Phase A skeleton. Patient search, the typed FHIR tool
+          registry, and the patient-summary agent land in subsequent PRs.
+        </p>
+        <p className="mt-2">
+          See{" "}
+          <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
+            TASKS.md
+          </code>{" "}
+          at the repo root for the Phase A backlog.
+        </p>
+      </div>
+
+      <ul
+        data-testid="phase-a-checklist"
+        className="space-y-1 text-sm text-slate-600"
+      >
+        <li>· Read-only against a configured FHIR server</li>
+        <li>· Synthetic data only</li>
+        <li>· Typed, patient-scoped FHIR tools (deny-by-default)</li>
+        <li>· Evidence-backed structured answers</li>
+        <li>· Persisted tool calls and final answers</li>
+      </ul>
+    </section>
+  );
+}

--- a/apps/workbench/src/pages/NewConnectionPage.tsx
+++ b/apps/workbench/src/pages/NewConnectionPage.tsx
@@ -1,0 +1,154 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  createConnection,
+  type AuthType,
+  type ConnectionKind,
+  type CreateConnectionInput,
+} from "../api/connections.js";
+
+export function NewConnectionPage() {
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+
+  const [name, setName] = useState("");
+  const [baseUrl, setBaseUrl] = useState("http://localhost:8080/fhir");
+  const [authType, setAuthType] = useState<AuthType>("none");
+  const [authToken, setAuthToken] = useState("");
+
+  const create = useMutation({
+    mutationFn: (input: CreateConnectionInput) => createConnection(input),
+    onSuccess: (row) => {
+      qc.invalidateQueries({ queryKey: ["connections"] });
+      navigate(`/connections/${row.id}`);
+    },
+  });
+
+  return (
+    <section className="space-y-4">
+      <header>
+        <h1 className="text-2xl font-semibold text-slate-900">New FHIR connection</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Configure a FHIR server to read from. Phase A supports{" "}
+          <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">fhir_clinical</code>{" "}
+          with{" "}
+          <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">none</code> or{" "}
+          <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">bearer</code>{" "}
+          auth only.
+        </p>
+      </header>
+
+      <form
+        className="space-y-4 rounded-md border border-slate-200 bg-white p-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          const input: CreateConnectionInput = {
+            name: name.trim(),
+            kind: "fhir_clinical" satisfies ConnectionKind,
+            baseUrl: baseUrl.trim(),
+            authType,
+            ...(authType === "bearer" ? { authToken } : {}),
+          };
+          create.mutate(input);
+        }}
+      >
+        <Field label="Name" htmlFor="name">
+          <input
+            id="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            maxLength={120}
+            placeholder="Local HAPI sandbox"
+            className="w-full rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+          />
+        </Field>
+
+        <Field label="Base URL" htmlFor="baseUrl">
+          <input
+            id="baseUrl"
+            type="url"
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+            required
+            placeholder="http://localhost:8080/fhir"
+            className="w-full rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+          />
+        </Field>
+
+        <Field label="Auth type" htmlFor="authType">
+          <select
+            id="authType"
+            value={authType}
+            onChange={(e) => setAuthType(e.target.value as AuthType)}
+            className="w-full rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+          >
+            <option value="none">none</option>
+            <option value="bearer">bearer</option>
+          </select>
+        </Field>
+
+        {authType === "bearer" && (
+          <Field label="Bearer token" htmlFor="authToken">
+            <input
+              id="authToken"
+              type="password"
+              value={authToken}
+              onChange={(e) => setAuthToken(e.target.value)}
+              required
+              maxLength={4096}
+              autoComplete="off"
+              className="w-full rounded-md border border-slate-300 px-3 py-1.5 text-sm font-mono"
+            />
+            <p className="mt-1 text-xs text-slate-500">
+              Stored locally in SQLite. Synthetic environments only.
+            </p>
+          </Field>
+        )}
+
+        {create.isError && (
+          <p className="rounded-md border border-rose-200 bg-rose-50 p-2 text-sm text-rose-800">
+            {(create.error as Error).message}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={create.isPending}
+            className="rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+          >
+            {create.isPending ? "Creating…" : "Create connection"}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label htmlFor={htmlFor} className="mb-1 block text-sm font-medium text-slate-700">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/apps/workbench/tailwind.config.js
+++ b/apps/workbench/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{ts,tsx}",
+    "../../packages/react-fhir/src/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/apps/workbench/tsconfig.json
+++ b/apps/workbench/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "../../packages/react-fhir" }]
+}

--- a/apps/workbench/tsconfig.node.json
+++ b/apps/workbench/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true,
+    "types": ["node"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["db", "scripts", "drizzle.config.ts", "vite.config.ts", "vitest.config.ts"]
+}

--- a/apps/workbench/tsconfig.node.json
+++ b/apps/workbench/tsconfig.node.json
@@ -7,5 +7,5 @@
     "module": "ESNext",
     "moduleResolution": "Bundler"
   },
-  "include": ["db", "scripts", "drizzle.config.ts", "vite.config.ts", "vitest.config.ts"]
+  "include": ["db", "scripts", "server", "drizzle.config.ts", "vite.config.ts", "vitest.config.ts"]
 }

--- a/apps/workbench/vite.config.ts
+++ b/apps/workbench/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  base: process.env.VITE_BASE_PATH ?? "/",
+  server: {
+    port: 5174,
+    host: "127.0.0.1",
+  },
+});

--- a/apps/workbench/vite.config.ts
+++ b/apps/workbench/vite.config.ts
@@ -1,11 +1,19 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const SERVER_PORT = process.env.WORKBENCH_PORT ?? "5175";
+
 export default defineConfig({
   plugins: [react()],
   base: process.env.VITE_BASE_PATH ?? "/",
   server: {
     port: 5174,
     host: "127.0.0.1",
+    proxy: {
+      "/api": {
+        target: `http://127.0.0.1:${SERVER_PORT}`,
+        changeOrigin: false,
+      },
+    },
   },
 });

--- a/apps/workbench/vitest.config.ts
+++ b/apps/workbench/vitest.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
     name: "workbench",
     environment: "node",
     globals: true,
-    include: ["src/**/*.test.{ts,tsx}", "db/**/*.test.ts", "scripts/**/*.test.ts"],
+    include: [
+      "src/**/*.test.{ts,tsx}",
+      "db/**/*.test.ts",
+      "scripts/**/*.test.ts",
+      "server/**/*.test.ts",
+    ],
   },
 });

--- a/apps/workbench/vitest.config.ts
+++ b/apps/workbench/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "workbench",
+    environment: "node",
+    globals: true,
+    include: ["src/**/*.test.{ts,tsx}", "db/**/*.test.ts", "scripts/**/*.test.ts"],
+  },
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,40 @@
+# Architecture
+
+> Placeholder. Filled out incrementally as Phase A PRs land. Locked down in
+> PR 10 (Demo Hardening and Write-Up).
+
+## Components (planned)
+
+| Component | Where it lives | Status |
+| --- | --- | --- |
+| Workbench UI shell | `apps/workbench/src/` | PR 1 ✅ |
+| SQLite + Drizzle local DB | `apps/workbench/db/` | PR 1 ✅ (skeleton) |
+| FHIR DataConnection | `apps/workbench/db/`, `apps/workbench/src/` | PR 2 |
+| Patient search + resource viewer | `apps/workbench/src/` | PR 3 |
+| Typed FHIR tool registry | TBD (`apps/workbench/src/agent/tools/`) | PR 4 |
+| `AgentAnswer` schema + renderer | TBD | PR 5 |
+| Patient-summary agent loop | TBD | PR 6 |
+| Audit logging | `apps/workbench/db/` | PR 7 |
+| Eval harness | TBD | PR 8 |
+| Failure gallery | `apps/workbench/src/pages/` | PR 9 |
+
+## Boundary between frontend and node-only code
+
+The workbench is one package but two TypeScript projects:
+
+- `tsconfig.json` covers `src/` (browser, `vite/client` types).
+- `tsconfig.node.json` covers `db/`, `scripts/`, and `*.config.ts` (node).
+
+`db/` and `scripts/` must never be imported from `src/`. Server-side
+enforcement of patient scope (PR 4) lives behind a future API surface; the
+frontend never opens SQLite directly.
+
+## FHIR-native choices (carried into later PRs)
+
+- Evidence references in `EvidenceBackedClaim` use FHIR relative URLs
+  (`Condition/abc`) so they can be resolved by the resource viewer.
+- Audit log shape mirrors `AuditEvent` + `Provenance` so write-back is a
+  no-op flip later, even though Phase A never writes back.
+- Eval fixtures are stored as FHIR `Bundle` resources, not bespoke JSON.
+- Tool envelopes return `Bundle` `searchset` on success and
+  `OperationOutcome` on error, not a parallel error shape.

--- a/docs/data-connections.md
+++ b/docs/data-connections.md
@@ -1,0 +1,89 @@
+# Data Connections
+
+A `data_connection` points the workbench at a FHIR server it can read from.
+Phase A is read-only and synthetic-only.
+
+## Phase A allow-list
+
+| Field | Allowed values |
+| --- | --- |
+| `kind` | `fhir_clinical` |
+| `authType` | `none`, `bearer` |
+
+Anything else (OMOP, claims, wearable, SMART on FHIR, OAuth client_credentials,
+mTLS) is rejected at the validation boundary in `server/schemas.ts`. There
+is no DB-only path for unsupported values.
+
+## Where things live
+
+| File | What it is |
+| --- | --- |
+| `apps/workbench/db/schema.ts` | Drizzle table `data_connection` |
+| `apps/workbench/db/migrations/0001_data_connection.sql` | Initial migration |
+| `apps/workbench/server/schemas.ts` | Zod input schemas (Phase A allow-list) |
+| `apps/workbench/server/services/fhir-connection.ts` | `/metadata` probe |
+| `apps/workbench/server/services/connection-store.ts` | CRUD + capability persistence |
+| `apps/workbench/server/routes/connections.ts` | Hono routes |
+| `apps/workbench/src/api/connections.ts` | Frontend API client |
+| `apps/workbench/src/pages/Connections*Page.tsx` | UI |
+
+## HTTP API
+
+| Method | Path | What it does |
+| --- | --- | --- |
+| `GET` | `/api/connections` | List connections (auth tokens redacted) |
+| `POST` | `/api/connections` | Create a connection |
+| `GET` | `/api/connections/:id` | Get one connection |
+| `POST` | `/api/connections/:id/test` | Fetch `/metadata`, persist the result |
+| `DELETE` | `/api/connections/:id` | Remove a connection |
+
+Auth tokens **never** leave the server. The frontend only sees
+`hasAuthToken: true | false` on each row.
+
+The `test` endpoint:
+
+1. Loads the connection by id.
+2. Calls `${baseUrl}/metadata` with `Accept: application/fhir+json` and (if
+   bearer) an `Authorization` header.
+3. Verifies the response is a `CapabilityStatement`.
+4. Persists `lastCapabilityAt`, `lastCapabilityStatus`,
+   `lastCapabilityFhirVersion`, `lastCapabilitySoftware`, and
+   `lastCapabilityJson` on success; persists `lastCapabilityError` on
+   failure.
+
+## Local development
+
+The frontend (Vite) and the API (Hono) run as two processes. From the repo
+root, in two terminals:
+
+```bash
+pnpm --filter @fhir-place/workbench server
+pnpm --filter @fhir-place/workbench dev
+```
+
+Vite dev (port 5174) proxies `/api` to the Hono server (port 5175). Override
+the API port with `WORKBENCH_PORT`.
+
+```bash
+WORKBENCH_PORT=6000 pnpm --filter @fhir-place/workbench server
+WORKBENCH_PORT=6000 pnpm --filter @fhir-place/workbench dev
+```
+
+The SQLite DB file is `apps/workbench/workbench.sqlite` by default. Override
+with `WORKBENCH_DB_URL=/some/path.sqlite`.
+
+Run migrations (idempotent) before the first server start:
+
+```bash
+pnpm --filter @fhir-place/workbench db:setup
+```
+
+## What is **not** supported (Phase A icebox)
+
+- SMART on FHIR auth (`authType: "smart"` is rejected)
+- OAuth client_credentials, mTLS, custom auth headers
+- BigQuery, OMOP, claims, wearable connection types
+- Connection-level scoping by patient compartment (that lives at the tool
+  layer in PR 4, not here)
+- Encryption at rest for stored bearer tokens — Phase A is synthetic-only
+  single-user local; document it, don't pretend to solve it

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,0 +1,47 @@
+# Limitations
+
+> Placeholder. Filled out incrementally as Phase A PRs land. Finalised in
+> PR 10 (Demo Hardening and Write-Up).
+
+## What the workbench cannot do
+
+- **Cannot be used clinically.** Synthetic data only. Not a clinical decision
+  support tool. No PHI path.
+- **Cannot write to the FHIR server.** Read-only by design. Write-back is
+  Phase A icebox.
+- **Cannot generate arbitrary FHIR queries.** The agent can only call the
+  registered, typed, patient-scoped tools.
+- **Cannot answer questions outside the selected patient's scope.** Tools
+  reject missing or unauthorized patient IDs.
+- **Cannot follow instructions embedded in resource text.** Resource content
+  is data, not instruction.
+- **Cannot be relied on for completeness.** When evidence is insufficient,
+  the agent emits a cannot-determine claim, not a guess.
+
+## Phase A icebox (intentionally excluded)
+
+- SMART on FHIR auth
+- Real PHI handling
+- HIPAA compliance claims
+- Write-back / mutation
+- Draft / queue / approval workflows
+- Prior authorization
+- Care-gap detection
+- Quality-measure explanation
+- CQL execution, `$evaluate-measure`
+- DocumentReference text extraction
+- MCP server
+- BigQuery / OMOP / claims-style FHIR / wearable connection types
+- Memory, multi-agent planning
+- Clinician preview mode
+- Arbitrary FHIR query generation
+- Arbitrary code execution by the agent
+
+## Known incompletenesses (Phase A)
+
+- The eval suite is small (PR 8 ships ≥ 2 cases). It is not a benchmark.
+- The audit log mirrors `AuditEvent` / `Provenance` shape but is not written
+  back to the FHIR server.
+- One LLM provider is wired up (PR 6); no automatic provider failover.
+- No multi-user authentication. The workbench is a local-first single-user
+  research tool.

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -1,0 +1,54 @@
+# Safety
+
+> Placeholder. Filled out incrementally as Phase A PRs land. Finalised in
+> PR 10 (Demo Hardening and Write-Up).
+
+## What this project is, and isn't
+
+This is a **research workbench** for evidence-backed agent answers grounded in
+**synthetic FHIR data**. It is not:
+
+- a clinical decision support tool,
+- a SMART on FHIR app,
+- a HIPAA-compliant system,
+- a chatbot for real patients.
+
+Every UI surface must carry the synthetic-only / not-for-clinical-use banner.
+
+## The safety layers (all must hold)
+
+1. **Synthetic-only inputs.** The supported deployment mode is a local FHIR
+   server seeded with synthetic data, or the public HAPI sandbox. There is no
+   PHI path.
+2. **Read-only.** Phase A never writes to the FHIR server. Write-back is icebox.
+3. **Typed, patient-scoped tools.** The agent cannot generate arbitrary FHIR
+   queries. It can only call the registered tools, each of which:
+   - validates input against a typed schema,
+   - requires a patient ID,
+   - is server-side scoped to the selected patient,
+   - is deny-by-default for missing or unauthorized patient IDs,
+   - has explicit result limits and timeouts.
+4. **Resource text is data, not instruction.** Anything fetched from the FHIR
+   server is wrapped before it reaches a system prompt or tool-name position.
+5. **Structured answers.** The agent's final output validates against the
+   `AgentAnswer` schema. Supported claims must cite source resources;
+   missing-data and cannot-determine are first-class fields, not absences.
+6. **Audit log everything.** Every run, every tool call, every final answer
+   is persisted and can be replay-inspected.
+7. **Evals before "done".** Phase A is not done until the eval harness covers
+   the named hard cases (no-allergy-data, missing-labs, prompt injection in
+   resource text, out-of-scope patient).
+
+## Hard negatives
+
+The following are explicitly **not** Phase A:
+
+SMART on FHIR auth, real PHI, HIPAA claims, write-back, draft / queue /
+approval, prior auth, care-gap detection, quality-measure explanation, CQL,
+`$evaluate-measure`, DocumentReference text extraction, MCP server,
+BigQuery/OMOP/claims/wearable connections, memory, multi-agent planning,
+clinician preview mode, arbitrary FHIR query generation by the agent,
+arbitrary code execution by the agent.
+
+If a future request seems to require any of these, stop and confirm before
+shipping.

--- a/openspec/changes/add-fhir-data-connection/acceptance.md
+++ b/openspec/changes/add-fhir-data-connection/acceptance.md
@@ -1,0 +1,35 @@
+# Acceptance — `add-fhir-data-connection`
+
+This change is accepted when **all** of the following hold:
+
+- [ ] `pnpm --filter @fhir-place/workbench db:setup` applies migrations
+      `0000_initial.sql` and `0001_data_connection.sql` against a fresh
+      SQLite file.
+- [ ] `pnpm --filter @fhir-place/workbench server` starts a Hono server on
+      port 5175 (configurable via `WORKBENCH_PORT`) that serves
+      `/api/health` and `/api/connections`.
+- [ ] `pnpm --filter @fhir-place/workbench dev` starts the Vite frontend on
+      port 5174 with `/api` proxied to the Hono server.
+- [ ] In the UI, a user can:
+      - [ ] Open the "Connections" page from the top nav.
+      - [ ] Create a new `fhir_clinical` connection with `none` or
+            `bearer` auth.
+      - [ ] See an error in the form when validation fails (e.g. missing
+            bearer token).
+      - [ ] Click **Test connection** and see the parsed FHIR version,
+            software, and a status badge.
+      - [ ] Delete a connection.
+- [ ] The synthetic-only / not-for-clinical-use banner stays visible on
+      every connections page.
+- [ ] Unsupported `kind` (e.g. `omop`) or `authType` (e.g. `smart`) values
+      are rejected with a 400 by the API.
+- [ ] Auth tokens never appear in any HTTP response body — verified by a
+      route test (`never returns the auth token in any response`).
+- [ ] `pnpm -r typecheck` and `pnpm -r test:run` pass with the new tests
+      included.
+- [ ] `pnpm --filter @fhir-place/workbench build` produces a Vite bundle.
+- [ ] `docs/data-connections.md` lists the allow-list, API surface, file
+      layout, dev workflow, and Phase A icebox.
+- [ ] No Phase A icebox item is introduced by this change. Specifically:
+      no SMART, no PHI, no write-back, no arbitrary FHIR query generation,
+      no MCP/OMOP/claims/wearable connection types.

--- a/openspec/changes/add-fhir-data-connection/proposal.md
+++ b/openspec/changes/add-fhir-data-connection/proposal.md
@@ -1,0 +1,75 @@
+# Proposal — `add-fhir-data-connection`
+
+## Summary
+
+Introduce the FHIR `DataConnection` abstraction: a typed, persisted
+configuration for a FHIR server the workbench can read from, plus a
+`/metadata` probe that fetches and persists a CapabilityStatement summary.
+This is PR 2 of Phase A.
+
+## Motivation
+
+The workbench needs a stable way to reference a FHIR server before any of
+the typed patient-scoped tools (PR 4) or the agent loop (PR 6) can run. The
+allow-list — `kind: fhir_clinical` and `authType: none | bearer` only — has
+to be enforced at the server boundary so unsupported modes (SMART, OMOP,
+claims) cannot be persisted by accident or by a misconfigured client.
+
+CapabilityStatement support also lands here so the connection setup flow
+ends in "this server is alive, here's what it claims to support" rather
+than just storing a URL.
+
+## Scope of this change (PR 2)
+
+In:
+
+- A `data_connection` table with denormalised `last_capability_*` fields.
+- A small Hono API (`apps/workbench/server/`) on port 5175 with:
+  - `GET / POST /api/connections`
+  - `GET / DELETE /api/connections/:id`
+  - `POST /api/connections/:id/test`
+- A FHIR `/metadata` probe service that returns the FHIR version and
+  software identification, and stores the raw CapabilityStatement.
+- A frontend connection setup UI: list, create, detail, test, delete.
+- Vite dev proxy `/api` → API port.
+- Docs at `docs/data-connections.md`.
+
+Out:
+
+- Patient search and the resource viewer (PR 3).
+- Tools (PR 4).
+- LLM and agent (PR 6).
+- Audit logging (PR 7) — capability fetch is not yet persisted as an
+  `AuditEvent`-shaped record.
+
+## Architecture decision: separate Hono process
+
+The Vite frontend cannot open SQLite directly (and shouldn't), so PR 2
+introduces a small Hono server alongside the Vite dev server. Two processes
+in dev (`pnpm --filter @fhir-place/workbench server` + `dev`); one in
+production (Vite emits a static bundle, Hono serves the API). This is the
+shape we'll need anyway for PR 4's server-enforced patient scope.
+
+## Safety
+
+- The auth allow-list is enforced in `server/schemas.ts` (Zod). Unknown
+  `kind` or `authType` values get a 400 before any DB write.
+- `bearer` auth requires a token; `none` rejects a token. Both rules are
+  unit-tested.
+- Stored auth tokens never leave the server. The API surface returns
+  `hasAuthToken: boolean` only.
+- The `/metadata` probe verifies the response is a `CapabilityStatement`
+  before persisting it; otherwise the connection is marked
+  `lastCapabilityStatus: "error"` with the reason.
+
+## Non-goals
+
+This change does **not**:
+
+- Add SMART on FHIR auth, OAuth client_credentials, mTLS, or any other
+  authentication mode.
+- Encrypt bearer tokens at rest. Phase A is synthetic-only; the README and
+  `docs/data-connections.md` say so explicitly.
+- Add connection-level scoping by patient compartment — that's the tool
+  registry's job (PR 4).
+- Add capability history; only the latest probe is stored.

--- a/openspec/changes/add-fhir-data-connection/requirements.md
+++ b/openspec/changes/add-fhir-data-connection/requirements.md
@@ -1,0 +1,65 @@
+# Requirements — `add-fhir-data-connection`
+
+## Functional
+
+- F1. A `data_connection` row is uniquely identified by an opaque `id` and
+  carries: `name`, `kind`, `baseUrl`, `authType`, optional `authToken`,
+  timestamps, and the latest CapabilityStatement summary fields.
+- F2. The API exposes the following endpoints under `/api/connections`:
+  `GET /`, `POST /`, `GET /:id`, `POST /:id/test`, `DELETE /:id`.
+- F3. `POST /` validates the input against a typed schema and returns 400
+  with a structured `{ error: "invalid_input", issues: [...] }` body on
+  failure.
+- F4. `POST /:id/test` calls `${baseUrl}/metadata` with `Accept:
+  application/fhir+json` and (when configured) a `Bearer` auth header,
+  verifies the response is a `CapabilityStatement`, and persists either the
+  parsed summary or a structured error.
+- F5. The frontend renders a list of connections with status, a create
+  form, a detail page with a test button, and a delete affordance.
+- F6. The Vite dev server proxies `/api` to the Hono server.
+- F7. The synthetic-only banner remains visible on every page introduced
+  by this change.
+
+## Non-functional
+
+- N1. The `kind` allow-list is `["fhir_clinical"]`. Other values are
+  rejected at the API boundary, regardless of HTTP path.
+- N2. The `authType` allow-list is `["none", "bearer"]`. Other values are
+  rejected at the API boundary.
+- N3. `authType: "bearer"` requires a non-empty `authToken`; `authType:
+  "none"` rejects a token.
+- N4. Auth tokens never appear in any HTTP response body. The redacted row
+  type is `Omit<DataConnection, "authToken"> & { hasAuthToken: boolean }`.
+- N5. The frontend never opens SQLite directly.
+- N6. The store is injectable: `createConnectionStore(db, { fetchFn,
+  generateId, now })`. Tests substitute `fetchFn` instead of relying on
+  global `vi.mock`.
+
+## Tests
+
+- T1. Unit tests cover `authHeadersFor` for all four meaningful inputs
+  (none, bearer w/ token, bearer w/o token, unknown auth type).
+- T2. Unit tests cover `probeCapabilityStatement` for: success, non-2xx,
+  wrong `resourceType`, network failure, and trailing-slash baseUrl.
+- T3. Route integration tests cover: list-empty, create-happy-path,
+  unsupported-kind, unsupported-auth-type, bearer-without-token,
+  none-with-token, 404-on-unknown-id, test-success, test-error, delete,
+  and token-redaction (no response body contains the stored token).
+
+## Safety
+
+- S1. Unsupported connection types and auth types cannot be persisted by
+  any path the API exposes.
+- S2. A malformed `/metadata` response (wrong shape or non-JSON) does not
+  panic the server; the connection is marked `lastCapabilityStatus:
+  "error"` with the reason.
+- S3. The probe `Accept` header is `application/fhir+json`. The probe sends
+  `Authorization: Bearer …` only when `authType === "bearer"` *and* a token
+  is configured.
+
+## Documentation
+
+- D1. `docs/data-connections.md` describes the allow-list, the API surface,
+  the file layout, the local dev workflow, and the Phase A icebox.
+- D2. `apps/workbench/README.md` references `docs/data-connections.md` and
+  the two-process dev setup.

--- a/openspec/changes/add-fhir-data-connection/tasks.md
+++ b/openspec/changes/add-fhir-data-connection/tasks.md
@@ -1,0 +1,31 @@
+# Tasks — `add-fhir-data-connection`
+
+- [x] Add `data_connection` table to `db/schema.ts` with denormalised
+      `last_capability_*` fields.
+- [x] Add migration `db/migrations/0001_data_connection.sql`.
+- [x] Add `server/schemas.ts` with the Phase A `kind` and `authType`
+      allow-lists and a Zod input schema.
+- [x] Add `server/services/fhir-connection.ts` with `authHeadersFor` and
+      `probeCapabilityStatement`.
+- [x] Add `server/services/connection-store.ts` with CRUD and capability
+      persistence; the store accepts injected `fetchFn`, `generateId`, and
+      `now` so tests don't reach for globals.
+- [x] Add `server/routes/connections.ts` (Hono router) and `server/app.ts`
+      (root app with `/api/health` + `/api/connections`).
+- [x] Add `server/index.ts` entry that boots the Hono app on
+      `WORKBENCH_PORT` (default 5175).
+- [x] Add `server/test-utils.ts` to spin up an in-memory test app with a
+      tmp SQLite file and a redactable connection store.
+- [x] Vitest tests for service and routes (token redaction included).
+- [x] Frontend API client at `src/api/connections.ts`.
+- [x] Frontend UI: `ConnectionsListPage`, `NewConnectionPage`,
+      `ConnectionDetailPage`, plus `ConnectionStatusBadge`.
+- [x] Wire the new routes into `App.tsx` and add a top-level nav link.
+- [x] Vite dev proxy `/api` → `WORKBENCH_PORT` (default 5175).
+- [x] Add `pnpm server` + `pnpm server:start` scripts.
+- [x] Update `apps/workbench/README.md` to mention the two-process dev
+      flow and link to `docs/data-connections.md`.
+- [x] Add `docs/data-connections.md`.
+- [x] Add `openspec/changes/add-fhir-data-connection/{proposal,requirements,tasks,acceptance}.md`.
+- [x] `pnpm -r typecheck`, `pnpm -r test:run`, and the workbench build all
+      pass.

--- a/openspec/changes/add-workbench-app/acceptance.md
+++ b/openspec/changes/add-workbench-app/acceptance.md
@@ -1,0 +1,24 @@
+# Acceptance — `add-workbench-app`
+
+This change is accepted when **all** of the following are true:
+
+- [ ] `pnpm install` succeeds at the repo root from a clean checkout.
+- [ ] `pnpm --filter @fhir-place/workbench dev` starts a Vite server on
+      `http://127.0.0.1:5174` and the page renders the synthetic-only banner
+      and the "FHIR Agent Workbench" home page.
+- [ ] `pnpm --filter @fhir-place/workbench db:setup` creates a SQLite file
+      at the configured path and applies the `0000_initial.sql` migration.
+- [ ] `pnpm -r typecheck` exits 0 with the new package included.
+- [ ] `pnpm -r test:run` exits 0 with the new package's tests included,
+      including:
+      - the synthetic-only banner test, and
+      - the Drizzle round-trip test.
+- [ ] `pnpm --filter @fhir-place/workbench build` produces a Vite bundle.
+- [ ] The CI workflow (`.github/workflows/ci.yml`) exercises the workbench
+      build.
+- [ ] `apps/workbench/README.md` opens with the synthetic-only / not-for-
+      clinical-use disclaimer.
+- [ ] `AGENTS.md` exists at the repo root and lists the Phase A icebox.
+- [ ] `docs/architecture.md`, `docs/safety.md`, and `docs/limitations.md`
+      exist as placeholders linked from the workbench README.
+- [ ] None of the Phase A icebox items are introduced by this change.

--- a/openspec/changes/add-workbench-app/proposal.md
+++ b/openspec/changes/add-workbench-app/proposal.md
@@ -1,0 +1,71 @@
+# Proposal — `add-workbench-app`
+
+## Summary
+
+Add a new package, `@fhir-place/workbench`, as the home of the FHIR Agent
+Workbench Phase A. This change introduces the repository foundation only:
+the app skeleton, a local-first SQLite database, the synthetic-only UI
+banner, and the supporting docs and CI hooks. Subsequent OpenSpec changes
+build features on top.
+
+## Motivation
+
+The existing repo ships a generic spec-driven FHIR component library
+(`@fhir-place/react-fhir`) and a demo app. The workbench is a separate
+research project with a different threat model and a different definition of
+done — synthetic-only, read-only, evidence-backed agent answers over typed
+patient-scoped tools.
+
+Carving it out as its own workspace package means:
+
+- The library and demo retain their general-purpose framing.
+- Workbench-specific safety constraints (no write-back, no SMART, no PHI)
+  are encoded in one place and don't bleed into the library.
+- The Phase A scope is reviewable PR-by-PR without entangling library work.
+
+## Scope of this change (PR 1 only)
+
+In:
+
+- New workspace package `apps/workbench/` with Vite + React + Tailwind
+  matching `apps/demo/` conventions.
+- A SQLite + Drizzle local-first DB scaffold with a placeholder
+  `schema_version` table and a `pnpm db:setup` script. Real models land in
+  later changes.
+- A synthetic-only / not-for-clinical-use banner rendered on every page.
+- Top-level docs placeholders (`docs/architecture.md`, `docs/safety.md`,
+  `docs/limitations.md`) and `AGENTS.md`.
+- CI hook so the new package is typechecked, tested, and built.
+
+Out:
+
+- Patient search (PR 3, change `add-patient-search-and-viewer`).
+- Tool registry (PR 4, change `add-agent-tool-registry`).
+- Agent loop, audit logging, evals — all later changes.
+- Any feature listed in the Phase A icebox.
+
+## Stack decisions
+
+- **pnpm workspace** — already in use by the repo.
+- **Vite + React 18 + Tailwind 3** — mirrors `apps/demo/` so reviewers and
+  contributors don't context-switch between two stacks.
+- **TanStack Query + react-router** — same as the demo.
+- **`@fhir-place/react-fhir`'s `FetchFhirClient`** — reuse rather than
+  reinvent the FHIR client.
+- **SQLite via `better-sqlite3` + Drizzle ORM** — local-first, single-file,
+  no external services. The `db/` directory is node-only and segregated
+  from the Vite frontend by a separate `tsconfig.node.json`.
+- **Zod** — installed now; load-bearing in PR 5 (`AgentAnswer` schema) but
+  declared here so later PRs don't have to add a fundamental dep.
+
+## Non-goals
+
+This change does **not**:
+
+- Add SMART on FHIR auth.
+- Open a path for PHI.
+- Add any write-back path against the FHIR server.
+- Add real `data_connection`, `agent_session`, `tool_call`, or
+  `evidence_claim` models — those land in their own OpenSpec changes.
+- Wire up an LLM provider — that lands in PR 6
+  (`add-patient-summary-agent`).

--- a/openspec/changes/add-workbench-app/requirements.md
+++ b/openspec/changes/add-workbench-app/requirements.md
@@ -1,0 +1,48 @@
+# Requirements — `add-workbench-app`
+
+## Functional
+
+- F1. The repository contains a workspace package named
+  `@fhir-place/workbench` at `apps/workbench/`.
+- F2. The package exposes the following pnpm scripts: `dev`, `build`,
+  `test`, `test:run`, `typecheck`, `db:setup`, `db:generate`.
+- F3. Running `pnpm --filter @fhir-place/workbench dev` starts a Vite dev
+  server that serves the workbench UI on `http://127.0.0.1:5174`.
+- F4. The UI shell renders a synthetic-only / not-for-clinical-use banner on
+  every page (in PR 1 there is one page; the banner stays as the app grows).
+- F5. The package contains a local-first SQLite database wired through
+  Drizzle ORM. Running `pnpm --filter @fhir-place/workbench db:setup`
+  creates `workbench.sqlite` and applies all migrations under
+  `db/migrations/`.
+- F6. Drizzle's schema lives at `db/schema.ts`. PR 1 ships a
+  `schema_version` placeholder table; subsequent OpenSpec changes replace or
+  extend it.
+
+## Non-functional
+
+- N1. The frontend (`src/`) and the node-only code (`db/`, `scripts/`) are
+  enforced as separate TypeScript projects via `tsconfig.json` and
+  `tsconfig.node.json`.
+- N2. `src/` does not import anything from `db/` or `scripts/`.
+- N3. The package mirrors the demo's stack: Vite, React 18, Tailwind 3,
+  TanStack Query, React Router. No new state-management library.
+- N4. The package reuses `@fhir-place/react-fhir`'s `FetchFhirClient`; it
+  does not reimplement a FHIR HTTP client.
+
+## Safety
+
+- S1. The synthetic-only banner uses `role="alert"` and copy that names both
+  "synthetic data only" and "not for clinical use".
+- S2. The README states upfront that the app is synthetic-only and not
+  clinical. The disclaimer also appears in `docs/safety.md` and
+  `docs/limitations.md`.
+- S3. No SMART on FHIR auth, PHI handling, write-back, CQL, MCP server,
+  prior auth, care-gap detection, DocumentReference extraction, or
+  arbitrary FHIR query generation is introduced by this change. The icebox
+  in `TASKS.md` and `docs/limitations.md` is the source of truth.
+
+## CI
+
+- C1. The repo's existing `pnpm -r typecheck` and `pnpm -r test:run`
+  commands cover the new package.
+- C2. `pnpm --filter @fhir-place/workbench build` is exercised in CI.

--- a/openspec/changes/add-workbench-app/tasks.md
+++ b/openspec/changes/add-workbench-app/tasks.md
@@ -1,0 +1,25 @@
+# Tasks — `add-workbench-app`
+
+- [x] Create `apps/workbench/` workspace package.
+- [x] Add `package.json`, `tsconfig.json`, `tsconfig.node.json`,
+      `vite.config.ts`, `vitest.config.ts`, `tailwind.config.js`,
+      `postcss.config.js`, `index.html`.
+- [x] Add UI shell: `src/main.tsx`, `src/App.tsx`, `src/index.css`,
+      `src/config.ts`, `src/pages/HomePage.tsx`,
+      `src/components/SyntheticOnlyBanner.tsx`.
+- [x] Vitest test asserting the synthetic-only banner renders the required
+      copy and `role="alert"`.
+- [x] Add Drizzle config and SQLite scaffold: `drizzle.config.ts`,
+      `db/schema.ts`, `db/client.ts`, `db/migrations/0000_initial.sql`,
+      `scripts/db-setup.ts`.
+- [x] Vitest test that opens the SQLite DB, applies migrations, and
+      round-trips a row through Drizzle.
+- [x] Add `apps/workbench/README.md` with synthetic-only positioning, local
+      setup, scripts table, and Phase A non-goals.
+- [x] Add `AGENTS.md` at the repo root.
+- [x] Add `docs/architecture.md`, `docs/safety.md`, `docs/limitations.md`
+      placeholders.
+- [x] Add `openspec/changes/add-workbench-app/{proposal,requirements,tasks,acceptance}.md`.
+- [x] Update `.github/workflows/ci.yml` to also build the workbench.
+- [x] Verify `pnpm -r typecheck`, `pnpm -r test:run`, and
+      `pnpm --filter @fhir-place/workbench build` succeed locally.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@fhir-place/react-fhir':
         specifier: workspace:*
         version: link:../../packages/react-fhir
+      '@hono/node-server':
+        specifier: ^2.0.1
+        version: 2.0.1(hono@4.12.16)
       '@tanstack/react-query':
         specifier: ^5.62.0
         version: 5.99.2(react@18.3.1)
@@ -88,6 +91,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)
+      hono:
+        specifier: ^4.12.16
+        version: 4.12.16
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -967,6 +973,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@hono/node-server@2.0.1':
+    resolution: {integrity: sha512-jI9yMDyFpqBeSighf/zlXnQG/nl9AyBc6aAgy4XtxJMyt/CNyJpvPfzDD+bCc2zAOmhhqtF6TnmIaY+xV4mIrw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
 
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
@@ -1886,6 +1898,10 @@ packages:
 
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
+
+  hono@4.12.16:
+    resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
+    engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -3395,6 +3411,10 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@hono/node-server@2.0.1(hono@4.12.16)':
+    dependencies:
+      hono: 4.12.16
+
   '@inquirer/ansi@2.0.5': {}
 
   '@inquirer/confirm@6.0.12(@types/node@22.19.17)':
@@ -4252,6 +4272,8 @@ snapshots:
     dependencies:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.0
+
+  hono@4.12.16: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7))
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(tsx@4.21.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.5.0(postcss@8.5.10)
@@ -59,13 +59,13 @@ importers:
         version: 8.5.10
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19
+        version: 3.4.19(tsx@4.21.0)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)
+        version: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)(tsx@4.21.0)
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))
@@ -73,6 +73,76 @@ importers:
       msw:
         specifier: ^2.7.0
         version: 2.13.4(@types/node@22.19.17)(typescript@5.9.3)
+
+  apps/workbench:
+    dependencies:
+      '@fhir-place/react-fhir':
+        specifier: workspace:*
+        version: link:../../packages/react-fhir
+      '@tanstack/react-query':
+        specifier: ^5.62.0
+        version: 5.99.2(react@18.3.1)
+      better-sqlite3:
+        specifier: ^12.9.0
+        version: 12.9.0
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: ^7.0.0
+        version: 7.14.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      zod:
+        specifier: ^4.4.1
+        version: 4.4.1
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/fhir':
+        specifier: ^0.0.41
+        version: 0.0.41
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
+      '@types/react':
+        specifier: ^18.3.0
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(tsx@4.21.0))
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.5.0(postcss@8.5.10)
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.10
+      tailwindcss:
+        specifier: ^3.4.17
+        version: 3.4.19(tsx@4.21.0)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)(tsx@4.21.0)
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))
 
   packages/react-fhir:
     dependencies:
@@ -305,6 +375,17 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
@@ -317,6 +398,18 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -327,6 +420,18 @@ packages:
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.21.5':
@@ -341,6 +446,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -353,6 +470,18 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.21.5':
     resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
@@ -363,6 +492,18 @@ packages:
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.21.5':
@@ -377,6 +518,18 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.21.5':
     resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
@@ -387,6 +540,18 @@ packages:
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.21.5':
@@ -401,6 +566,18 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.21.5':
     resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
@@ -411,6 +588,18 @@ packages:
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.21.5':
@@ -425,6 +614,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.21.5':
     resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
@@ -435,6 +636,18 @@ packages:
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.21.5':
@@ -449,6 +662,18 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.21.5':
     resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
@@ -459,6 +684,18 @@ packages:
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.21.5':
@@ -473,6 +710,18 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.21.5':
     resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
@@ -483,6 +732,18 @@ packages:
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.21.5':
@@ -497,6 +758,18 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.21.5':
     resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
@@ -509,10 +782,28 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -527,10 +818,28 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -545,11 +854,29 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
@@ -563,6 +890,18 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
@@ -573,6 +912,18 @@ packages:
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.21.5':
@@ -587,6 +938,18 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
@@ -595,6 +958,12 @@ packages:
 
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -891,6 +1260,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/dompurify@3.2.0':
     resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
     deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
@@ -1023,6 +1395,9 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.20:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
     engines: {node: '>=6.0.0'}
@@ -1032,9 +1407,19 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-sqlite3@12.9.0:
+    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1044,6 +1429,12 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1074,6 +1465,9 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -1140,9 +1534,17 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1154,6 +1556,10 @@ packages:
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   didyoumean@1.2.2:
@@ -1175,6 +1581,102 @@ packages:
   dompurify@3.4.1:
     resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
 
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
+    hasBin: true
+
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1184,6 +1686,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -1212,6 +1717,11 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
@@ -1219,6 +1729,11 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1233,6 +1748,10 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1266,6 +1785,9 @@ packages:
       picomatch:
         optional: true
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -1280,6 +1802,9 @@ packages:
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -1317,6 +1842,12 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1380,6 +1911,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1387,6 +1921,12 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -1520,9 +2060,19 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -1553,6 +2103,13 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
+
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
@@ -1570,6 +2127,9 @@ packages:
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -1708,6 +2268,12 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -1716,6 +2282,9 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1726,6 +2295,10 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -1767,6 +2340,10 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -1782,6 +2359,9 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -1808,6 +2388,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -1849,12 +2432,25 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   spawndamnit@3.0.1:
@@ -1880,6 +2476,9 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -1891,6 +2490,10 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -1912,6 +2515,13 @@ packages:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -1978,6 +2588,14 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
@@ -2143,6 +2761,9 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -2176,6 +2797,9 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  zod@4.4.1:
+    resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
 
 snapshots:
 
@@ -2468,10 +3092,28 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
+  '@drizzle-team/brocli@0.10.2': {}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.14.0
+
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
   '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
     optional: true
 
   '@esbuild/android-arm64@0.21.5':
@@ -2480,10 +3122,22 @@ snapshots:
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
   '@esbuild/android-arm@0.21.5':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
     optional: true
 
   '@esbuild/android-x64@0.21.5':
@@ -2492,10 +3146,22 @@ snapshots:
   '@esbuild/android-x64@0.25.12':
     optional: true
 
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
     optional: true
 
   '@esbuild/darwin-x64@0.21.5':
@@ -2504,10 +3170,22 @@ snapshots:
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-x64@0.21.5':
@@ -2516,10 +3194,22 @@ snapshots:
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
     optional: true
 
   '@esbuild/linux-arm@0.21.5':
@@ -2528,10 +3218,22 @@ snapshots:
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
     optional: true
 
   '@esbuild/linux-loong64@0.21.5':
@@ -2540,10 +3242,22 @@ snapshots:
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
   '@esbuild/linux-ppc64@0.21.5':
@@ -2552,10 +3266,22 @@ snapshots:
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.18.20':
     optional: true
 
   '@esbuild/linux-s390x@0.21.5':
@@ -2564,13 +3290,28 @@ snapshots:
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
+    optional: true
+
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -2579,7 +3320,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -2588,7 +3338,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.18.20':
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
@@ -2597,10 +3356,22 @@ snapshots:
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.18.20':
     optional: true
 
   '@esbuild/win32-ia32@0.21.5':
@@ -2609,10 +3380,19 @@ snapshots:
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@inquirer/ansi@2.0.5': {}
@@ -2861,6 +3641,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/dompurify@3.2.0':
     dependencies:
       dompurify: 3.4.1
@@ -2895,7 +3679,7 @@ snapshots:
   '@types/trusted-types@2.0.7':
     optional: true
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -2903,7 +3687,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2996,13 +3780,30 @@ snapshots:
       postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.20: {}
 
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
 
+  better-sqlite3@12.9.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   binary-extensions@2.3.0: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   braces@3.0.3:
     dependencies:
@@ -3015,6 +3816,13 @@ snapshots:
       electron-to-chromium: 1.5.342
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   cac@6.7.14: {}
 
@@ -3050,6 +3858,8 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  chownr@1.1.4: {}
 
   cli-width@4.1.0: {}
 
@@ -3103,13 +3913,21 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
+
+  deep-extend@0.6.0: {}
 
   delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
+
+  detect-libc@2.1.2: {}
 
   didyoumean@1.2.2: {}
 
@@ -3127,6 +3945,18 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
+  drizzle-kit@0.31.10:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      tsx: 4.21.0
+
+  drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0):
+    optionalDependencies:
+      '@types/better-sqlite3': 7.6.13
+      better-sqlite3: 12.9.0
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -3136,6 +3966,10 @@ snapshots:
   electron-to-chromium@1.5.342: {}
 
   emoji-regex@8.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enquirer@2.4.1:
     dependencies:
@@ -3160,6 +3994,31 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.3
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -3216,6 +4075,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
 
   esprima@4.0.1: {}
@@ -3223,6 +4111,8 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
 
@@ -3254,6 +4144,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -3272,6 +4164,8 @@ snapshots:
       mime-types: 2.1.35
 
   fraction.js@5.3.4: {}
+
+  fs-constants@1.0.0: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -3314,6 +4208,12 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -3381,9 +4281,15 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   indent-string@4.0.0: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -3507,7 +4413,13 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mri@1.2.0: {}
 
@@ -3548,6 +4460,12 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
+
   node-releases@2.0.37: {}
 
   normalize-path@3.0.0: {}
@@ -3557,6 +4475,10 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   outdent@0.5.0: {}
 
@@ -3632,12 +4554,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.10
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.10):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.10)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.10
+      tsx: 4.21.0
 
   postcss-nested@6.2.0(postcss@8.5.10):
     dependencies:
@@ -3657,6 +4580,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prettier@2.8.8: {}
 
   pretty-format@27.5.1:
@@ -3665,11 +4603,23 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -3710,6 +4660,12 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
@@ -3722,6 +4678,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   resolve@1.22.12:
     dependencies:
@@ -3773,6 +4731,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -3801,9 +4761,24 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   slash@3.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
 
   spawndamnit@3.0.1:
     dependencies:
@@ -3826,6 +4801,10 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -3835,6 +4814,8 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-json-comments@2.0.1: {}
 
   sucrase@3.35.1:
     dependencies:
@@ -3852,7 +4833,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(tsx@4.21.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -3871,7 +4852,7 @@ snapshots:
       postcss: 8.5.10
       postcss-import: 15.1.0(postcss@8.5.10)
       postcss-js: 4.1.0(postcss@8.5.10)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.10)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.10)(tsx@4.21.0)
       postcss-nested: 6.2.0(postcss@8.5.10)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -3879,6 +4860,21 @@ snapshots:
     transitivePeerDependencies:
       - tsx
       - yaml
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   term-size@2.2.1: {}
 
@@ -3935,6 +4931,17 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-fest@5.6.0:
     dependencies:
       tagged-tag: 1.0.0
@@ -3982,7 +4989,7 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
 
-  vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7):
+  vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3994,6 +5001,7 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
       jiti: 1.21.7
+      tsx: 4.21.0
 
   vitest@2.1.9(@types/node@22.19.17)(jsdom@25.0.1)(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3)):
     dependencies:
@@ -4063,6 +5071,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrappy@1.0.2: {}
+
   ws@8.20.0: {}
 
   xml-name-validator@5.0.0: {}
@@ -4084,3 +5094,5 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  zod@4.4.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,5 +3,6 @@ packages:
   - apps/*
 
 onlyBuiltDependencies:
+  - better-sqlite3
   - esbuild
   - msw


### PR DESCRIPTION
Closes #71. Stacks on #80 (PR 1). Part of #69 (Phase A).

> ⚠️ Stacked on #80 — until that merges, the diff here will include PR 1's
> commits. Review PR 1 first; this PR's *new* changes are everything under
> `apps/workbench/server/`, the new `src/api/`, the new `Connection*` pages,
> the second migration, the new docs, and the new OpenSpec change folder.

## Summary

Adds the `data_connection` abstraction and a small Hono API the frontend
talks to over `/api`. Phase A's connection allow-list
(`kind=fhir_clinical`, `authType=none|bearer`) is enforced at the
validation boundary in `server/schemas.ts` so unsupported modes (SMART,
OMOP, claims) cannot be persisted by any path the API exposes.

## What landed

### Server (`apps/workbench/server/`, port 5175 by default)

| Method | Path | What it does |
| --- | --- | --- |
| GET | `/api/health` | Smoke endpoint |
| GET | `/api/connections` | List (auth tokens redacted) |
| POST | `/api/connections` | Create (Zod-validated) |
| GET | `/api/connections/:id` | Get one |
| POST | `/api/connections/:id/test` | Fetch `/metadata`, persist summary |
| DELETE | `/api/connections/:id` | Delete |

The connection store accepts injected `fetchFn`, `generateId`, and `now()`
so tests substitute deterministic doubles instead of reaching for global
mocks.

### Schema

- New table `data_connection` with denormalised `last_capability_*` fields
  (latest probe only — capability *history* is out of scope for Phase A).
- Migration `db/migrations/0001_data_connection.sql`.

### Frontend

- Top-nav "Connections" link.
- List page with status badges and inline test/delete.
- New-connection form with Phase-A-aware fields (auth-type select hides
  the token field when `none`).
- Detail page with **Test connection** and a collapsible raw
  CapabilityStatement viewer.
- Vite dev proxies `/api` → `WORKBENCH_PORT` (default 5175). Override with
  `WORKBENCH_PORT=6000`.

### Safety properties

- Unsupported `kind` (e.g. `omop`) → 400.
- Unsupported `authType` (e.g. `smart`) → 400.
- `bearer` without a token → 400.
- `none` with a token → 400.
- Auth tokens never appear in any HTTP response. Verified by a route test
  (`never returns the auth token in any response`).
- Malformed `/metadata` response (wrong shape, non-JSON, network error)
  marks `lastCapabilityStatus: "error"` with a structured reason; never
  panics the server.

### Docs

- `docs/data-connections.md`: allow-list, API surface, file layout, dev
  workflow, Phase A icebox.
- `apps/workbench/README.md` updated: two-process dev flow, scripts table,
  layout diagram.

### OpenSpec

`openspec/changes/add-fhir-data-connection/` — proposal, requirements,
tasks, acceptance.

## Test plan

- [x] `pnpm -r typecheck` — green.
- [x] `pnpm -r test:run` — 256 react-fhir + 15 demo + 22 workbench tests
      pass.
- [x] `pnpm --filter @fhir-place/workbench build` — Vite bundle.
- [x] Live server smoke test: `/api/health`, create, list, and SMART
      auth → 400.

```
$ curl -s http://127.0.0.1:5180/api/health
{"ok":true,"app":"fhir-place/workbench","phase":"A"}

$ curl -s -X POST -H 'Content-Type: application/json' \
    -d '{"name":"x","kind":"fhir_clinical","baseUrl":"https://x/fhir","authType":"smart","authToken":"x"}' \
    http://127.0.0.1:5180/api/connections
# -> HTTP 400 invalid_input
```

## Architecture notes

- I introduced a separate Hono process rather than putting the API into
  Vite middleware. Two processes in dev (`server` + `dev`); one in prod
  (Vite emits a static bundle, Hono serves the API). This is the shape
  PR 4 (server-enforced patient scope) needs anyway.
- I deliberately did **not** reuse `@fhir-place/react-fhir`'s
  `FetchFhirClient` for the `/metadata` probe — that client is an
  abstraction over patient/resource reads, and the metadata endpoint is a
  one-shot probe where we want to inspect the HTTP layer (status code,
  content-type, body parse errors). The patient-scoped tools (PR 4) will
  reuse `FetchFhirClient`.
- Capability *history* is out of scope; only the latest probe is stored
  on the connection row.

## Phase A icebox (still excluded)

No SMART, no PHI path, no write-back, no MCP, no OMOP/claims/wearable
connection types, no encryption-at-rest for stored bearer tokens (Phase A
is synthetic-only single-user local; documented, not pretended-to-solve).

https://claude.ai/code/session_0171aCQPjQQMteJhAvwc1DtQ


---
_Generated by [Claude Code](https://claude.ai/code/session_0171aCQPjQQMteJhAvwc1DtQ)_