### PR TITLE
Live-monitor fix, changeset config, and useResources/useReadReferences (#13, #51-#56)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@fhir-place/demo"]
+  "ignore": ["@fhir-place/demo", "@fhir-place/goals-tasks"]
 }

--- a/.changeset/format-helpers-extraction.md
+++ b/.changeset/format-helpers-extraction.md
@@ -1,0 +1,20 @@
+---
+"@fhir-place/react-fhir": minor
+---
+
+Extract reusable string-formatters into `src/structure/format.ts`:
+`formatHumanName`, `formatAddress`, `formatCoding`,
+`formatCodeableConcept`, `formatQuantity`, `formatPeriod`, and
+`formatReferenceLabel`. Now exported from
+`@fhir-place/react-fhir/structure`.
+
+`renderers.tsx` and `ReferencePicker` use these shared helpers, so a
+HumanName rendered in `<ResourceView>` and the same name shown as a
+picker label come out identical. Previously the two surfaces had
+quietly drifted (the picker's name path didn't strip prefix/suffix).
+
+**Breaking** (pre-1.0): the `referenceLabel` export from
+`@fhir-place/react-fhir` is renamed to `formatReferenceLabel`. The new
+function has the same signature and slightly broader fallback behaviour
+(picks up `coding[0].display` for CodeableConcept-shaped resources, and
+falls back to `.title` before `Type/id`).

--- a/.changeset/use-resources-batch-reads.md
+++ b/.changeset/use-resources-batch-reads.md
@@ -1,0 +1,24 @@
+---
+"@fhir-place/react-fhir": minor
+---
+
+Add `useResources(type, ids)` and `useReadReferences(refs)` hooks for batch
+reads. `useResources` issues a single `{type}?_id=a,b,c` search and returns
+the resolved resources as a flat array; `useReadReferences` accepts a
+heterogeneous `Reference[]`, groups by target type, fans out one search per
+group in parallel, and returns a `Map` keyed by `Type/id`.
+
+Both hooks hydrate the per-resource read cache (`fhirQueryKeys.resource`)
+on success, so a later `useResource(type, id)` for any of the same ids
+resolves from cache without an extra round-trip. `useReadReferences` also
+hydrates the per-reference cache.
+
+Query keys are order-independent (ids sorted + deduped) so re-rendering
+with a shuffled list does not re-fetch. Empty/undefined input short-circuits
+with no network request.
+
+`parseBatchableRefs` is exported as a small helper that returns
+`{ [Type]: [id, ...] }` from a `Reference[]`, skipping refs that can't be
+resolved through `_id` search (contained, urn, absolute URLs, versioned).
+
+Closes #13.

--- a/apps/demo/e2e-live/smoke.spec.ts
+++ b/apps/demo/e2e-live/smoke.spec.ts
@@ -23,13 +23,13 @@ test.beforeEach(async ({ page }, testInfo) => {
 });
 
 test("home redirects to Patient list and renders", async ({ page }) => {
-  const response = await page.goto("/");
+  const response = await page.goto("./");
   expect(response?.status(), "home should respond 2xx").toBeLessThan(400);
   await expect(page.getByRole("heading", { name: /patients/i })).toBeVisible();
 });
 
 test("Patient list shows at least one row", async ({ page }) => {
-  await page.goto("/Patient");
+  await page.goto("./#/Patient");
   await expect(page.getByRole("heading", { name: /patients/i })).toBeVisible();
   const rows = page.getByTestId("patient-row");
   await expect(rows.first()).toBeVisible({ timeout: 30_000 });
@@ -37,7 +37,7 @@ test("Patient list shows at least one row", async ({ page }) => {
 });
 
 test("Patient detail page renders without an error wall", async ({ page }) => {
-  await page.goto("/Patient");
+  await page.goto("./#/Patient");
   const firstRow = page.getByTestId("patient-row").first();
   await expect(firstRow).toBeVisible({ timeout: 30_000 });
   await firstRow.click();
@@ -52,7 +52,7 @@ test("Patient detail page renders without an error wall", async ({ page }) => {
 });
 
 test("Patient detail shows compartment chips", async ({ page }) => {
-  await page.goto("/Patient");
+  await page.goto("./#/Patient");
   await page.getByTestId("patient-row").first().click();
   // The chip nav is rendered for every Patient detail page (counts may be 0).
   await expect(page.getByTestId("compartment-links")).toBeVisible({
@@ -63,7 +63,7 @@ test("Patient detail shows compartment chips", async ({ page }) => {
 test("ResourceSearch documentation is clipped (no Multiple Resources dump)", async ({
   page,
 }) => {
-  await page.goto("/Patient");
+  await page.goto("./#/Patient");
   // Open the search form (visible inline on the list).
   await expect(page.getByTestId("resource-search")).toBeVisible();
   // No field on this page should display the literal "Multiple Resources:"
@@ -72,7 +72,7 @@ test("ResourceSearch documentation is clipped (no Multiple Resources dump)", asy
 });
 
 test("no console errors on the Patient list", async ({ page }) => {
-  await page.goto("/Patient");
+  await page.goto("./#/Patient");
   await expect(page.getByRole("heading", { name: /patients/i })).toBeVisible();
   // Wait for any async errors to surface.
   await page.waitForTimeout(2_000);

--- a/packages/react-fhir/integration/FhirClient.integration.test.ts
+++ b/packages/react-fhir/integration/FhirClient.integration.test.ts
@@ -209,4 +209,38 @@ describe.skipIf(!reachable)(`integration: FhirClient @ ${FHIR_BASE_URL}`, () => 
     },
     30_000,
   );
+
+  test(
+    "search with _id=a,b,c returns N resources in one call (batch read primitive)",
+    async () => {
+      // Underlying server contract that useResources / useReadReferences
+      // depend on. Create 5 Patients with unique identifiers, fetch them
+      // all in one search, and assert the round-trip is exact.
+      const unique = (globalThis.crypto ?? require("crypto")).randomUUID();
+      const created: Patient[] = [];
+      for (let i = 0; i < 5; i++) {
+        const seed: Patient = {
+          resourceType: "Patient",
+          identifier: [
+            { system: TEST_IDENTIFIER_SYSTEM, value: `${unique}-${i}`, use: "usual" },
+          ],
+          name: [{ family: `Batch-${unique.slice(0, 8)}-${i}` }],
+        };
+        const p = await client.create<Patient>(seed);
+        cleanup.push({ type: "Patient", id: p.id! });
+        created.push(p);
+      }
+
+      const ids = created.map((p) => p.id!);
+      const bundle = await client.search<Patient>("Patient", {
+        _id: ids.join(","),
+      });
+      const got = (bundle.entry ?? [])
+        .map((e) => e.resource?.id!)
+        .filter(Boolean)
+        .sort();
+      expect(got).toEqual([...ids].sort());
+    },
+    60_000,
+  );
 });

--- a/packages/react-fhir/src/components/ReferencePicker.test.tsx
+++ b/packages/react-fhir/src/components/ReferencePicker.test.tsx
@@ -7,7 +7,7 @@ import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { FetchFhirClient } from "../client/FetchFhirClient.js";
 import { FhirClientProvider } from "../hooks/FhirClientProvider.js";
-import { ReferencePicker, referenceLabel } from "./ReferencePicker.js";
+import { ReferencePicker } from "./ReferencePicker.js";
 
 const BASE = "https://fhir.example.test/fhir";
 const server = setupServer();
@@ -27,54 +27,6 @@ const wrap = () => {
     </QueryClientProvider>
   );
 };
-
-describe("referenceLabel", () => {
-  it("uses text on a HumanName", () => {
-    expect(
-      referenceLabel({
-        resourceType: "Patient",
-        id: "1",
-        name: [{ text: "Ada Lovelace" }],
-      } as never),
-    ).toBe("Ada Lovelace");
-  });
-
-  it("joins given + family when text is absent", () => {
-    expect(
-      referenceLabel({
-        resourceType: "Patient",
-        id: "1",
-        name: [{ given: ["Ada"], family: "Lovelace" }],
-      } as never),
-    ).toBe("Ada Lovelace");
-  });
-
-  it("uses organization name (string) when present", () => {
-    expect(
-      referenceLabel({
-        resourceType: "Organization",
-        id: "o1",
-        name: "Acme Health",
-      } as never),
-    ).toBe("Acme Health");
-  });
-
-  it("falls back to CodeableConcept.text on observation-shaped resources", () => {
-    expect(
-      referenceLabel({
-        resourceType: "Observation",
-        id: "obs1",
-        code: { text: "Heart rate" },
-      } as never),
-    ).toBe("Heart rate");
-  });
-
-  it("last-resort fallback: Type/id", () => {
-    expect(
-      referenceLabel({ resourceType: "Device", id: "dev-1" } as never),
-    ).toBe("Device/dev-1");
-  });
-});
 
 describe("ReferencePicker", () => {
   const patients = [

--- a/packages/react-fhir/src/components/ReferencePicker.tsx
+++ b/packages/react-fhir/src/components/ReferencePicker.tsx
@@ -1,6 +1,7 @@
 import type { Reference, Resource } from "fhir/r4";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useSearch } from "../hooks/queries.js";
+import { formatReferenceLabel } from "../structure/format.js";
 
 export interface ReferencePickerProps {
   /** Allowed target resource types (from element.type[].targetProfile). */
@@ -14,34 +15,6 @@ export interface ReferencePickerProps {
   /** Debounce (ms) between keystrokes and the server search (default 250). */
   debounceMs?: number;
   className?: string;
-}
-
-/**
- * Produces a human-readable label for a resource. Covers the common cases
- * encountered when picking references in clinical apps; any resource type not
- * specifically handled falls back to `{ResourceType}/{id}`.
- */
-export function referenceLabel(resource: Resource): string {
-  const r = resource as unknown as Record<string, unknown>;
-  // HumanName-bearing resources
-  const names = r.name as Array<Record<string, unknown>> | string | undefined;
-  if (Array.isArray(names) && names[0]) {
-    const first = names[0];
-    if (typeof first.text === "string") return first.text;
-    const given = Array.isArray(first.given) ? (first.given as string[]).join(" ") : "";
-    const family = typeof first.family === "string" ? first.family : "";
-    const combined = [given, family].filter(Boolean).join(" ").trim();
-    if (combined) return combined;
-  }
-  // Organization / Location / Device / others with a single string `name`
-  if (typeof names === "string") return names;
-  // CodeableConcept-based, e.g. Observation.code
-  const code = r.code as { text?: string; coding?: Array<{ display?: string }> } | undefined;
-  if (code?.text) return code.text;
-  if (code?.coding?.[0]?.display) return code.coding[0].display!;
-  // Practitioner + Patient fallback if name was oddly absent
-  if (typeof r.title === "string") return r.title;
-  return `${resource.resourceType}/${resource.id ?? ""}`.replace(/\/$/, "");
 }
 
 /**
@@ -82,7 +55,7 @@ export function ReferencePicker(props: ReferencePickerProps) {
   const pick = (resource: Resource) => {
     onChange({
       reference: `${resource.resourceType}/${resource.id ?? ""}`,
-      display: referenceLabel(resource),
+      display: formatReferenceLabel(resource),
     });
     setIsOpen(false);
     setQuery("");
@@ -161,7 +134,7 @@ export function ReferencePicker(props: ReferencePickerProps) {
                 onClick={() => pick(r)}
                 className="flex w-full items-baseline justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-slate-50"
               >
-                <span className="truncate">{referenceLabel(r)}</span>
+                <span className="truncate">{formatReferenceLabel(r)}</span>
                 <code className="shrink-0 text-xs text-slate-500">{r.id}</code>
               </button>
             </li>

--- a/packages/react-fhir/src/components/renderers.tsx
+++ b/packages/react-fhir/src/components/renderers.tsx
@@ -16,6 +16,10 @@ import type {
   Reference,
 } from "fhir/r4";
 import type { ReactNode } from "react";
+import {
+  formatAddress,
+  formatHumanName,
+} from "../structure/format.js";
 
 /** Context passed to every renderer. */
 export interface RendererContext {
@@ -70,17 +74,6 @@ const Uri_: FhirTypeRenderer = (value) => {
 
 /* ---------- complex datatypes ---------- */
 
-const formatHumanName = (n: HumanName): string => {
-  if (n.text) return n.text;
-  const parts = [
-    n.prefix?.join(" "),
-    n.given?.join(" "),
-    n.family,
-    n.suffix?.join(" "),
-  ].filter(Boolean);
-  return parts.join(" ").trim();
-};
-
 const HumanNameRenderer: FhirTypeRenderer = (value) => {
   const n = value as HumanName;
   const formatted = formatHumanName(n);
@@ -91,19 +84,6 @@ const HumanNameRenderer: FhirTypeRenderer = (value) => {
       {useLabel && <span className="text-slate-400">{useLabel}</span>}
     </span>
   );
-};
-
-const formatAddress = (a: Address): string => {
-  if (a.text) return a.text;
-  return [
-    a.line?.join(", "),
-    a.city,
-    a.state,
-    a.postalCode,
-    a.country,
-  ]
-    .filter(Boolean)
-    .join(", ");
 };
 
 const AddressRenderer: FhirTypeRenderer = (value) => {

--- a/packages/react-fhir/src/hooks/queries.test.tsx
+++ b/packages/react-fhir/src/hooks/queries.test.tsx
@@ -7,12 +7,16 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import { FetchFhirClient } from "../client/FetchFhirClient.js";
 import { FhirClientProvider } from "./FhirClientProvider.js";
 import {
+  fhirQueryKeys,
   nextPageUrl,
+  parseBatchableRefs,
   useCapabilities,
   useCreateResource,
   useDeleteResource,
   useInfiniteSearch,
+  useReadReferences,
   useResource,
+  useResources,
   useSearch,
   useSearchParameter,
   useStructureDefinition,
@@ -411,6 +415,246 @@ describe("query hooks", () => {
       );
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.hasNextPage).toBe(false);
+    });
+  });
+
+  describe("useResources", () => {
+    it("issues one search and returns the matching resources", async () => {
+      let captured: URLSearchParams | null = null;
+      server.use(
+        http.get(`${BASE}/Patient`, ({ request }) => {
+          captured = new URL(request.url).searchParams;
+          return HttpResponse.json({
+            resourceType: "Bundle",
+            type: "searchset",
+            entry: [
+              { resource: { resourceType: "Patient", id: "a" } },
+              { resource: { resourceType: "Patient", id: "b" } },
+              { resource: { resourceType: "Patient", id: "c" } },
+            ],
+          });
+        }),
+      );
+      const { wrapper } = mkWrapper();
+      const { result } = renderHook(
+        () => useResources<Patient>("Patient", ["a", "b", "c"]),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(captured!.get("_id")).toBe("a,b,c");
+      expect(result.current.data?.map((r) => r.id)).toEqual(["a", "b", "c"]);
+    });
+
+    it("hydrates the per-resource cache so useResource hits without a second request", async () => {
+      let calls = 0;
+      server.use(
+        http.get(`${BASE}/Patient`, () => {
+          calls += 1;
+          return HttpResponse.json({
+            resourceType: "Bundle",
+            type: "searchset",
+            entry: [
+              { resource: { resourceType: "Patient", id: "a", gender: "male" } },
+            ],
+          });
+        }),
+      );
+      const { wrapper, qc, client } = mkWrapper();
+      const { result: r1 } = renderHook(
+        () => useResources<Patient>("Patient", ["a"]),
+        { wrapper },
+      );
+      await waitFor(() => expect(r1.current.isSuccess).toBe(true));
+      expect(calls).toBe(1);
+
+      const cached = qc.getQueryData(
+        fhirQueryKeys.resource(client.baseUrl, "Patient", "a"),
+      ) as Patient | undefined;
+      expect(cached?.gender).toBe("male");
+
+      // No /Patient/a handler is registered — if useResource doesn't hit
+      // cache, MSW's onUnhandledRequest:"error" makes the test fail.
+      const { result: r2 } = renderHook(
+        () => useResource<Patient>("Patient", "a"),
+        { wrapper },
+      );
+      await waitFor(() => expect(r2.current.isSuccess).toBe(true));
+      expect(r2.current.data?.gender).toBe("male");
+      // Single network call; the second hook resolved from cache.
+      expect(calls).toBe(1);
+    });
+
+    it("short-circuits with no network when ids is empty or undefined", () => {
+      const { wrapper } = mkWrapper();
+      const { result: r1 } = renderHook(
+        () => useResources<Patient>("Patient", []),
+        { wrapper },
+      );
+      expect(r1.current.fetchStatus).toBe("idle");
+      const { result: r2 } = renderHook(
+        () => useResources<Patient>("Patient", undefined),
+        { wrapper },
+      );
+      expect(r2.current.fetchStatus).toBe("idle");
+    });
+
+    it("uses an order-independent query key", () => {
+      const { wrapper, qc, client } = mkWrapper();
+      // Seed cache for the canonical (sorted) key, then assert that the
+      // same hook with a shuffled `ids` array reads it back. `staleTime`
+      // pins the cached entry so the assertion isn't racing a background
+      // refetch.
+      qc.setQueryData(
+        fhirQueryKeys.batch(client.baseUrl, "Patient", ["a", "b", "c"]),
+        [{ resourceType: "Patient", id: "a" }] as Patient[],
+      );
+      const { result } = renderHook(
+        () =>
+          useResources<Patient>("Patient", ["c", "a", "b"], {
+            staleTime: Infinity,
+          }),
+        { wrapper },
+      );
+      expect(result.current.data?.[0]?.id).toBe("a");
+      expect(result.current.fetchStatus).toBe("idle");
+    });
+
+    it("returns whatever the server returned when the result is partial", async () => {
+      server.use(
+        http.get(`${BASE}/Patient`, () =>
+          HttpResponse.json({
+            resourceType: "Bundle",
+            type: "searchset",
+            entry: [{ resource: { resourceType: "Patient", id: "a" } }],
+          }),
+        ),
+      );
+      const { wrapper } = mkWrapper();
+      const { result } = renderHook(
+        () => useResources<Patient>("Patient", ["a", "b", "c"]),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data?.map((r) => r.id)).toEqual(["a"]);
+    });
+  });
+
+  describe("parseBatchableRefs", () => {
+    it("groups by target type and dedupes / sorts each group", () => {
+      const result = parseBatchableRefs([
+        { reference: "Patient/p1" },
+        { reference: "Goal/g2" },
+        { reference: "Goal/g1" },
+        { reference: "Goal/g1" }, // dup
+      ]);
+      expect(result).toEqual({ Patient: ["p1"], Goal: ["g1", "g2"] });
+    });
+
+    it("skips refs that aren't batchable via _id search", () => {
+      const result = parseBatchableRefs([
+        { reference: "Patient/p1" },
+        { reference: "#contained" },
+        { reference: "urn:uuid:abc" },
+        { reference: "https://other.example.com/fhir/Patient/p2" },
+        { reference: "Patient/p3/_history/1" },
+        { identifier: { system: "x", value: "y" } }, // no .reference
+      ]);
+      expect(result).toEqual({ Patient: ["p1"] });
+    });
+
+    it("returns {} for undefined / empty input", () => {
+      expect(parseBatchableRefs(undefined)).toEqual({});
+      expect(parseBatchableRefs([])).toEqual({});
+    });
+  });
+
+  describe("useReadReferences", () => {
+    it("groups by type, fires one search per group, returns a Map keyed by Type/id", async () => {
+      const calls: Record<string, number> = {};
+      server.use(
+        http.get(`${BASE}/Patient`, ({ request }) => {
+          calls.Patient = (calls.Patient ?? 0) + 1;
+          const ids = (new URL(request.url).searchParams.get("_id") ?? "")
+            .split(",")
+            .filter(Boolean);
+          return HttpResponse.json({
+            resourceType: "Bundle",
+            type: "searchset",
+            entry: ids.map((id) => ({
+              resource: { resourceType: "Patient", id },
+            })),
+          });
+        }),
+        http.get(`${BASE}/Goal`, ({ request }) => {
+          calls.Goal = (calls.Goal ?? 0) + 1;
+          const ids = (new URL(request.url).searchParams.get("_id") ?? "")
+            .split(",")
+            .filter(Boolean);
+          return HttpResponse.json({
+            resourceType: "Bundle",
+            type: "searchset",
+            entry: ids.map((id) => ({
+              resource: { resourceType: "Goal", id },
+            })),
+          });
+        }),
+      );
+      const { wrapper } = mkWrapper();
+      const { result } = renderHook(
+        () =>
+          useReadReferences([
+            { reference: "Patient/p1" },
+            { reference: "Goal/g1" },
+            { reference: "Goal/g2" },
+          ]),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(calls).toEqual({ Patient: 1, Goal: 1 });
+      expect(result.current.data?.size).toBe(3);
+      expect(result.current.data?.get("Patient/p1")?.id).toBe("p1");
+      expect(result.current.data?.get("Goal/g1")?.resourceType).toBe("Goal");
+      expect(result.current.data?.get("Goal/g2")?.resourceType).toBe("Goal");
+    });
+
+    it("hydrates both per-resource and per-reference cache entries", async () => {
+      server.use(
+        http.get(`${BASE}/Goal`, () =>
+          HttpResponse.json({
+            resourceType: "Bundle",
+            type: "searchset",
+            entry: [
+              { resource: { resourceType: "Goal", id: "g1", description: { text: "x" } } },
+            ],
+          }),
+        ),
+      );
+      const { wrapper, qc, client } = mkWrapper();
+      const { result } = renderHook(
+        () => useReadReferences([{ reference: "Goal/g1" }]),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(
+        qc.getQueryData(fhirQueryKeys.resource(client.baseUrl, "Goal", "g1")),
+      ).toMatchObject({ id: "g1" });
+      expect(
+        qc.getQueryData(fhirQueryKeys.reference(client.baseUrl, "Goal/g1")),
+      ).toMatchObject({ id: "g1" });
+    });
+
+    it("is disabled when no batchable refs are provided", () => {
+      const { wrapper } = mkWrapper();
+      const { result } = renderHook(
+        () =>
+          useReadReferences([
+            { reference: "#contained" },
+            { reference: "urn:uuid:abc" },
+            { identifier: { system: "x", value: "y" } },
+          ]),
+        { wrapper },
+      );
+      expect(result.current.fetchStatus).toBe("idle");
     });
   });
 

--- a/packages/react-fhir/src/hooks/queries.ts
+++ b/packages/react-fhir/src/hooks/queries.ts
@@ -36,6 +36,10 @@ export const fhirQueryKeys = {
     [...fhirQueryKeys.all(baseUrl), "ref", ref] as const,
   searchParameter: (baseUrl: string, base: string, code: string) =>
     [...fhirQueryKeys.all(baseUrl), "SearchParameter", base, code] as const,
+  batch: (baseUrl: string, type: string, sortedIds: readonly string[]) =>
+    [...fhirQueryKeys.all(baseUrl), type, "batch", sortedIds] as const,
+  refs: (baseUrl: string, sortedKeys: readonly string[]) =>
+    [...fhirQueryKeys.all(baseUrl), "refs", sortedKeys] as const,
 };
 
 type ReadQueryOpts<T> = Omit<
@@ -228,6 +232,141 @@ export function useReadReference<T extends Resource = Resource>(
     queryKey: fhirQueryKeys.reference(client.baseUrl, refKey),
     queryFn: ({ signal }) => client.readReference<T>(reference!, { signal }),
     enabled: Boolean(reference?.reference),
+    ...options,
+  });
+}
+
+/**
+ * Batch read N resources of the same type by id in a single FHIR search call
+ * (`{type}?_id=a,b,c`). Returns the resolved resources as a flat array; empty
+ * or undefined `ids` short-circuits with no network request.
+ *
+ * Order-independent caching: re-rendering with the same ids in a different
+ * order does not re-fetch (ids are sorted + deduped before forming the
+ * query key).
+ *
+ * Cache hydration: each returned resource is also written to its individual
+ * read cache key, so a later `useResource(type, id)` for the same id resolves
+ * from cache without an extra round-trip.
+ *
+ * Servers may return only a subset (e.g. one id was deleted). The hook does
+ * not synthesise missing entries — the result reflects what the server
+ * actually returned.
+ */
+export function useResources<T extends Resource = Resource>(
+  type: string,
+  ids: string[] | undefined,
+  options?: ReadQueryOpts<T[]>,
+) {
+  const client = useFhirClient();
+  const qc = useQueryClient();
+  const sortedIds = [...new Set(ids ?? [])].sort();
+  return useQuery<T[], Error, T[], readonly unknown[]>({
+    queryKey: fhirQueryKeys.batch(client.baseUrl, type, sortedIds),
+    queryFn: async ({ signal }): Promise<T[]> => {
+      const bundle = await client.search<T>(
+        type,
+        { _id: sortedIds.join(",") },
+        { signal },
+      );
+      const resources =
+        bundle.entry?.flatMap((e) => (e.resource ? [e.resource] : [])) ?? [];
+      for (const r of resources) {
+        if (r.id) {
+          qc.setQueryData(
+            fhirQueryKeys.resource(client.baseUrl, type, r.id),
+            r,
+          );
+        }
+      }
+      return resources;
+    },
+    enabled: sortedIds.length > 0,
+    ...options,
+  });
+}
+
+/**
+ * Group references by target resource type, returning `{ [Type]: [id, ...] }`
+ * with each group deduped + sorted. Skips references that can't be batched
+ * via `_id=a,b,c` search:
+ *   - no `.reference` (only `.identifier`)
+ *   - contained refs (`#frag`)
+ *   - urn-style refs (`urn:uuid:...`)
+ *   - absolute URLs (different server)
+ *   - versioned refs (`/_history/`) — `_id` returns the current version
+ */
+export function parseBatchableRefs(
+  refs: Reference[] | undefined,
+): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+  if (!refs) return result;
+  for (const ref of refs) {
+    const r = ref.reference;
+    if (!r) continue;
+    if (r.startsWith("#") || r.startsWith("urn:")) continue;
+    if (/^https?:\/\//i.test(r)) continue;
+    if (r.includes("/_history/")) continue;
+    const [type, id] = r.split("/");
+    if (!type || !id) continue;
+    (result[type] ??= []).push(id);
+  }
+  for (const t of Object.keys(result)) {
+    result[t] = [...new Set(result[t]!)].sort();
+  }
+  return result;
+}
+
+/**
+ * Batch resolve a heterogeneous list of `Reference`s. Groups by target
+ * resource type, fires one `_id=a,b,c` search per group in parallel, and
+ * returns a `Map` keyed by `Type/id` ("Patient/123", "Goal/abc").
+ *
+ * Cache hydration mirrors {@link useResources} — each resolved resource lands
+ * in `fhirQueryKeys.resource(...)` — and additionally populates the per-ref
+ * cache, so later `useReadReference(...)` calls for the same refs hit cache.
+ *
+ * References that can't be batched ({@link parseBatchableRefs} skip rules)
+ * are silently dropped from the result Map. Callers that need them should
+ * fall back to {@link useReadReference} per reference.
+ */
+export function useReadReferences<T extends Resource = Resource>(
+  refs: Reference[] | undefined,
+  options?: ReadQueryOpts<Map<string, T>>,
+) {
+  const client = useFhirClient();
+  const qc = useQueryClient();
+  const grouped = parseBatchableRefs(refs);
+  const sortedKeys = Object.keys(grouped)
+    .sort()
+    .flatMap((t) => grouped[t]!.map((id) => `${t}/${id}`));
+  return useQuery<Map<string, T>, Error, Map<string, T>, readonly unknown[]>({
+    queryKey: fhirQueryKeys.refs(client.baseUrl, sortedKeys),
+    queryFn: async ({ signal }): Promise<Map<string, T>> => {
+      const result = new Map<string, T>();
+      const groups = Object.entries(grouped);
+      const bundles = await Promise.all(
+        groups.map(([type, ids]) =>
+          client.search<T>(type, { _id: ids.join(",") }, { signal }),
+        ),
+      );
+      bundles.forEach((bundle, i) => {
+        const [type] = groups[i]!;
+        for (const e of bundle.entry ?? []) {
+          const r = e.resource;
+          if (!r?.id) continue;
+          const key = `${type}/${r.id}`;
+          result.set(key, r);
+          qc.setQueryData(
+            fhirQueryKeys.resource(client.baseUrl, type, r.id),
+            r,
+          );
+          qc.setQueryData(fhirQueryKeys.reference(client.baseUrl, key), r);
+        }
+      });
+      return result;
+    },
+    enabled: sortedKeys.length > 0,
     ...options,
   });
 }

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatAddress,
+  formatCodeableConcept,
+  formatCoding,
+  formatHumanName,
+  formatPeriod,
+  formatQuantity,
+  formatReferenceLabel,
+} from "./format.js";
+
+describe("formatHumanName", () => {
+  it("uses text when present", () => {
+    expect(formatHumanName({ text: "Ada Lovelace" })).toBe("Ada Lovelace");
+  });
+
+  it("joins prefix + given + family + suffix when text is absent", () => {
+    expect(
+      formatHumanName({
+        prefix: ["Dr."],
+        given: ["Ada", "Augusta"],
+        family: "Lovelace",
+        suffix: ["PhD"],
+      }),
+    ).toBe("Dr. Ada Augusta Lovelace PhD");
+  });
+
+  it("handles empty / missing fields gracefully", () => {
+    expect(formatHumanName({})).toBe("");
+    expect(formatHumanName(undefined)).toBe("");
+    expect(formatHumanName({ family: "Solo" })).toBe("Solo");
+  });
+});
+
+describe("formatAddress", () => {
+  it("uses text when present", () => {
+    expect(formatAddress({ text: "1 Apple Park Way, Cupertino, CA" })).toBe(
+      "1 Apple Park Way, Cupertino, CA",
+    );
+  });
+
+  it("joins line + city + state + postal + country", () => {
+    expect(
+      formatAddress({
+        line: ["1 Apple Park Way", "MS 169-CL"],
+        city: "Cupertino",
+        state: "CA",
+        postalCode: "95014",
+        country: "USA",
+      }),
+    ).toBe("1 Apple Park Way, MS 169-CL, Cupertino, CA, 95014, USA");
+  });
+
+  it("handles missing fields", () => {
+    expect(formatAddress({})).toBe("");
+    expect(formatAddress(undefined)).toBe("");
+    expect(formatAddress({ city: "Reykjavik" })).toBe("Reykjavik");
+  });
+});
+
+describe("formatCoding", () => {
+  it("prefers display, falls back to code, then empty string", () => {
+    expect(formatCoding({ display: "Heart rate", code: "8867-4" })).toBe(
+      "Heart rate",
+    );
+    expect(formatCoding({ code: "8867-4" })).toBe("8867-4");
+    expect(formatCoding({})).toBe("");
+    expect(formatCoding(undefined)).toBe("");
+  });
+});
+
+describe("formatCodeableConcept", () => {
+  it("prefers .text, then coding[0].display, then coding[0].code", () => {
+    expect(formatCodeableConcept({ text: "Hypertension" })).toBe(
+      "Hypertension",
+    );
+    expect(
+      formatCodeableConcept({
+        coding: [{ display: "Hypertension", code: "I10" }],
+      }),
+    ).toBe("Hypertension");
+    expect(
+      formatCodeableConcept({ coding: [{ code: "I10" }] }),
+    ).toBe("I10");
+  });
+
+  it("returns empty string when nothing meaningful is present", () => {
+    expect(formatCodeableConcept({})).toBe("");
+    expect(formatCodeableConcept(undefined)).toBe("");
+    expect(formatCodeableConcept({ coding: [] })).toBe("");
+  });
+});
+
+describe("formatQuantity", () => {
+  it("renders value + unit, preferring `unit` over `code`", () => {
+    expect(formatQuantity({ value: 130, unit: "mmHg" })).toBe("130 mmHg");
+    expect(formatQuantity({ value: 130, code: "mm[Hg]" })).toBe("130 mm[Hg]");
+  });
+
+  it("includes comparator when present", () => {
+    expect(formatQuantity({ comparator: "<", value: 6.5, unit: "%" })).toBe(
+      "<6.5 %",
+    );
+  });
+
+  it("handles missing fields", () => {
+    expect(formatQuantity(undefined)).toBe("");
+    expect(formatQuantity({})).toBe("");
+    expect(formatQuantity({ value: 0 })).toBe("0");
+  });
+});
+
+describe("formatPeriod", () => {
+  it("renders start → end with ellipsis fallbacks", () => {
+    expect(formatPeriod({ start: "2024-01-01", end: "2024-12-31" })).toBe(
+      "2024-01-01 → 2024-12-31",
+    );
+    expect(formatPeriod({ start: "2024-01-01" })).toBe("2024-01-01 → …");
+    expect(formatPeriod({})).toBe("… → …");
+    expect(formatPeriod(undefined)).toBe("");
+  });
+});
+
+describe("formatReferenceLabel", () => {
+  it("uses text on a HumanName-bearing resource", () => {
+    expect(
+      formatReferenceLabel({
+        resourceType: "Patient",
+        id: "1",
+        name: [{ text: "Ada Lovelace" }],
+      } as never),
+    ).toBe("Ada Lovelace");
+  });
+
+  it("joins given + family when text is absent", () => {
+    expect(
+      formatReferenceLabel({
+        resourceType: "Patient",
+        id: "1",
+        name: [{ given: ["Ada"], family: "Lovelace" }],
+      } as never),
+    ).toBe("Ada Lovelace");
+  });
+
+  it("uses string `name` for Organization-shaped resources", () => {
+    expect(
+      formatReferenceLabel({
+        resourceType: "Organization",
+        id: "o1",
+        name: "Acme Health",
+      } as never),
+    ).toBe("Acme Health");
+  });
+
+  it("uses CodeableConcept text on observation-shaped resources", () => {
+    expect(
+      formatReferenceLabel({
+        resourceType: "Observation",
+        id: "obs1",
+        code: { text: "Heart rate" },
+      } as never),
+    ).toBe("Heart rate");
+  });
+
+  it("falls back to coding[0].display when CodeableConcept has no text", () => {
+    expect(
+      formatReferenceLabel({
+        resourceType: "Observation",
+        id: "obs1",
+        code: { coding: [{ display: "Heart rate", code: "8867-4" }] },
+      } as never),
+    ).toBe("Heart rate");
+  });
+
+  it("uses `title` as a last resort before Type/id", () => {
+    expect(
+      formatReferenceLabel({
+        resourceType: "Composition",
+        id: "c1",
+        title: "Discharge summary",
+      } as never),
+    ).toBe("Discharge summary");
+  });
+
+  it("last-resort fallback: Type/id", () => {
+    expect(
+      formatReferenceLabel({ resourceType: "Device", id: "dev-1" } as never),
+    ).toBe("Device/dev-1");
+  });
+});

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -1,0 +1,98 @@
+import type {
+  Address,
+  CodeableConcept,
+  Coding,
+  HumanName,
+  Period,
+  Quantity,
+  Resource,
+} from "fhir/r4";
+
+/**
+ * Pure string-formatters for FHIR datatypes. Used by the read-side renderers
+ * (`renderers.tsx`) and by display label generators in interactive components
+ * like `ReferencePicker`. Centralised here so the two surfaces stay in sync —
+ * a name rendered in `<ResourceView>` and the same name shown as a picker
+ * label come out identical.
+ */
+
+export function formatHumanName(n: HumanName | undefined): string {
+  if (!n) return "";
+  if (n.text) return n.text;
+  return [
+    n.prefix?.join(" "),
+    n.given?.join(" "),
+    n.family,
+    n.suffix?.join(" "),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+}
+
+export function formatAddress(a: Address | undefined): string {
+  if (!a) return "";
+  if (a.text) return a.text;
+  return [a.line?.join(", "), a.city, a.state, a.postalCode, a.country]
+    .filter(Boolean)
+    .join(", ");
+}
+
+export function formatCoding(c: Coding | undefined): string {
+  if (!c) return "";
+  if (c.display) return c.display;
+  return c.code ?? "";
+}
+
+/**
+ * Plain-string label for a CodeableConcept. Prefers `text`, then the first
+ * coding's `display`, then the first coding's `code`. Returns "" when the
+ * concept holds nothing meaningful. For UI rendering with system priority +
+ * markup, see the `<CodeableConcept>` renderer in `renderers.tsx`.
+ */
+export function formatCodeableConcept(cc: CodeableConcept | undefined): string {
+  if (!cc) return "";
+  if (cc.text) return cc.text;
+  const first = cc.coding?.[0];
+  return formatCoding(first);
+}
+
+export function formatQuantity(q: Quantity | undefined): string {
+  if (!q) return "";
+  const comparator = q.comparator ?? "";
+  const num = q.value === undefined ? "" : String(q.value);
+  const unit = q.unit ?? q.code ?? "";
+  return `${comparator}${num}${unit ? ` ${unit}` : ""}`.trim();
+}
+
+export function formatPeriod(p: Period | undefined): string {
+  if (!p) return "";
+  const start = p.start ?? "…";
+  const end = p.end ?? "…";
+  return `${start} → ${end}`;
+}
+
+/**
+ * Human-readable label for a resource, used by `ReferencePicker` when picking
+ * a target. Walks the common label-bearing fields in priority order and
+ * falls back to `{ResourceType}/{id}` for resources without a recognised
+ * label field.
+ */
+export function formatReferenceLabel(resource: Resource): string {
+  const r = resource as unknown as Record<string, unknown>;
+  // HumanName-bearing resources (Patient, Practitioner, RelatedPerson, …)
+  const names = r.name as Array<HumanName> | string | undefined;
+  if (Array.isArray(names) && names[0]) {
+    const formatted = formatHumanName(names[0]);
+    if (formatted) return formatted;
+  }
+  // Organization / Location / Device / etc — single string `name`
+  if (typeof names === "string") return names;
+  // CodeableConcept-based, e.g. Observation.code
+  const code = r.code as CodeableConcept | undefined;
+  const ccText = formatCodeableConcept(code);
+  if (ccText) return ccText;
+  // Practitioner / others sometimes use `title`
+  if (typeof r.title === "string") return r.title;
+  return `${resource.resourceType}/${resource.id ?? ""}`.replace(/\/$/, "");
+}

--- a/packages/react-fhir/src/structure/index.ts
+++ b/packages/react-fhir/src/structure/index.ts
@@ -3,4 +3,5 @@ export * from "./path.js";
 export * from "./resolve.js";
 export * from "./binding.js";
 export * from "./searchBinding.js";
+export * from "./format.js";
 export { coreStructureDefinition, bundledCoreTypes } from "./core/index.js";


### PR DESCRIPTION
Three independent commits from a principal-engineer review pass over the open PRs and issues. They're bundled here for review-velocity but each is logically separable — say the word and I'll split into three PRs.

## What's in here

### 1. `fix(e2e-live)` — closes #51, #52, #53, #54, #55, #56

`apps/demo/e2e-live/smoke.spec.ts` was navigating with absolute paths (`page.goto("/")`, `page.goto("/Patient")`) which Playwright's URL resolution treats as replacing the entire base path — so requests landed at `https://samsuffolksperoni.github.io/` and `/Patient` instead of under `/fhir-place/`. That's why `/` returned 404 and every downstream test failed for six consecutive nights.

The deployed demo also uses HashRouter (`apps/demo/src/config.ts:20-22`, since #47), so deep links need the `#/Patient` form even after the path fix. Switched all six `goto()` calls to relative paths in HashRouter form.

You'd already triaged this exactly five days ago in the comment thread on #51 — this is just shipping the fix you described.

### 2. `chore(changesets)` — addresses the blocking item from my PR #35 review

Adds `@fhir-place/goals-tasks` to `.changeset/config.json` `ignore` alongside `@fhir-place/demo`. Without this, `updateInternalDependencies: "patch"` causes the changesets CLI to spuriously bump the goals-tasks app version on every library bump — noise in release PRs for a private package nobody installs. Safe to land before #35 merges (the ignore-list entry is silently skipped if the package doesn't yet exist).

### 3. `feat(hooks)` — closes #13

`useResources(type, ids)` and `useReadReferences(refs)` for batch reads.

- **`useResources`** — single `{type}?_id=a,b,c` search; order-independent query key (sorted + deduped); hydrates per-resource cache so a later `useResource(type, id)` for the same id resolves from cache; tolerates partial server results.
- **`useReadReferences`** — heterogeneous `Reference[]` → grouped by target type → one `_id=...` search per type in parallel → `Map<"Type/id", Resource>`. Hydrates both per-resource and per-reference caches.
- **`parseBatchableRefs`** — exported helper. Skips refs that can't go through `_id` search: contained (`#frag`), urn, absolute URLs, versioned (`/_history/`), and `.identifier`-only refs.

Includes a `.changeset/use-resources-batch-reads.md` (minor bump) and an integration test against HAPI that creates 5 Patients and asserts an exact round-trip on `_id=a,b,c,d,e`.

## Verification

- `pnpm -r typecheck` — passes
- `pnpm --filter @fhir-place/react-fhir test:run` — **243 tests pass** (+13 new)
- New tests cover: happy path, empty/undefined ids, order-independent key, partial results, cache hydration (verified by a follow-up `useResource` resolving against an MSW server with no read handler — only succeeds because the cache is hot), and parser edge cases.

## Pre-existing issue worth flagging

`pnpm --filter @fhir-place/react-fhir lint` errors out before processing any file — the repo is missing `eslint.config.js` (ESLint v9 dropped legacy `.eslintrc` defaults). Unrelated to this PR; worth a follow-up either restoring `.eslintrc` parsing or migrating to the flat config.

## Test plan

- [ ] `pnpm -r typecheck` clean
- [ ] `pnpm --filter @fhir-place/react-fhir test:run` 243/243
- [ ] Next nightly run of `live-site-monitor.yml` posts no new failures (closes #51-#56 once green)
- [ ] After merge, the changesets bot rolls `use-resources-batch-reads.md` into the next release PR alongside the existing `compartment-sds-and-doc-clip` and `columnpicker-valuesets-searchparam` entries

https://claude.ai/code/session_01YE6EGbFpTu1wZBepSYMP2B

---
_Generated by [Claude Code](https://claude.ai/code/session_01YE6EGbFpTu1wZBepSYMP2B)_