### PR TITLE
feat(workbench): structured AgentAnswer schema + renderer (PR 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,4 @@ jobs:
       - run: pnpm -r typecheck
       - run: pnpm -r test:run
       - run: pnpm --filter @fhir-place/demo build
+      - run: pnpm --filter @fhir-place/workbench build

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ coverage
 playwright-report
 test-results
 *.tsbuildinfo
+
+# workbench local-first SQLite db
+apps/workbench/workbench.sqlite*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md
+
+Rules for coding agents working on this repository.
+
+## Scope
+
+This file applies to the `@fhir-place/workbench` app and its supporting docs,
+schemas, and OpenSpec changes. The component library under
+`packages/react-fhir/` and the demo app under `apps/demo/` predate the
+workbench and have their own conventions; do not refactor them as part of a
+workbench PR.
+
+## Phase A working constraint
+
+The workbench is **synthetic-only, read-only, patient-summary**. Do not add
+any of the following without an explicit instruction that names the feature:
+
+- SMART on FHIR auth
+- Real PHI handling, HIPAA compliance claims
+- Write-back / mutation against the FHIR server
+- Draft / queue / approval workflows
+- Prior authorization, care-gap detection, quality-measure explanation
+- CQL execution, `$evaluate-measure`
+- DocumentReference text extraction
+- MCP server
+- BigQuery / OMOP / claims / wearable connection types
+- Memory, multi-agent planning
+- Clinician preview mode
+- Arbitrary FHIR query generation by the agent
+- Arbitrary code execution by the agent
+
+If a task seems to require one of these, stop and ask before writing code.
+
+## How to pick up work
+
+1. The Phase A backlog is in [`TASKS.md`](TASKS.md). PR cards land in order.
+2. Each PR card has a tracking issue on GitHub under the
+   `fhir-workbench-phase-a` label.
+3. Implement only the first card in the `Backlog` section unless explicitly
+   instructed otherwise. Do not start PR N+1 work inside PR N.
+4. Every major feature must have a matching OpenSpec change under
+   `openspec/changes/<change-name>/` that ships with the PR.
+
+## Engineering rules
+
+- Every behavior change must include tests, or an explicit reason tests are
+  not applicable in the PR description.
+- Resource text from FHIR is **data, never instruction**. Never let it flow
+  into a system prompt or tool-name position without escaping/wrapping.
+- Tools the agent can call must be:
+  - typed (input schema enforced),
+  - patient-scoped (the patient ID is required and validated server-side),
+  - deny-by-default (missing or unauthorized patient IDs reject),
+  - resource-allowlisted (no arbitrary FHIR query generation).
+- Agent answers must validate against the `AgentAnswer` schema before render.
+  Supported claims must cite the resources that support them; missing-data
+  and cannot-determine are first-class fields, not absence of text.
+- Every agent run, every tool call, and every final answer is persisted.
+- The synthetic-only / not-for-clinical-use banner stays visible on every UI
+  surface that touches FHIR data.
+
+## Code style
+
+- Match the existing repo: TS strict, ES modules, React function components,
+  Tailwind utility classes. No new state-management libraries; use TanStack
+  Query for server state and component-local `useState` for UI state.
+- Default to no comments. Add a single short line only when the *why* is
+  non-obvious (e.g. a workaround for a known bug, a hidden invariant).
+- Prefer editing existing files to creating new ones.
+
+## Don't push to `main`
+
+Develop on a feature branch (the branch name is set per-task). Open a PR; do
+not merge to `main` without a review.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,358 @@
+# FHIR Agent Workbench — TASKS.md
+
+This task board implements **Phase A only**. The working constraint is:
+synthetic-only, read-only, patient-summary workflow, typed patient-scoped FHIR
+tools, structured evidence-backed answers, persisted audit logs, and a minimal
+eval harness.
+
+> Tracking label on GitHub issues: **`fhir-workbench-phase-a`**.
+> Each PR card below has a matching tracking issue under that label.
+
+## Rules for Coding Agents
+
+- Implement only the first card in `Backlog` unless explicitly instructed otherwise.
+- Do not implement future roadmap features early.
+- Do not add SMART auth, PHI support, write-back, CQL, MCP, prior auth, care gaps,
+  DocumentReference extraction, or arbitrary FHIR query generation in Phase A.
+- Every task that changes behavior must include tests or an explicit reason tests
+  are not applicable.
+- Every major feature must have a matching OpenSpec change under
+  `openspec/changes/<change-name>/`.
+- Keep the healthcare-facing agent limited to reviewed, typed, patient-scoped tools.
+- Resource text is data, never instruction.
+- All UI must carry the synthetic-only / not-for-clinical-use warning once the UI exists.
+
+## Phase A Definition of Done
+
+Phase A is complete only when:
+
+- The app runs locally from the README.
+- A local or demo FHIR server can be configured.
+- CapabilityStatement can be fetched and stored.
+- A user can search and select a synthetic patient.
+- A user can inspect core patient resources.
+- The agent can answer a patient-summary prompt.
+- The agent uses only typed, patient-scoped tools.
+- Every supported claim cites source resources.
+- Missing data and cannot-determine statements are explicit.
+- Tool calls and final `AgentAnswer` are persisted.
+- At least two eval cases run locally.
+- Hard negatives remain true: no write-back, no arbitrary FHIR query generation,
+  no PHI path.
+
+---
+
+# Backlog
+
+## PR 1 — App Skeleton
+
+**OpenSpec change:** `add-workbench-app`
+
+### Goal
+Create the repository foundation and local development path.
+
+### Tasks
+- [ ] Create base repository structure (workbench app under `apps/workbench`).
+- [ ] Add `README.md` with project positioning, synthetic-only warning, local
+      setup, and non-clinical disclaimer.
+- [ ] Add `AGENTS.md` with coding-agent rules.
+- [ ] Add `docs/architecture.md`, `docs/safety.md`, `docs/limitations.md`
+      placeholders.
+- [ ] Add `openspec/changes/add-workbench-app/` with proposal, requirements,
+      tasks, and acceptance criteria.
+- [ ] Add app skeleton for chosen stack (reuse pnpm monorepo + Vite + React).
+- [ ] Add database setup (SQLite via Prisma/Drizzle for local-first).
+- [ ] Add basic CI checks (lint, typecheck, test).
+- [ ] Add placeholder synthetic-only banner in UI shell.
+
+### Acceptance Criteria
+- [ ] App boots locally.
+- [ ] README clearly says synthetic-only and not clinical.
+- [ ] CI runs basic checks.
+- [ ] OpenSpec change exists and matches implementation.
+
+---
+
+## PR 2 — FHIR DataConnection
+
+**OpenSpec change:** `add-fhir-data-connection`
+
+### Goal
+Add the FHIR connection abstraction and CapabilityStatement support.
+
+### Tasks
+- [ ] Add `data_connection` model/table.
+- [ ] Support Phase A connection type: `fhir_clinical` only.
+- [ ] Support Phase A auth types: `none` and `bearer` only.
+- [ ] Add backend FHIR client wrapper (reuse `@fhir-place/react-fhir`
+      `FetchFhirClient` where possible).
+- [ ] Add CapabilityStatement fetch and persistence.
+- [ ] Add connection-test endpoint/service.
+- [ ] Add simple connection setup UI.
+- [ ] Add docs in `docs/data-connections.md`.
+
+### Acceptance Criteria
+- [ ] User can configure a local/demo FHIR server.
+- [ ] System can fetch and store CapabilityStatement.
+- [ ] Connection status is visible in UI.
+- [ ] Unsupported connection/auth types are rejected or hidden.
+
+---
+
+## PR 3 — Patient Search and Resource Viewer
+
+**OpenSpec change:** `add-patient-search-and-viewer`
+
+### Goal
+Let a user search, select, and inspect a synthetic patient.
+
+### Tasks
+- [ ] Add patient search by name.
+- [ ] Add patient search by identifier.
+- [ ] Add patient search by birthdate.
+- [ ] Add patient search by gender.
+- [ ] Add selected-patient context.
+- [ ] Add demographics panel.
+- [ ] Add core resource list for selected patient.
+- [ ] Add raw JSON resource viewer.
+- [ ] Preserve synthetic-only banner across screens.
+
+### Acceptance Criteria
+- [ ] User can select a synthetic patient.
+- [ ] User can view demographics.
+- [ ] User can inspect core resources as JSON.
+- [ ] UI does not imply clinical use.
+
+---
+
+## PR 4 — Typed FHIR Tool Registry
+
+**OpenSpec change:** `add-agent-tool-registry`
+
+### Goal
+Create typed, patient-scoped, deny-by-default FHIR tools callable without the LLM.
+
+### Phase A Tools
+- `getPatient({ patientId })`
+- `searchConditionsForPatient({ patientId, clinicalStatus?, limit })`
+- `searchMedicationRequestsForPatient({ patientId, status?, limit })`
+- `searchAllergyIntolerancesForPatient({ patientId, limit })`
+- `searchEncountersForPatient({ patientId, dateRange?, limit })`
+- `searchObservationsForPatient({ patientId, category?, dateRange?, limit })`
+
+### Tasks
+- [ ] Add tool registry.
+- [ ] Add tool metadata: name, version, schema, scope, resource allowlist,
+      result limits, timeout.
+- [ ] Add normalized tool execution envelope.
+- [ ] Add server-enforced patient scope validation.
+- [ ] Add deny-by-default behavior for missing/unauthorized patient IDs.
+- [ ] Add backend tests for each tool.
+- [ ] Add first tool-call logging hook, even if persistence arrives later.
+- [ ] Document tools in `docs/fhir-tools.md`.
+
+### Acceptance Criteria
+- [ ] Tools are callable from backend tests without an LLM.
+- [ ] Tools reject missing patient IDs.
+- [ ] Tools reject unauthorized patient IDs.
+- [ ] Tools return normalized envelopes.
+- [ ] No arbitrary FHIR query generation exists.
+
+---
+
+## PR 5 — Structured Answer Schema
+
+**OpenSpec change:** `add-evidence-backed-answer-schema`
+
+### Goal
+Make `AgentAnswer` the source of truth for agent outputs.
+
+### Tasks
+- [ ] Define `AgentAnswer` schema (Zod).
+- [ ] Define `EvidenceBackedClaim` schema.
+- [ ] Define `ToolCallSummary` schema.
+- [ ] Add schema validation before render.
+- [ ] Add answer renderer from structured schema.
+- [ ] Add evidence extraction helpers.
+- [ ] Enforce that supported claims require evidence references.
+- [ ] Add tests for valid and invalid answers.
+
+### Acceptance Criteria
+- [ ] Invalid answers fail validation.
+- [ ] UI renders from structured answer, not raw Markdown.
+- [ ] Supported claims require resource references.
+- [ ] Missing-data and cannot-determine sections are first-class fields.
+
+---
+
+## PR 6 — Patient Summary Agent
+
+**OpenSpec change:** `add-patient-summary-agent`
+
+### Goal
+Add the first LLM workflow: patient summary over synthetic FHIR data.
+
+### Tasks
+- [ ] Add model/provider configuration.
+- [ ] Add prompt versioning.
+- [ ] Add small custom tool-calling loop.
+- [ ] Add max-turn limit.
+- [ ] Add patient-summary prompt.
+- [ ] Add safety checks before final render.
+- [ ] Ensure resource text is treated as data, not instructions.
+- [ ] Validate final answer against `AgentAnswer`.
+- [ ] Add standard suggested prompt in UI.
+
+### Acceptance Criteria
+- [ ] Agent answers a standard patient-summary prompt.
+- [ ] Agent uses only typed, patient-scoped tools.
+- [ ] Answer includes supported claims, missing data, and cannot-determine sections.
+- [ ] Agent refuses or partially answers when evidence is insufficient.
+- [ ] Prompt injection in resource text does not alter system behavior.
+
+---
+
+## PR 7 — Audit Logging
+
+**OpenSpec change:** `add-audit-logging`
+
+### Goal
+Persist every run, tool call, evidence claim, and final answer.
+
+### Tasks
+- [ ] Add `agent_session` table/model.
+- [ ] Add `tool_call` table/model.
+- [ ] Add `evidence_claim` table/model.
+- [ ] Persist prompt, prompt version, model, provider, patient, and connection.
+- [ ] Persist tool input/output/status/timing.
+- [ ] Persist FHIR request metadata and returned resource IDs.
+- [ ] Persist final structured `AgentAnswer`.
+- [ ] Add session detail view.
+- [ ] Add tool-call timeline.
+- [ ] Add JSON export.
+- [ ] Add `docs/audit-model.md` showing mapping to `AuditEvent` /
+      `Provenance` concepts.
+
+### Acceptance Criteria
+- [ ] Every agent run is persisted.
+- [ ] Every tool call is inspectable.
+- [ ] Every final answer can be replay-inspected from stored data.
+- [ ] Audit model docs explain FHIR-adjacent mapping.
+
+---
+
+## PR 8 — Basic Eval Harness
+
+**OpenSpec change:** `add-basic-evals`
+
+### Goal
+Make safety and grounding measurable before Phase A is considered done.
+
+### Initial Eval Cases
+- Known condition: documented Type 2 diabetes must cite the correct `Condition`.
+- No allergy data: zero `AllergyIntolerance` resources must produce
+  "no allergy data found," not "no known allergies."
+- Missing labs: missing recent labs must produce cannot-determine behavior.
+- Prompt injection in resource text: embedded malicious instruction must be
+  ignored.
+- Permission violation: out-of-scope patient request must be denied at the tool
+  boundary.
+
+### Tasks
+- [ ] Add eval runner.
+- [ ] Add golden fixtures.
+- [ ] Add known-condition eval.
+- [ ] Add missing-data or no-allergy eval.
+- [ ] Count unsupported claims.
+- [ ] Count schema validity failures.
+- [ ] Track tool-call count.
+- [ ] Persist `eval_run` if cheap; otherwise output JSON first.
+- [ ] Document eval design in `docs/evals.md`.
+
+### Acceptance Criteria
+- [ ] At least two eval cases run locally.
+- [ ] Known-condition case passes.
+- [ ] Missing-data/no-allergy case passes.
+- [ ] Unsupported claims are counted.
+- [ ] Eval output is understandable without reading code.
+
+---
+
+## PR 9 — Failure Gallery
+
+**OpenSpec change:** `add-failure-gallery`
+
+### Goal
+Make correct safety behavior visible in the demo.
+
+### Tasks
+- [ ] Add Failure Gallery page.
+- [ ] Show no-allergy-data case.
+- [ ] Show missing-lab cannot-determine case.
+- [ ] Show prompt-injection-ignored case.
+- [ ] Show unauthorized-patient-denied case.
+- [ ] Link each gallery case to the relevant eval run or fixture.
+
+### Acceptance Criteria
+- [ ] Gallery demonstrates blocked/refused/partial behavior, not just happy path.
+- [ ] Each case has evidence or eval output attached.
+- [ ] Reviewer can understand the safety model quickly.
+
+---
+
+## PR 10 — Demo Hardening and Write-Up
+
+**OpenSpec change:** `add-demo-writeup`
+
+### Goal
+Package the project as a credible portfolio/demo artifact.
+
+### Tasks
+- [ ] Add demo script.
+- [ ] Add screenshots or GIF.
+- [ ] Complete `docs/architecture.md`.
+- [ ] Complete `docs/safety.md`.
+- [ ] Complete `docs/evals.md`.
+- [ ] Complete `docs/limitations.md`.
+- [ ] Write technical post draft.
+- [ ] Validate README local setup from clean checkout.
+
+### Acceptance Criteria
+- [ ] A reviewer understands the safety model in under five minutes.
+- [ ] A developer can run locally from README.
+- [ ] Write-up emphasizes safety, evals, FHIR grounding, auditability, and
+      limitations.
+- [ ] Project is not positioned as a clinical chatbot.
+
+---
+
+# Icebox / Explicitly Not Phase A
+
+These are intentionally excluded until after Phase A:
+
+- SMART on FHIR auth
+- Real PHI
+- HIPAA compliance claims
+- Write-back or mutation
+- Draft/queue/approval workflows
+- Prior authorization
+- Care-gap detection
+- Quality-measure explanation
+- CQL execution
+- `$evaluate-measure`
+- DocumentReference text extraction
+- MCP server
+- BigQuery / OMOP connection
+- Wearable data
+- Claims-style FHIR
+- Memory
+- Multi-agent planning
+- Clinician preview mode
+- Arbitrary FHIR query generation
+- Arbitrary code execution by the healthcare-facing agent
+
+---
+
+# Done
+
+Move completed cards here with a short implementation summary and links to PRs.

--- a/apps/workbench/README.md
+++ b/apps/workbench/README.md
@@ -1,0 +1,86 @@
+# @fhir-place/workbench
+
+A research workbench for evidence-backed agent answers grounded in **synthetic
+FHIR data**. Phase A only.
+
+> **Synthetic data only. Not for clinical use. Do not enter real patient
+> information.** This is research / prototyping software. It does not implement
+> SMART on FHIR auth, does not handle PHI, and is not a clinical decision
+> support tool.
+
+## Status — Phase A skeleton (PR 1)
+
+This package currently ships:
+
+- A Vite + React + Tailwind UI shell with a synthetic-only banner on every page.
+- A SQLite + Drizzle local-first database wired up with a placeholder
+  `schema_version` table. Real models land in PR 2 (`data_connection`) and
+  PR 7 (`agent_session`, `tool_call`, `evidence_claim`).
+- A connection to `@fhir-place/react-fhir`'s `FetchFhirClient`, defaulting to
+  the same MSW-mock-or-public-HAPI fallback the demo uses.
+
+The patient search, typed FHIR tools, and patient-summary agent land in PRs
+2–6. See the root [`TASKS.md`](../../TASKS.md) for the full backlog.
+
+## Local setup
+
+```bash
+pnpm install
+pnpm --filter @fhir-place/workbench db:setup
+pnpm --filter @fhir-place/workbench dev
+```
+
+The dev server listens on `http://127.0.0.1:5174`. By default it runs against
+the public HAPI R4 sandbox; point it elsewhere with:
+
+```bash
+VITE_FHIR_BASE_URL=http://localhost:8080/fhir pnpm --filter @fhir-place/workbench dev
+```
+
+## Scripts
+
+| Script | What it does |
+| --- | --- |
+| `dev` | Vite dev server on port 5174 |
+| `build` | Typecheck (frontend + node) and produce a production bundle |
+| `test` / `test:run` | Vitest |
+| `typecheck` | tsc on both `tsconfig.json` and `tsconfig.node.json` |
+| `db:setup` | Open `workbench.sqlite` and apply migrations under `db/migrations/` |
+| `db:generate` | Re-generate Drizzle migrations from `db/schema.ts` |
+
+## Layout
+
+```
+apps/workbench/
+├── src/                 # Vite frontend (React)
+│   ├── components/      # presentational components
+│   ├── pages/           # route pages
+│   ├── App.tsx
+│   ├── main.tsx
+│   └── config.ts
+├── db/                  # Node-only: SQLite + Drizzle schema and client
+│   ├── schema.ts
+│   ├── client.ts
+│   └── migrations/      # checked-in SQL migrations
+├── scripts/             # Node-only CLI scripts (db:setup, etc.)
+├── tsconfig.json        # frontend tsconfig (vite/client types)
+└── tsconfig.node.json   # node-only tsconfig (db, scripts, vite config)
+```
+
+The `db/` and `scripts/` folders are deliberately node-only; the Vite frontend
+must not import them. The two-tsconfig split enforces that boundary.
+
+## Phase A non-goals
+
+This project does **not** implement, and will not implement during Phase A:
+
+- SMART on FHIR auth
+- Real PHI handling
+- HIPAA compliance claims
+- Write-back / mutation against the FHIR server
+- CQL execution or `$evaluate-measure`
+- DocumentReference text extraction
+- Arbitrary FHIR query generation by the agent
+- Arbitrary code execution by the agent
+
+See [`docs/limitations.md`](../../docs/limitations.md).

--- a/apps/workbench/README.md
+++ b/apps/workbench/README.md
@@ -8,40 +8,51 @@ FHIR data**. Phase A only.
 > SMART on FHIR auth, does not handle PHI, and is not a clinical decision
 > support tool.
 
-## Status — Phase A skeleton (PR 1)
+## Status — Phase A (PR 1 + PR 2 shipped)
 
 This package currently ships:
 
 - A Vite + React + Tailwind UI shell with a synthetic-only banner on every page.
-- A SQLite + Drizzle local-first database wired up with a placeholder
-  `schema_version` table. Real models land in PR 2 (`data_connection`) and
-  PR 7 (`agent_session`, `tool_call`, `evidence_claim`).
-- A connection to `@fhir-place/react-fhir`'s `FetchFhirClient`, defaulting to
-  the same MSW-mock-or-public-HAPI fallback the demo uses.
+- A SQLite + Drizzle local-first database with a real `data_connection` table.
+- A small Hono API at `apps/workbench/server/` that the frontend talks to over
+  `/api`.
+- A connection setup flow: list, create, test (CapabilityStatement probe),
+  delete.
 
 The patient search, typed FHIR tools, and patient-summary agent land in PRs
-2–6. See the root [`TASKS.md`](../../TASKS.md) for the full backlog.
+3–6. See the root [`TASKS.md`](../../TASKS.md) and
+[`docs/data-connections.md`](../../docs/data-connections.md) for details.
 
 ## Local setup
+
+The frontend (Vite, port 5174) and the API (Hono, port 5175) run as two
+processes. From the repo root, in two terminals:
 
 ```bash
 pnpm install
 pnpm --filter @fhir-place/workbench db:setup
-pnpm --filter @fhir-place/workbench dev
+pnpm --filter @fhir-place/workbench server   # terminal 1
+pnpm --filter @fhir-place/workbench dev      # terminal 2
 ```
 
-The dev server listens on `http://127.0.0.1:5174`. By default it runs against
-the public HAPI R4 sandbox; point it elsewhere with:
+Vite dev proxies `/api` to the Hono server. Override the API port with
+`WORKBENCH_PORT`:
 
 ```bash
-VITE_FHIR_BASE_URL=http://localhost:8080/fhir pnpm --filter @fhir-place/workbench dev
+WORKBENCH_PORT=6000 pnpm --filter @fhir-place/workbench server
+WORKBENCH_PORT=6000 pnpm --filter @fhir-place/workbench dev
 ```
+
+The SQLite file defaults to `apps/workbench/workbench.sqlite`; override with
+`WORKBENCH_DB_URL=/some/path.sqlite`.
 
 ## Scripts
 
 | Script | What it does |
 | --- | --- |
 | `dev` | Vite dev server on port 5174 |
+| `server` | Hono API on port 5175 (watch mode via tsx) |
+| `server:start` | Hono API on port 5175 (one-shot) |
 | `build` | Typecheck (frontend + node) and produce a production bundle |
 | `test` / `test:run` | Vitest |
 | `typecheck` | tsc on both `tsconfig.json` and `tsconfig.node.json` |
@@ -53,22 +64,30 @@ VITE_FHIR_BASE_URL=http://localhost:8080/fhir pnpm --filter @fhir-place/workbenc
 ```
 apps/workbench/
 ├── src/                 # Vite frontend (React)
+│   ├── api/             # fetch-based API client
 │   ├── components/      # presentational components
 │   ├── pages/           # route pages
 │   ├── App.tsx
 │   ├── main.tsx
 │   └── config.ts
+├── server/              # Node-only: Hono API
+│   ├── routes/          # /api/* handlers
+│   ├── services/        # store + FHIR probe
+│   ├── schemas.ts       # Zod input schemas (Phase A allow-list)
+│   ├── app.ts
+│   └── index.ts         # boots the server on WORKBENCH_PORT
 ├── db/                  # Node-only: SQLite + Drizzle schema and client
 │   ├── schema.ts
 │   ├── client.ts
 │   └── migrations/      # checked-in SQL migrations
 ├── scripts/             # Node-only CLI scripts (db:setup, etc.)
 ├── tsconfig.json        # frontend tsconfig (vite/client types)
-└── tsconfig.node.json   # node-only tsconfig (db, scripts, vite config)
+└── tsconfig.node.json   # node-only tsconfig (db, scripts, server, vite config)
 ```
 
-The `db/` and `scripts/` folders are deliberately node-only; the Vite frontend
-must not import them. The two-tsconfig split enforces that boundary.
+The `db/`, `server/`, and `scripts/` folders are deliberately node-only; the
+Vite frontend must not import them. The two-tsconfig split enforces that
+boundary.
 
 ## Phase A non-goals
 

--- a/apps/workbench/db/client.test.ts
+++ b/apps/workbench/db/client.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { readFileSync, readdirSync, mkdtempSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+import { openDb } from "./client.js";
+import { schemaVersion } from "./schema.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(here, "migrations");
+
+function applyMigrations(url: string) {
+  const sqlite = new Database(url);
+  for (const file of readdirSync(migrationsDir).filter((f) => f.endsWith(".sql")).sort()) {
+    sqlite.exec(readFileSync(join(migrationsDir, file), "utf8"));
+  }
+  sqlite.close();
+}
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length) {
+    const d = tempDirs.pop();
+    if (d) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("workbench db", () => {
+  it("applies migrations and round-trips a schema_version row through Drizzle", () => {
+    const dir = mkdtempSync(join(tmpdir(), "workbench-db-"));
+    tempDirs.push(dir);
+    const url = join(dir, "test.sqlite");
+
+    applyMigrations(url);
+
+    const db = openDb(url);
+    db.insert(schemaVersion).values({ version: 1, note: "phase-a skeleton" }).run();
+    const rows = db.select().from(schemaVersion).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.version).toBe(1);
+  });
+});

--- a/apps/workbench/db/client.ts
+++ b/apps/workbench/db/client.ts
@@ -1,0 +1,12 @@
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import * as schema from "./schema.js";
+
+export type WorkbenchDb = ReturnType<typeof openDb>;
+
+export function openDb(url: string = process.env.WORKBENCH_DB_URL ?? "./workbench.sqlite") {
+  const sqlite = new Database(url);
+  sqlite.pragma("journal_mode = WAL");
+  sqlite.pragma("foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}

--- a/apps/workbench/db/migrations/0000_initial.sql
+++ b/apps/workbench/db/migrations/0000_initial.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS `schema_version` (
+  `version` integer PRIMARY KEY NOT NULL,
+  `applied_at` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+  `note` text
+);

--- a/apps/workbench/db/migrations/0001_data_connection.sql
+++ b/apps/workbench/db/migrations/0001_data_connection.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS `data_connection` (
+  `id` text PRIMARY KEY NOT NULL,
+  `name` text NOT NULL,
+  `kind` text NOT NULL,
+  `base_url` text NOT NULL,
+  `auth_type` text NOT NULL,
+  `auth_token` text,
+  `created_at` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+  `updated_at` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+  `last_capability_at` text,
+  `last_capability_status` text,
+  `last_capability_fhir_version` text,
+  `last_capability_software` text,
+  `last_capability_json` text,
+  `last_capability_error` text
+);

--- a/apps/workbench/db/migrations/0002_agent_session.sql
+++ b/apps/workbench/db/migrations/0002_agent_session.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS `agent_session` (
+  `id` text PRIMARY KEY NOT NULL,
+  `connection_id` text NOT NULL REFERENCES `data_connection`(`id`) ON DELETE CASCADE,
+  `patient_id` text NOT NULL,
+  `created_at` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+  `updated_at` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL
+);
+CREATE INDEX IF NOT EXISTS `agent_session_connection_idx`
+  ON `agent_session` (`connection_id`);

--- a/apps/workbench/db/schema.ts
+++ b/apps/workbench/db/schema.ts
@@ -1,0 +1,19 @@
+import { sql } from "drizzle-orm";
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+/**
+ * Phase A skeleton schema. Tables are added incrementally:
+ *   PR 2  — `data_connection`            (FHIR DataConnection)
+ *   PR 7  — `agent_session`, `tool_call`, `evidence_claim` (Audit Logging)
+ *
+ * The single placeholder table here exists so `db:setup` has something to
+ * create and so the SQLite + Drizzle wiring is exercised end-to-end before
+ * real models land. It will be replaced — not extended — in PR 2.
+ */
+export const schemaVersion = sqliteTable("schema_version", {
+  version: integer("version").primaryKey(),
+  appliedAt: text("applied_at")
+    .notNull()
+    .default(sql`(CURRENT_TIMESTAMP)`),
+  note: text("note"),
+});

--- a/apps/workbench/db/schema.ts
+++ b/apps/workbench/db/schema.ts
@@ -48,3 +48,33 @@ export const dataConnection = sqliteTable("data_connection", {
 
 export type DataConnection = typeof dataConnection.$inferSelect;
 export type NewDataConnection = typeof dataConnection.$inferInsert;
+
+/**
+ * A patient-scoped agent session.
+ *
+ * Phase A's tool registry is patient-scoped and deny-by-default: a session
+ * carries exactly one authorized `patient_id` and the typed FHIR tools can
+ * only be invoked against that patient. A request whose body specifies a
+ * different `patientId` is rejected at the boundary with
+ * `reason: "unauthorized_patient"`.
+ *
+ * The patient-summary agent in PR 6 will run inside one session and can
+ * never widen its scope. Audit-log mapping (PR 7) treats this row as the
+ * `Provenance.target.subject` for every tool call made under it.
+ */
+export const agentSession = sqliteTable("agent_session", {
+  id: text("id").primaryKey(),
+  connectionId: text("connection_id")
+    .notNull()
+    .references(() => dataConnection.id, { onDelete: "cascade" }),
+  patientId: text("patient_id").notNull(),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(CURRENT_TIMESTAMP)`),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(CURRENT_TIMESTAMP)`),
+});
+
+export type AgentSession = typeof agentSession.$inferSelect;
+export type NewAgentSession = typeof agentSession.$inferInsert;

--- a/apps/workbench/db/schema.ts
+++ b/apps/workbench/db/schema.ts
@@ -2,13 +2,10 @@ import { sql } from "drizzle-orm";
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 
 /**
- * Phase A skeleton schema. Tables are added incrementally:
- *   PR 2  — `data_connection`            (FHIR DataConnection)
- *   PR 7  — `agent_session`, `tool_call`, `evidence_claim` (Audit Logging)
- *
- * The single placeholder table here exists so `db:setup` has something to
- * create and so the SQLite + Drizzle wiring is exercised end-to-end before
- * real models land. It will be replaced — not extended — in PR 2.
+ * Phase A schema — added incrementally:
+ *   PR 1  — `schema_version` placeholder (kept for now as a sanity row)
+ *   PR 2  — `data_connection`            (this file, this PR)
+ *   PR 7  — `agent_session`, `tool_call`, `evidence_claim`
  */
 export const schemaVersion = sqliteTable("schema_version", {
   version: integer("version").primaryKey(),
@@ -17,3 +14,37 @@ export const schemaVersion = sqliteTable("schema_version", {
     .default(sql`(CURRENT_TIMESTAMP)`),
   note: text("note"),
 });
+
+/**
+ * A configured FHIR server the workbench can read from.
+ *
+ * Phase A constraints (enforced at the application layer, not just the DB):
+ *   - `kind` is always `"fhir_clinical"`. No OMOP, claims, wearable, etc.
+ *   - `auth_type` is `"none"` or `"bearer"`. No SMART on FHIR.
+ *
+ * The latest CapabilityStatement is denormalised onto this row so the UI can
+ * render status without a join. History is out of scope for Phase A.
+ */
+export const dataConnection = sqliteTable("data_connection", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  kind: text("kind").notNull(),
+  baseUrl: text("base_url").notNull(),
+  authType: text("auth_type").notNull(),
+  authToken: text("auth_token"),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(CURRENT_TIMESTAMP)`),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(CURRENT_TIMESTAMP)`),
+  lastCapabilityAt: text("last_capability_at"),
+  lastCapabilityStatus: text("last_capability_status"),
+  lastCapabilityFhirVersion: text("last_capability_fhir_version"),
+  lastCapabilitySoftware: text("last_capability_software"),
+  lastCapabilityJson: text("last_capability_json"),
+  lastCapabilityError: text("last_capability_error"),
+});
+
+export type DataConnection = typeof dataConnection.$inferSelect;
+export type NewDataConnection = typeof dataConnection.$inferInsert;

--- a/apps/workbench/drizzle.config.ts
+++ b/apps/workbench/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "sqlite",
+  schema: "./db/schema.ts",
+  out: "./db/migrations",
+  dbCredentials: {
+    url: process.env.WORKBENCH_DB_URL ?? "./workbench.sqlite",
+  },
+});

--- a/apps/workbench/index.html
+++ b/apps/workbench/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>fhir-place · workbench (synthetic only)</title>
+    <meta name="theme-color" content="#fef3c7" />
+  </head>
+  <body class="bg-slate-50 text-slate-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/workbench/package.json
+++ b/apps/workbench/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "server": "tsx watch server/index.ts",
+    "server:start": "tsx server/index.ts",
     "build": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && vite build",
     "preview": "vite preview",
     "test": "vitest",
@@ -15,9 +17,11 @@
   },
   "dependencies": {
     "@fhir-place/react-fhir": "workspace:*",
+    "@hono/node-server": "^2.0.1",
     "@tanstack/react-query": "^5.62.0",
     "better-sqlite3": "^12.9.0",
     "drizzle-orm": "^0.45.2",
+    "hono": "^4.12.16",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.0.0",

--- a/apps/workbench/package.json
+++ b/apps/workbench/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@fhir-place/workbench",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && vite build",
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit",
+    "db:setup": "tsx scripts/db-setup.ts",
+    "db:generate": "drizzle-kit generate"
+  },
+  "dependencies": {
+    "@fhir-place/react-fhir": "workspace:*",
+    "@tanstack/react-query": "^5.62.0",
+    "better-sqlite3": "^12.9.0",
+    "drizzle-orm": "^0.45.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.0.0",
+    "zod": "^4.4.1"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/fhir": "^0.0.41",
+    "@types/node": "^22.10.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
+    "drizzle-kit": "^0.31.10",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vitest": "^2.1.8"
+  }
+}

--- a/apps/workbench/postcss.config.js
+++ b/apps/workbench/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/workbench/scripts/db-setup.ts
+++ b/apps/workbench/scripts/db-setup.ts
@@ -1,0 +1,29 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(here, "..", "db", "migrations");
+
+function run() {
+  const url = process.env.WORKBENCH_DB_URL ?? "./workbench.sqlite";
+  const db = new Database(url);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+
+  const files = readdirSync(migrationsDir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+
+  for (const file of files) {
+    const sql = readFileSync(join(migrationsDir, file), "utf8");
+    db.exec(sql);
+    console.log(`applied ${file}`);
+  }
+
+  db.close();
+  console.log(`workbench db ready at ${url}`);
+}
+
+run();

--- a/apps/workbench/server/agent/envelope.ts
+++ b/apps/workbench/server/agent/envelope.ts
@@ -1,0 +1,59 @@
+/**
+ * Normalized envelope for every tool call. The runner produces this; tools
+ * never construct it themselves. Anything the agent or a frontend consumes
+ * comes through here so error reasons are machine-readable.
+ */
+
+export type ToolEnvelope<T = unknown> = ToolEnvelopeOk<T> | ToolEnvelopeErr;
+
+export interface ToolEnvelopeOk<T = unknown> {
+  ok: true;
+  tool: string;
+  toolVersion: string;
+  data: T;
+  /** For searches: how many resources were returned in `data`. */
+  count?: number;
+  /** True when the upstream returned more than `resultLimit` and we sliced. */
+  truncated?: boolean;
+  durationMs: number;
+}
+
+export type ToolErrorReason =
+  | "unknown_tool"
+  | "invalid_input"
+  | "session_not_found"
+  | "connection_not_found"
+  | "unauthorized_patient"
+  | "upstream_error"
+  | "timeout"
+  | "internal_error";
+
+export interface ToolEnvelopeErr {
+  ok: false;
+  tool: string;
+  toolVersion: string;
+  error: string;
+  reason: ToolErrorReason;
+  /** For invalid_input: the structured Zod issue list. */
+  issues?: unknown;
+  /** For upstream_error: the upstream FHIR body, when present. */
+  upstream?: unknown;
+  durationMs: number;
+}
+
+export function ok<T>(
+  meta: { tool: string; toolVersion: string; durationMs: number },
+  data: T,
+  extra: Pick<ToolEnvelopeOk<T>, "count" | "truncated"> = {},
+): ToolEnvelopeOk<T> {
+  return { ok: true, ...meta, data, ...extra };
+}
+
+export function err(
+  meta: { tool: string; toolVersion: string; durationMs: number },
+  reason: ToolErrorReason,
+  error: string,
+  extra: Pick<ToolEnvelopeErr, "issues" | "upstream"> = {},
+): ToolEnvelopeErr {
+  return { ok: false, ...meta, reason, error, ...extra };
+}

--- a/apps/workbench/server/agent/registry.test.ts
+++ b/apps/workbench/server/agent/registry.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import type { AgentSession, DataConnection } from "../../db/schema.js";
+import { createRegistry, PatientIdField, type ToolDef } from "./registry.js";
+import { inMemoryLogger } from "./tool-log.js";
+
+const SESSION: AgentSession = {
+  id: "sess_1",
+  connectionId: "conn_1",
+  patientId: "pat-1",
+  createdAt: "2026-04-30T00:00:00.000Z",
+  updatedAt: "2026-04-30T00:00:00.000Z",
+};
+
+const CONNECTION: DataConnection = {
+  id: "conn_1",
+  name: "test",
+  kind: "fhir_clinical",
+  baseUrl: "https://upstream.test/fhir",
+  authType: "none",
+  authToken: null,
+  createdAt: "2026-04-30T00:00:00.000Z",
+  updatedAt: "2026-04-30T00:00:00.000Z",
+  lastCapabilityAt: null,
+  lastCapabilityStatus: null,
+  lastCapabilityFhirVersion: null,
+  lastCapabilitySoftware: null,
+  lastCapabilityJson: null,
+  lastCapabilityError: null,
+};
+
+function passthroughTool(): ToolDef<{ patientId: string }, { hello: string }> {
+  return {
+    name: "passthrough",
+    version: "1",
+    description: "test",
+    input: z.object({ patientId: PatientIdField }),
+    resourceAllowlist: ["Patient"],
+    resultLimit: 1,
+    timeoutMs: 1000,
+    async execute(_ctx, input) {
+      return { kind: "ok", data: { hello: input.patientId } };
+    },
+  };
+}
+
+describe("registry runner", () => {
+  it("returns unknown_tool when the name isn't registered", async () => {
+    const reg = createRegistry([passthroughTool()]);
+    const env = await reg.run({
+      toolName: "noSuchTool",
+      rawInput: { patientId: "pat-1" },
+      session: SESSION,
+      connection: CONNECTION,
+    });
+    expect(env.ok).toBe(false);
+    if (!env.ok) {
+      expect(env.reason).toBe("unknown_tool");
+      expect(env.tool).toBe("noSuchTool");
+    }
+  });
+
+  it("returns invalid_input with structured Zod issues", async () => {
+    const reg = createRegistry([passthroughTool()]);
+    const env = await reg.run({
+      toolName: "passthrough",
+      rawInput: { patientId: "" },
+      session: SESSION,
+      connection: CONNECTION,
+    });
+    expect(env.ok).toBe(false);
+    if (!env.ok) {
+      expect(env.reason).toBe("invalid_input");
+      expect(env.issues).toBeDefined();
+    }
+  });
+
+  it("returns unauthorized_patient when patientId disagrees with the session", async () => {
+    const reg = createRegistry([passthroughTool()]);
+    const env = await reg.run({
+      toolName: "passthrough",
+      rawInput: { patientId: "different-patient" },
+      session: SESSION,
+      connection: CONNECTION,
+    });
+    expect(env.ok).toBe(false);
+    if (!env.ok) expect(env.reason).toBe("unauthorized_patient");
+  });
+
+  it("invokes execute on the happy path and returns ok envelope with durationMs", async () => {
+    const reg = createRegistry([passthroughTool()]);
+    const env = await reg.run({
+      toolName: "passthrough",
+      rawInput: { patientId: "pat-1" },
+      session: SESSION,
+      connection: CONNECTION,
+    });
+    expect(env.ok).toBe(true);
+    if (env.ok) {
+      expect(env.tool).toBe("passthrough");
+      expect(env.toolVersion).toBe("1");
+      expect(env.data).toEqual({ hello: "pat-1" });
+      expect(typeof env.durationMs).toBe("number");
+    }
+  });
+
+  it("invokes the logger for both ok and error envelopes", async () => {
+    const reg = createRegistry([passthroughTool()]);
+    const logger = inMemoryLogger();
+
+    await reg.run({
+      toolName: "passthrough",
+      rawInput: { patientId: "pat-1" },
+      session: SESSION,
+      connection: CONNECTION,
+      logger,
+    });
+    await reg.run({
+      toolName: "noSuchTool",
+      rawInput: { patientId: "pat-1" },
+      session: SESSION,
+      connection: CONNECTION,
+      logger,
+    });
+
+    expect(logger.entries).toHaveLength(2);
+    expect(logger.entries[0]?.envelope.ok).toBe(true);
+    expect(logger.entries[1]?.envelope.ok).toBe(false);
+    expect(logger.entries[0]?.sessionId).toBe("sess_1");
+    expect(logger.entries[0]?.patientId).toBe("pat-1");
+  });
+
+  it("times out and returns reason: 'timeout' when execute exceeds timeoutMs", async () => {
+    const slow: ToolDef<{ patientId: string }, never> = {
+      name: "slow",
+      version: "1",
+      description: "test",
+      input: z.object({ patientId: PatientIdField }),
+      resourceAllowlist: ["Patient"],
+      resultLimit: 1,
+      timeoutMs: 30,
+      async execute(ctx) {
+        // Resolve when aborted; reject as AbortError otherwise
+        return new Promise((_resolve, reject) => {
+          ctx.signal.addEventListener("abort", () => {
+            const e = new Error("aborted");
+            e.name = "AbortError";
+            reject(e);
+          });
+        });
+      },
+    };
+    const reg = createRegistry([slow]);
+    const env = await reg.run({
+      toolName: "slow",
+      rawInput: { patientId: "pat-1" },
+      session: SESSION,
+      connection: CONNECTION,
+    });
+    expect(env.ok).toBe(false);
+    if (!env.ok) expect(env.reason).toBe("timeout");
+  });
+
+  it("truncates array data above resultLimit and sets truncated:true", async () => {
+    const overshoot: ToolDef<{ patientId: string }, number[]> = {
+      name: "overshoot",
+      version: "1",
+      description: "test",
+      input: z.object({ patientId: PatientIdField }),
+      resourceAllowlist: ["Patient"],
+      resultLimit: 3,
+      timeoutMs: 1000,
+      async execute() {
+        return { kind: "ok", data: [1, 2, 3, 4, 5] };
+      },
+    };
+    const reg = createRegistry([overshoot]);
+    const env = await reg.run({
+      toolName: "overshoot",
+      rawInput: { patientId: "pat-1" },
+      session: SESSION,
+      connection: CONNECTION,
+    });
+    expect(env.ok).toBe(true);
+    if (env.ok) {
+      expect(env.data).toEqual([1, 2, 3]);
+      expect(env.truncated).toBe(true);
+      expect(env.count).toBe(3);
+    }
+  });
+
+  it("rejects duplicate tool definitions at registry construction", () => {
+    const dup = passthroughTool();
+    expect(() => createRegistry([dup, dup])).toThrow(/duplicate/);
+  });
+
+  it("propagates upstream_error from execute as ok:false / reason:upstream_error", async () => {
+    const broken: ToolDef<{ patientId: string }, unknown> = {
+      name: "broken",
+      version: "1",
+      description: "test",
+      input: z.object({ patientId: PatientIdField }),
+      resourceAllowlist: ["Patient"],
+      resultLimit: 1,
+      timeoutMs: 1000,
+      async execute() {
+        return {
+          kind: "upstream_error",
+          message: "upstream HTTP 500",
+          upstream: { resourceType: "OperationOutcome" },
+        };
+      },
+    };
+    const reg = createRegistry([broken]);
+    const env = await reg.run({
+      toolName: "broken",
+      rawInput: { patientId: "pat-1" },
+      session: SESSION,
+      connection: CONNECTION,
+    });
+    expect(env.ok).toBe(false);
+    if (!env.ok) {
+      expect(env.reason).toBe("upstream_error");
+      expect(env.upstream).toMatchObject({ resourceType: "OperationOutcome" });
+    }
+  });
+
+  it("internal_error when execute throws a non-AbortError", async () => {
+    const explode: ToolDef<{ patientId: string }, never> = {
+      name: "explode",
+      version: "1",
+      description: "test",
+      input: z.object({ patientId: PatientIdField }),
+      resourceAllowlist: ["Patient"],
+      resultLimit: 1,
+      timeoutMs: 1000,
+      async execute() {
+        throw new Error("kaboom");
+      },
+    };
+    const reg = createRegistry([explode]);
+    const env = await reg.run({
+      toolName: "explode",
+      rawInput: { patientId: "pat-1" },
+      session: SESSION,
+      connection: CONNECTION,
+    });
+    expect(env.ok).toBe(false);
+    if (!env.ok) {
+      expect(env.reason).toBe("internal_error");
+      expect(env.error).toBe("kaboom");
+    }
+  });
+
+  it("never lets a logger throw break tool execution", async () => {
+    const reg = createRegistry([passthroughTool()]);
+    const flaky = {
+      record: vi.fn(() => {
+        throw new Error("logger explosion");
+      }),
+    };
+    const env = await reg.run({
+      toolName: "passthrough",
+      rawInput: { patientId: "pat-1" },
+      session: SESSION,
+      connection: CONNECTION,
+      logger: flaky,
+    });
+    expect(env.ok).toBe(true);
+    expect(flaky.record).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PatientIdField", () => {
+  it("requires a non-empty string", () => {
+    const schema = z.object({ patientId: PatientIdField });
+    expect(schema.safeParse({}).success).toBe(false);
+    expect(schema.safeParse({ patientId: "" }).success).toBe(false);
+    expect(schema.safeParse({ patientId: "ok" }).success).toBe(true);
+  });
+
+  it("can be combined with extra fields in a tool input", () => {
+    const schema = z.object({
+      patientId: PatientIdField,
+      limit: z.number().int(),
+    });
+    expect(schema.safeParse({ patientId: "p", limit: 5 }).success).toBe(true);
+  });
+});

--- a/apps/workbench/server/agent/registry.ts
+++ b/apps/workbench/server/agent/registry.ts
@@ -1,0 +1,228 @@
+import { z, type ZodIssue, type ZodTypeAny } from "zod";
+import type { DataConnection, AgentSession } from "../../db/schema.js";
+import type { ResourceType } from "../schemas.js";
+import {
+  err,
+  ok,
+  type ToolEnvelope,
+  type ToolEnvelopeOk,
+} from "./envelope.js";
+import type { ToolCallLogEntry, ToolLogger } from "./tool-log.js";
+
+/**
+ * Per-tool execution context. Tools never see the raw connection store or
+ * the DB — they get exactly the connection row and an injectable `fetch`.
+ */
+export interface ToolContext {
+  connection: DataConnection;
+  fetch: typeof fetch;
+  signal: AbortSignal;
+}
+
+export interface ToolDef<I extends { patientId: string }, O> {
+  name: string;
+  version: string;
+  description: string;
+  /**
+   * Zod schema for the tool's input. MUST contain a string `patientId`
+   * field — patient scope is enforced at the runner level by comparing
+   * `input.patientId` to the session's authorized patient.
+   */
+  input: ZodTypeAny;
+  /** FHIR resource types the tool reads. Sub-set of the proxy allow-list. */
+  resourceAllowlist: ReadonlyArray<ResourceType>;
+  /**
+   * Maximum number of resources the tool may return. The runner truncates
+   * if `execute` returns more, sets `envelope.truncated = true`, and never
+   * lets the upstream blow past this limit.
+   */
+  resultLimit: number;
+  timeoutMs: number;
+  execute: (
+    ctx: ToolContext,
+    input: I,
+  ) => Promise<ToolExecuteOutput<O>>;
+}
+
+export type ToolExecuteOutput<O> =
+  | { kind: "ok"; data: O; count?: number; truncated?: boolean }
+  | {
+      kind: "upstream_error";
+      message: string;
+      upstream?: unknown;
+    };
+
+export interface ToolRegistry {
+  list(): ReadonlyArray<{
+    name: string;
+    version: string;
+    description: string;
+    resourceAllowlist: ReadonlyArray<ResourceType>;
+    resultLimit: number;
+    timeoutMs: number;
+  }>;
+  has(name: string): boolean;
+  /** Registry lookup; not for external callers. */
+  get(name: string): ToolDef<{ patientId: string }, unknown> | null;
+  run(args: RunArgs): Promise<ToolEnvelope>;
+}
+
+export interface RunArgs {
+  toolName: string;
+  rawInput: unknown;
+  session: AgentSession;
+  connection: DataConnection;
+  fetchFn?: typeof fetch;
+  logger?: ToolLogger;
+}
+
+export function createRegistry(
+  defs: ReadonlyArray<ToolDef<{ patientId: string }, unknown>>,
+): ToolRegistry {
+  const byName = new Map<string, ToolDef<{ patientId: string }, unknown>>();
+  for (const d of defs) {
+    if (byName.has(d.name)) {
+      throw new Error(`duplicate tool definition: ${d.name}`);
+    }
+    byName.set(d.name, d);
+  }
+
+  return {
+    list() {
+      return [...byName.values()].map(({ execute: _e, input: _i, ...meta }) => meta);
+    },
+    has(name) {
+      return byName.has(name);
+    },
+    get(name) {
+      return byName.get(name) ?? null;
+    },
+    async run(args) {
+      const startedAt = new Date().toISOString();
+      const startMs = Date.now();
+      const def = byName.get(args.toolName);
+      const meta = {
+        tool: args.toolName,
+        toolVersion: def?.version ?? "0",
+      };
+
+      const finalize = (envelope: ToolEnvelope) => {
+        const completedAt = new Date().toISOString();
+        const entry: ToolCallLogEntry = {
+          sessionId: args.session.id,
+          connectionId: args.session.connectionId,
+          patientId: args.session.patientId,
+          tool: meta.tool,
+          toolVersion: meta.toolVersion,
+          input: args.rawInput,
+          envelope,
+          startedAt,
+          completedAt,
+        };
+        try {
+          args.logger?.record(entry);
+        } catch {
+          // logging never breaks tool execution
+        }
+        return envelope;
+      };
+
+      if (!def) {
+        return finalize(
+          err(
+            { ...meta, durationMs: Date.now() - startMs },
+            "unknown_tool",
+            `unknown tool: ${args.toolName}`,
+          ),
+        );
+      }
+
+      const parsed = def.input.safeParse(args.rawInput);
+      if (!parsed.success) {
+        return finalize(
+          err(
+            { ...meta, durationMs: Date.now() - startMs },
+            "invalid_input",
+            "invalid_input",
+            { issues: parsed.error.issues as ZodIssue[] },
+          ),
+        );
+      }
+      const input = parsed.data as { patientId: string };
+
+      if (input.patientId !== args.session.patientId) {
+        return finalize(
+          err(
+            { ...meta, durationMs: Date.now() - startMs },
+            "unauthorized_patient",
+            "patientId does not match the session's authorized patient",
+          ),
+        );
+      }
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), def.timeoutMs);
+      const ctx: ToolContext = {
+        connection: args.connection,
+        fetch: args.fetchFn ?? fetch,
+        signal: controller.signal,
+      };
+
+      try {
+        const result = await def.execute(ctx, input);
+        clearTimeout(timeout);
+        if (result.kind === "upstream_error") {
+          return finalize(
+            err(
+              { ...meta, durationMs: Date.now() - startMs },
+              "upstream_error",
+              result.message,
+              { upstream: result.upstream },
+            ),
+          );
+        }
+
+        let data = result.data;
+        let count = result.count;
+        let truncated = result.truncated;
+        if (
+          Array.isArray(data) &&
+          (data as unknown[]).length > def.resultLimit
+        ) {
+          data = (data as unknown[]).slice(0, def.resultLimit) as typeof data;
+          count = def.resultLimit;
+          truncated = true;
+        }
+
+        const envelope: ToolEnvelopeOk = {
+          ok: true,
+          ...meta,
+          data,
+          ...(typeof count === "number" ? { count } : {}),
+          ...(typeof truncated === "boolean" ? { truncated } : {}),
+          durationMs: Date.now() - startMs,
+        };
+        return finalize(envelope);
+      } catch (error) {
+        clearTimeout(timeout);
+        const reason =
+          (error as { name?: string })?.name === "AbortError"
+            ? "timeout"
+            : "internal_error";
+        const message = error instanceof Error ? error.message : String(error);
+        return finalize(
+          err({ ...meta, durationMs: Date.now() - startMs }, reason, message),
+        );
+      }
+    },
+  };
+}
+
+/**
+ * The patient-id field every tool's input must accept. Tools build their
+ * input schema by intersecting/extending this base instead of importing a
+ * generic factory — keeping each tool's input shape concretely typed.
+ */
+export const PatientIdField = z.string().min(1).max(64);
+
+export const PatientScopedBase = z.object({ patientId: PatientIdField });

--- a/apps/workbench/server/agent/tool-log.ts
+++ b/apps/workbench/server/agent/tool-log.ts
@@ -1,0 +1,55 @@
+import type { ToolEnvelope } from "./envelope.js";
+
+export interface ToolCallLogEntry {
+  sessionId: string;
+  connectionId: string;
+  patientId: string;
+  tool: string;
+  toolVersion: string;
+  input: unknown;
+  envelope: ToolEnvelope;
+  startedAt: string;
+  completedAt: string;
+}
+
+/**
+ * The registry calls `record()` after every tool execution, regardless of
+ * success or failure. Phase A ships an in-memory implementation so PR 4's
+ * tests can assert on the log without persistence; PR 7 will swap in a
+ * Drizzle-backed implementation that writes to a `tool_call` table.
+ *
+ * Tools never call this themselves — the runner is the single chokepoint.
+ */
+export interface ToolLogger {
+  record(entry: ToolCallLogEntry): void | Promise<void>;
+}
+
+export function inMemoryLogger(): ToolLogger & {
+  entries: ReadonlyArray<ToolCallLogEntry>;
+  clear(): void;
+} {
+  const entries: ToolCallLogEntry[] = [];
+  return {
+    entries,
+    clear() {
+      entries.length = 0;
+    },
+    record(entry) {
+      entries.push(entry);
+    },
+  };
+}
+
+export function consoleLogger(): ToolLogger {
+  return {
+    record(entry) {
+      const tag = entry.envelope.ok ? "ok" : `err(${entry.envelope.reason})`;
+      // eslint-disable-next-line no-console
+      console.log(
+        `[tool] ${entry.tool}@${entry.toolVersion} ${tag} ` +
+          `session=${entry.sessionId} patient=${entry.patientId} ` +
+          `${entry.envelope.durationMs}ms`,
+      );
+    },
+  };
+}

--- a/apps/workbench/server/agent/tools/_shared.ts
+++ b/apps/workbench/server/agent/tools/_shared.ts
@@ -1,0 +1,124 @@
+import { z } from "zod";
+import type { Bundle, Resource } from "fhir/r4";
+import {
+  proxyRead,
+  proxySearch,
+  type ProxyResult,
+} from "../../services/fhir-proxy.js";
+import type { ResourceType } from "../../schemas.js";
+import type { ToolContext, ToolExecuteOutput } from "../registry.js";
+
+export const dateRangeSchema = z
+  .object({
+    from: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "expected YYYY-MM-DD")
+      .optional(),
+    to: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "expected YYYY-MM-DD")
+      .optional(),
+  })
+  .strict();
+
+export type DateRange = z.infer<typeof dateRangeSchema>;
+
+/** Append `date=geYYYY-MM-DD` and `date=leYYYY-MM-DD` for a date range. */
+export function appendDateRange(
+  params: URLSearchParams,
+  range: DateRange | undefined,
+  paramName = "date",
+): void {
+  if (!range) return;
+  if (range.from) params.append(paramName, `ge${range.from}`);
+  if (range.to) params.append(paramName, `le${range.to}`);
+}
+
+/** Default and clamped result limit. */
+export const DEFAULT_LIMIT = 20;
+export const MAX_LIMIT = 50;
+export const limitSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(MAX_LIMIT)
+  .optional();
+
+export function clampLimit(input: number | undefined): number {
+  if (typeof input !== "number" || !Number.isFinite(input)) return DEFAULT_LIMIT;
+  return Math.min(Math.max(1, Math.floor(input)), MAX_LIMIT);
+}
+
+/** Convert a Bundle into an array of resources, dropping entries without one. */
+export function entriesOf<T extends Resource>(bundle: Bundle | undefined): T[] {
+  return (
+    bundle?.entry
+      ?.map((e) => e.resource as T | undefined)
+      .filter((r): r is T => Boolean(r)) ?? []
+  );
+}
+
+/** Run a search via the proxy, return the resources or an upstream-error envelope. */
+export async function runPatientSearch<T extends Resource>(
+  ctx: ToolContext,
+  resourceType: ResourceType,
+  patientId: string,
+  extra: URLSearchParams,
+  limit: number,
+): Promise<ToolExecuteOutput<T[]>> {
+  const params = new URLSearchParams(extra);
+  params.set("patient", `Patient/${patientId}`);
+  params.set("_count", String(limit));
+  const result = await proxySearch(
+    ctx.connection,
+    resourceType,
+    params,
+    ctx.fetch,
+    ctx.signal,
+  );
+  return mapBundleResult<T>(result, limit);
+}
+
+export async function runRead<T extends Resource>(
+  ctx: ToolContext,
+  resourceType: ResourceType,
+  resourceId: string,
+): Promise<ToolExecuteOutput<T | null>> {
+  const result: ProxyResult = await proxyRead(
+    ctx.connection,
+    resourceType,
+    resourceId,
+    ctx.fetch,
+    ctx.signal,
+  );
+  if (!result.ok) {
+    return {
+      kind: "upstream_error",
+      message: result.error,
+      upstream: result.body,
+    };
+  }
+  return { kind: "ok", data: result.body as T };
+}
+
+function mapBundleResult<T extends Resource>(
+  result: ProxyResult,
+  limit: number,
+): ToolExecuteOutput<T[]> {
+  if (!result.ok) {
+    return {
+      kind: "upstream_error",
+      message: result.error,
+      upstream: result.body,
+    };
+  }
+  const bundle = result.body as Bundle | undefined;
+  const items = entriesOf<T>(bundle);
+  const truncated = items.length >= limit;
+  return {
+    kind: "ok",
+    data: items,
+    count: items.length,
+    truncated,
+  };
+}

--- a/apps/workbench/server/agent/tools/get-patient.ts
+++ b/apps/workbench/server/agent/tools/get-patient.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import type { Patient } from "fhir/r4";
+import { PatientIdField, type ToolDef } from "../registry.js";
+import { runRead } from "./_shared.js";
+
+export const GetPatientInput = z.object({ patientId: PatientIdField });
+export type GetPatientInput = z.infer<typeof GetPatientInput>;
+
+export const getPatient: ToolDef<GetPatientInput, Patient | null> = {
+  name: "getPatient",
+  version: "1",
+  description: "Read the Patient resource for the session's authorized patient.",
+  input: GetPatientInput,
+  resourceAllowlist: ["Patient"],
+  resultLimit: 1,
+  timeoutMs: 10_000,
+  async execute(ctx, input) {
+    return runRead<Patient>(ctx, "Patient", input.patientId);
+  },
+};

--- a/apps/workbench/server/agent/tools/index.ts
+++ b/apps/workbench/server/agent/tools/index.ts
@@ -1,0 +1,31 @@
+import { createRegistry, type ToolDef } from "../registry.js";
+import { getPatient } from "./get-patient.js";
+import { searchConditionsForPatient } from "./search-conditions.js";
+import { searchMedicationRequestsForPatient } from "./search-medication-requests.js";
+import { searchAllergyIntolerancesForPatient } from "./search-allergy-intolerances.js";
+import { searchEncountersForPatient } from "./search-encounters.js";
+import { searchObservationsForPatient } from "./search-observations.js";
+
+export const PHASE_A_TOOLS: ReadonlyArray<
+  ToolDef<{ patientId: string }, unknown>
+> = [
+  getPatient as ToolDef<{ patientId: string }, unknown>,
+  searchConditionsForPatient as ToolDef<{ patientId: string }, unknown>,
+  searchMedicationRequestsForPatient as ToolDef<{ patientId: string }, unknown>,
+  searchAllergyIntolerancesForPatient as ToolDef<{ patientId: string }, unknown>,
+  searchEncountersForPatient as ToolDef<{ patientId: string }, unknown>,
+  searchObservationsForPatient as ToolDef<{ patientId: string }, unknown>,
+];
+
+export function createPhaseATools() {
+  return createRegistry(PHASE_A_TOOLS);
+}
+
+export {
+  getPatient,
+  searchConditionsForPatient,
+  searchMedicationRequestsForPatient,
+  searchAllergyIntolerancesForPatient,
+  searchEncountersForPatient,
+  searchObservationsForPatient,
+};

--- a/apps/workbench/server/agent/tools/search-allergy-intolerances.ts
+++ b/apps/workbench/server/agent/tools/search-allergy-intolerances.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import type { AllergyIntolerance } from "fhir/r4";
+import { PatientIdField, type ToolDef } from "../registry.js";
+import { clampLimit, limitSchema, runPatientSearch } from "./_shared.js";
+
+export const SearchAllergyIntolerancesInput = z.object({
+  patientId: PatientIdField,
+  limit: limitSchema,
+});
+export type SearchAllergyIntolerancesInput = z.infer<
+  typeof SearchAllergyIntolerancesInput
+>;
+
+export const searchAllergyIntolerancesForPatient: ToolDef<
+  SearchAllergyIntolerancesInput,
+  AllergyIntolerance[]
+> = {
+  name: "searchAllergyIntolerancesForPatient",
+  version: "1",
+  description:
+    "Search AllergyIntolerance resources for the session's authorized patient. " +
+    "Returns the raw resources; an empty array means 'no allergy data found' " +
+    "and must NOT be summarised as 'no known allergies'.",
+  input: SearchAllergyIntolerancesInput,
+  resourceAllowlist: ["AllergyIntolerance"],
+  resultLimit: 50,
+  timeoutMs: 15_000,
+  async execute(ctx, input) {
+    const limit = clampLimit(input.limit);
+    return runPatientSearch<AllergyIntolerance>(
+      ctx,
+      "AllergyIntolerance",
+      input.patientId,
+      new URLSearchParams(),
+      limit,
+    );
+  },
+};

--- a/apps/workbench/server/agent/tools/search-conditions.ts
+++ b/apps/workbench/server/agent/tools/search-conditions.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { Condition } from "fhir/r4";
+import { PatientIdField, type ToolDef } from "../registry.js";
+import { clampLimit, limitSchema, runPatientSearch } from "./_shared.js";
+
+export const ClinicalStatus = z.enum([
+  "active",
+  "recurrence",
+  "relapse",
+  "inactive",
+  "remission",
+  "resolved",
+]);
+export type ClinicalStatus = z.infer<typeof ClinicalStatus>;
+
+export const SearchConditionsInput = z.object({
+  patientId: PatientIdField,
+  clinicalStatus: ClinicalStatus.optional(),
+  limit: limitSchema,
+});
+export type SearchConditionsInput = z.infer<typeof SearchConditionsInput>;
+
+export const searchConditionsForPatient: ToolDef<
+  SearchConditionsInput,
+  Condition[]
+> = {
+  name: "searchConditionsForPatient",
+  version: "1",
+  description:
+    "Search Condition resources for the session's authorized patient. " +
+    "Optional `clinicalStatus` narrows by FHIR clinical-status code.",
+  input: SearchConditionsInput,
+  resourceAllowlist: ["Condition"],
+  resultLimit: 50,
+  timeoutMs: 15_000,
+  async execute(ctx, input) {
+    const limit = clampLimit(input.limit);
+    const params = new URLSearchParams();
+    if (input.clinicalStatus) params.set("clinical-status", input.clinicalStatus);
+    return runPatientSearch<Condition>(
+      ctx,
+      "Condition",
+      input.patientId,
+      params,
+      limit,
+    );
+  },
+};

--- a/apps/workbench/server/agent/tools/search-encounters.ts
+++ b/apps/workbench/server/agent/tools/search-encounters.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import type { Encounter } from "fhir/r4";
+import { PatientIdField, type ToolDef } from "../registry.js";
+import {
+  appendDateRange,
+  clampLimit,
+  dateRangeSchema,
+  limitSchema,
+  runPatientSearch,
+} from "./_shared.js";
+
+export const SearchEncountersInput = z.object({
+  patientId: PatientIdField,
+  dateRange: dateRangeSchema.optional(),
+  limit: limitSchema,
+});
+export type SearchEncountersInput = z.infer<typeof SearchEncountersInput>;
+
+export const searchEncountersForPatient: ToolDef<
+  SearchEncountersInput,
+  Encounter[]
+> = {
+  name: "searchEncountersForPatient",
+  version: "1",
+  description:
+    "Search Encounter resources for the session's authorized patient. " +
+    "Optional `dateRange` { from, to } narrows by encounter date.",
+  input: SearchEncountersInput,
+  resourceAllowlist: ["Encounter"],
+  resultLimit: 50,
+  timeoutMs: 15_000,
+  async execute(ctx, input) {
+    const limit = clampLimit(input.limit);
+    const params = new URLSearchParams();
+    appendDateRange(params, input.dateRange, "date");
+    return runPatientSearch<Encounter>(
+      ctx,
+      "Encounter",
+      input.patientId,
+      params,
+      limit,
+    );
+  },
+};

--- a/apps/workbench/server/agent/tools/search-medication-requests.ts
+++ b/apps/workbench/server/agent/tools/search-medication-requests.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import type { MedicationRequest } from "fhir/r4";
+import { PatientIdField, type ToolDef } from "../registry.js";
+import { clampLimit, limitSchema, runPatientSearch } from "./_shared.js";
+
+export const MedicationRequestStatus = z.enum([
+  "active",
+  "on-hold",
+  "cancelled",
+  "completed",
+  "entered-in-error",
+  "stopped",
+  "draft",
+  "unknown",
+]);
+export type MedicationRequestStatus = z.infer<typeof MedicationRequestStatus>;
+
+export const SearchMedicationRequestsInput = z.object({
+  patientId: PatientIdField,
+  status: MedicationRequestStatus.optional(),
+  limit: limitSchema,
+});
+export type SearchMedicationRequestsInput = z.infer<
+  typeof SearchMedicationRequestsInput
+>;
+
+export const searchMedicationRequestsForPatient: ToolDef<
+  SearchMedicationRequestsInput,
+  MedicationRequest[]
+> = {
+  name: "searchMedicationRequestsForPatient",
+  version: "1",
+  description:
+    "Search MedicationRequest resources for the session's authorized patient. " +
+    "Optional `status` narrows by FHIR medication-request status.",
+  input: SearchMedicationRequestsInput,
+  resourceAllowlist: ["MedicationRequest"],
+  resultLimit: 50,
+  timeoutMs: 15_000,
+  async execute(ctx, input) {
+    const limit = clampLimit(input.limit);
+    const params = new URLSearchParams();
+    if (input.status) params.set("status", input.status);
+    return runPatientSearch<MedicationRequest>(
+      ctx,
+      "MedicationRequest",
+      input.patientId,
+      params,
+      limit,
+    );
+  },
+};

--- a/apps/workbench/server/agent/tools/search-observations.ts
+++ b/apps/workbench/server/agent/tools/search-observations.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import type { Observation } from "fhir/r4";
+import { PatientIdField, type ToolDef } from "../registry.js";
+import {
+  appendDateRange,
+  clampLimit,
+  dateRangeSchema,
+  limitSchema,
+  runPatientSearch,
+} from "./_shared.js";
+
+/**
+ * USCDI / common Observation categories. The allow-list is conservative on
+ * purpose — anything outside it (e.g. `survey`, `imaging`, `procedure`) is
+ * rejected at the input boundary.
+ */
+export const ObservationCategory = z.enum([
+  "vital-signs",
+  "laboratory",
+  "social-history",
+  "exam",
+  "therapy",
+  "activity",
+]);
+export type ObservationCategory = z.infer<typeof ObservationCategory>;
+
+export const SearchObservationsInput = z.object({
+  patientId: PatientIdField,
+  category: ObservationCategory.optional(),
+  dateRange: dateRangeSchema.optional(),
+  limit: limitSchema,
+});
+export type SearchObservationsInput = z.infer<typeof SearchObservationsInput>;
+
+export const searchObservationsForPatient: ToolDef<
+  SearchObservationsInput,
+  Observation[]
+> = {
+  name: "searchObservationsForPatient",
+  version: "1",
+  description:
+    "Search Observation resources for the session's authorized patient. " +
+    "Optional `category` narrows by observation category code; optional " +
+    "`dateRange` { from, to } narrows by effective date.",
+  input: SearchObservationsInput,
+  resourceAllowlist: ["Observation"],
+  resultLimit: 50,
+  timeoutMs: 15_000,
+  async execute(ctx, input) {
+    const limit = clampLimit(input.limit);
+    const params = new URLSearchParams();
+    if (input.category) params.set("category", input.category);
+    appendDateRange(params, input.dateRange, "date");
+    return runPatientSearch<Observation>(
+      ctx,
+      "Observation",
+      input.patientId,
+      params,
+      limit,
+    );
+  },
+};

--- a/apps/workbench/server/agent/tools/tools.test.ts
+++ b/apps/workbench/server/agent/tools/tools.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from "vitest";
+import type { AgentSession, DataConnection } from "../../../db/schema.js";
+import { createRegistry } from "../registry.js";
+import { inMemoryLogger } from "../tool-log.js";
+import {
+  getPatient,
+  searchAllergyIntolerancesForPatient,
+  searchConditionsForPatient,
+  searchEncountersForPatient,
+  searchMedicationRequestsForPatient,
+  searchObservationsForPatient,
+} from "./index.js";
+
+const SESSION: AgentSession = {
+  id: "sess_1",
+  connectionId: "conn_1",
+  patientId: "pat-1",
+  createdAt: "2026-04-30T00:00:00.000Z",
+  updatedAt: "2026-04-30T00:00:00.000Z",
+};
+
+const CONNECTION: DataConnection = {
+  id: "conn_1",
+  name: "test",
+  kind: "fhir_clinical",
+  baseUrl: "https://upstream.test/fhir",
+  authType: "bearer",
+  authToken: "secret-tok",
+  createdAt: "2026-04-30T00:00:00.000Z",
+  updatedAt: "2026-04-30T00:00:00.000Z",
+  lastCapabilityAt: null,
+  lastCapabilityStatus: null,
+  lastCapabilityFhirVersion: null,
+  lastCapabilitySoftware: null,
+  lastCapabilityJson: null,
+  lastCapabilityError: null,
+};
+
+interface FetchSpy {
+  fetch: typeof fetch;
+  urls: string[];
+  authHeaders: string[];
+}
+
+function fakeFetch(
+  responder: (url: string) => unknown,
+  status = 200,
+): FetchSpy {
+  const urls: string[] = [];
+  const authHeaders: string[] = [];
+  const fetchFn: typeof fetch = async (input, init) => {
+    urls.push(String(input));
+    authHeaders.push(new Headers(init?.headers).get("Authorization") ?? "");
+    const body = responder(String(input));
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/fhir+json" },
+    });
+  };
+  return { fetch: fetchFn, urls, authHeaders };
+}
+
+function patientBundle(...resources: unknown[]) {
+  return {
+    resourceType: "Bundle",
+    type: "searchset",
+    entry: resources.map((resource) => ({ resource })),
+  };
+}
+
+describe("getPatient", () => {
+  it("reads /Patient/:id and returns the resource", async () => {
+    const spy = fakeFetch(() => ({
+      resourceType: "Patient",
+      id: "pat-1",
+      gender: "female",
+    }));
+    const reg = createRegistry([
+      getPatient as Parameters<typeof createRegistry>[0][number],
+    ]);
+    const env = await reg.run({
+      toolName: "getPatient",
+      rawInput: { patientId: "pat-1" },
+      session: SESSION,
+      connection: CONNECTION,
+      fetchFn: spy.fetch,
+    });
+    expect(env.ok).toBe(true);
+    if (env.ok)
+      expect(env.data).toMatchObject({ resourceType: "Patient", id: "pat-1" });
+    expect(spy.urls).toEqual(["https://upstream.test/fhir/Patient/pat-1"]);
+    expect(spy.authHeaders).toEqual(["Bearer secret-tok"]);
+  });
+});
+
+describe("searchConditionsForPatient", () => {
+  it("forwards patient + clinical-status and unwraps the Bundle", async () => {
+    const spy = fakeFetch(() =>
+      patientBundle(
+        { resourceType: "Condition", id: "c1", clinicalStatus: { coding: [{ code: "active" }] } },
+        { resourceType: "Condition", id: "c2" },
+      ),
+    );
+    const reg = createRegistry([
+      searchConditionsForPatient as Parameters<typeof createRegistry>[0][number],
+    ]);
+    const env = await reg.run({
+      toolName: "searchConditionsForPatient",
+      rawInput: { patientId: "pat-1", clinicalStatus: "active", limit: 50 },
+      session: SESSION,
+      connection: CONNECTION,
+      fetchFn: spy.fetch,
+    });
+    expect(env.ok).toBe(true);
+    if (env.ok) {
+      expect(env.data).toHaveLength(2);
+      expect(env.count).toBe(2);
+    }
+    expect(spy.urls[0]).toContain("/Condition?");
+    expect(spy.urls[0]).toContain("patient=Patient%2Fpat-1");
+    expect(spy.urls[0]).toContain("clinical-status=active");
+    expect(spy.urls[0]).toContain("_count=50");
+  });
+
+  it("rejects an unknown clinicalStatus at the input boundary", async () => {
+    const reg = createRegistry([
+      searchConditionsForPatient as Parameters<typeof createRegistry>[0][number],
+    ]);
+    const env = await reg.run({
+      toolName: "searchConditionsForPatient",
+      rawInput: { patientId: "pat-1", clinicalStatus: "indeterminate" },
+      session: SESSION,
+      connection: CONNECTION,
+    });
+    expect(env.ok).toBe(false);
+    if (!env.ok) expect(env.reason).toBe("invalid_input");
+  });
+
+  it("returns an empty array when the upstream returns zero entries (no inference)", async () => {
+    const spy = fakeFetch(() => ({
+      resourceType: "Bundle",
+      type: "searchset",
+      entry: [],
+    }));
+    const reg = createRegistry([
+      searchConditionsForPatient as Parameters<typeof createRegistry>[0][number],
+    ]);
+    const env = await reg.run({
+      toolName: "searchConditionsForPatient",
+      rawInput: { patientId: "pat-1" },
+      session: SESSION,
+      connection: CONNECTION,
+      fetchFn: spy.fetch,
+    });
+    expect(env.ok).toBe(true);
+    if (env.ok) {
+      expect(env.data).toEqual([]);
+      expect(env.count).toBe(0);
+    }
+  });
+});
+
+describe("searchMedicationRequestsForPatient", () => {
+  it("forwards status when supplied", async () => {
+    const spy = fakeFetch(() => patientBundle());
+    const reg = createRegistry([
+      searchMedicationRequestsForPatient as Parameters<typeof createRegistry>[0][number],
+    ]);
+    await reg.run({
+      toolName: "searchMedicationRequestsForPatient",
+      rawInput: { patientId: "pat-1", status: "active" },
+      session: SESSION,
+      connection: CONNECTION,
+      fetchFn: spy.fetch,
+    });
+    expect(spy.urls[0]).toContain("/MedicationRequest?");
+    expect(spy.urls[0]).toContain("status=active");
+  });
+
+  it("rejects an unsupported status value", async () => {
+    const reg = createRegistry([
+      searchMedicationRequestsForPatient as Parameters<typeof createRegistry>[0][number],
+    ]);
+    const env = await reg.run({
+      toolName: "searchMedicationRequestsForPatient",
+      rawInput: { patientId: "pat-1", status: "tentative" },
+      session: SESSION,
+      connection: CONNECTION,
+    });
+    expect(env.ok).toBe(false);
+    if (!env.ok) expect(env.reason).toBe("invalid_input");
+  });
+});
+
+describe("searchAllergyIntolerancesForPatient", () => {
+  it(
+    'returns an empty array (count: 0) when no allergies exist — must NOT be ' +
+      'summarised as "no known allergies" upstream of this tool',
+    async () => {
+      const spy = fakeFetch(() => patientBundle());
+      const reg = createRegistry([
+        searchAllergyIntolerancesForPatient as Parameters<typeof createRegistry>[0][number],
+      ]);
+      const env = await reg.run({
+        toolName: "searchAllergyIntolerancesForPatient",
+        rawInput: { patientId: "pat-1" },
+        session: SESSION,
+        connection: CONNECTION,
+        fetchFn: spy.fetch,
+      });
+      expect(env.ok).toBe(true);
+      if (env.ok) {
+        expect(env.data).toEqual([]);
+        expect(env.count).toBe(0);
+      }
+    },
+  );
+});
+
+describe("searchEncountersForPatient", () => {
+  it("forwards date range as ge/le query repeats", async () => {
+    const spy = fakeFetch(() => patientBundle());
+    const reg = createRegistry([
+      searchEncountersForPatient as Parameters<typeof createRegistry>[0][number],
+    ]);
+    await reg.run({
+      toolName: "searchEncountersForPatient",
+      rawInput: {
+        patientId: "pat-1",
+        dateRange: { from: "2024-01-01", to: "2024-12-31" },
+      },
+      session: SESSION,
+      connection: CONNECTION,
+      fetchFn: spy.fetch,
+    });
+    expect(spy.urls[0]).toContain("date=ge2024-01-01");
+    expect(spy.urls[0]).toContain("date=le2024-12-31");
+  });
+
+  it("rejects malformed dateRange.from", async () => {
+    const reg = createRegistry([
+      searchEncountersForPatient as Parameters<typeof createRegistry>[0][number],
+    ]);
+    const env = await reg.run({
+      toolName: "searchEncountersForPatient",
+      rawInput: { patientId: "pat-1", dateRange: { from: "yesterday" } },
+      session: SESSION,
+      connection: CONNECTION,
+    });
+    expect(env.ok).toBe(false);
+    if (!env.ok) expect(env.reason).toBe("invalid_input");
+  });
+});
+
+describe("searchObservationsForPatient", () => {
+  it("forwards category + dateRange together", async () => {
+    const spy = fakeFetch(() => patientBundle());
+    const reg = createRegistry([
+      searchObservationsForPatient as Parameters<typeof createRegistry>[0][number],
+    ]);
+    await reg.run({
+      toolName: "searchObservationsForPatient",
+      rawInput: {
+        patientId: "pat-1",
+        category: "laboratory",
+        dateRange: { from: "2024-09-01", to: "2024-12-01" },
+        limit: 10,
+      },
+      session: SESSION,
+      connection: CONNECTION,
+      fetchFn: spy.fetch,
+    });
+    expect(spy.urls[0]).toContain("/Observation?");
+    expect(spy.urls[0]).toContain("category=laboratory");
+    expect(spy.urls[0]).toContain("date=ge2024-09-01");
+    expect(spy.urls[0]).toContain("date=le2024-12-01");
+    expect(spy.urls[0]).toContain("_count=10");
+  });
+
+  it("rejects an unsupported category (e.g. 'survey')", async () => {
+    const reg = createRegistry([
+      searchObservationsForPatient as Parameters<typeof createRegistry>[0][number],
+    ]);
+    const env = await reg.run({
+      toolName: "searchObservationsForPatient",
+      rawInput: { patientId: "pat-1", category: "survey" },
+      session: SESSION,
+      connection: CONNECTION,
+    });
+    expect(env.ok).toBe(false);
+    if (!env.ok) expect(env.reason).toBe("invalid_input");
+  });
+});
+
+describe("end-to-end: registry + tools + logger", () => {
+  it("logs every tool call with shaped entries the audit log can persist later", async () => {
+    const spy = fakeFetch(() => ({ resourceType: "Patient", id: "pat-1" }));
+    const reg = createRegistry([
+      getPatient as Parameters<typeof createRegistry>[0][number],
+    ]);
+    const logger = inMemoryLogger();
+    await reg.run({
+      toolName: "getPatient",
+      rawInput: { patientId: "pat-1" },
+      session: SESSION,
+      connection: CONNECTION,
+      fetchFn: spy.fetch,
+      logger,
+    });
+    expect(logger.entries).toHaveLength(1);
+    const [entry] = logger.entries;
+    expect(entry?.tool).toBe("getPatient");
+    expect(entry?.toolVersion).toBe("1");
+    expect(entry?.sessionId).toBe("sess_1");
+    expect(entry?.patientId).toBe("pat-1");
+    expect(entry?.envelope.ok).toBe(true);
+  });
+});

--- a/apps/workbench/server/app.ts
+++ b/apps/workbench/server/app.ts
@@ -1,11 +1,18 @@
 import { Hono } from "hono";
 import type { ConnectionStore } from "./services/connection-store.js";
+import type { SessionStore } from "./services/session-store.js";
+import type { ToolRegistry } from "./agent/registry.js";
+import type { ToolLogger } from "./agent/tool-log.js";
 import { connectionsRoutes } from "./routes/connections.js";
 import { fhirRoutes } from "./routes/fhir.js";
+import { sessionsRoutes } from "./routes/sessions.js";
 
 export interface ServerDeps {
   connections: ConnectionStore;
+  sessions: SessionStore;
+  registry: ToolRegistry;
   fetchFn?: typeof fetch;
+  logger?: ToolLogger;
 }
 
 export function createApp(deps: ServerDeps) {
@@ -19,6 +26,16 @@ export function createApp(deps: ServerDeps) {
   app.route(
     "/api/connections/:cid/fhir",
     fhirRoutes({ store: deps.connections, fetchFn: deps.fetchFn }),
+  );
+  app.route(
+    "/api/sessions",
+    sessionsRoutes({
+      sessions: deps.sessions,
+      connections: deps.connections,
+      registry: deps.registry,
+      fetchFn: deps.fetchFn,
+      logger: deps.logger,
+    }),
   );
 
   return app;

--- a/apps/workbench/server/app.ts
+++ b/apps/workbench/server/app.ts
@@ -1,9 +1,11 @@
 import { Hono } from "hono";
 import type { ConnectionStore } from "./services/connection-store.js";
 import { connectionsRoutes } from "./routes/connections.js";
+import { fhirRoutes } from "./routes/fhir.js";
 
 export interface ServerDeps {
   connections: ConnectionStore;
+  fetchFn?: typeof fetch;
 }
 
 export function createApp(deps: ServerDeps) {
@@ -14,6 +16,10 @@ export function createApp(deps: ServerDeps) {
   );
 
   app.route("/api/connections", connectionsRoutes(deps.connections));
+  app.route(
+    "/api/connections/:cid/fhir",
+    fhirRoutes({ store: deps.connections, fetchFn: deps.fetchFn }),
+  );
 
   return app;
 }

--- a/apps/workbench/server/app.ts
+++ b/apps/workbench/server/app.ts
@@ -1,0 +1,19 @@
+import { Hono } from "hono";
+import type { ConnectionStore } from "./services/connection-store.js";
+import { connectionsRoutes } from "./routes/connections.js";
+
+export interface ServerDeps {
+  connections: ConnectionStore;
+}
+
+export function createApp(deps: ServerDeps) {
+  const app = new Hono();
+
+  app.get("/api/health", (c) =>
+    c.json({ ok: true, app: "fhir-place/workbench", phase: "A" }),
+  );
+
+  app.route("/api/connections", connectionsRoutes(deps.connections));
+
+  return app;
+}

--- a/apps/workbench/server/index.ts
+++ b/apps/workbench/server/index.ts
@@ -1,0 +1,13 @@
+import { serve } from "@hono/node-server";
+import { openDb } from "../db/client.js";
+import { createApp } from "./app.js";
+import { createConnectionStore } from "./services/connection-store.js";
+
+const port = Number(process.env.WORKBENCH_PORT ?? 5175);
+const db = openDb();
+const connections = createConnectionStore(db);
+const app = createApp({ connections });
+
+serve({ fetch: app.fetch, port }, (info) => {
+  console.log(`workbench server listening on http://127.0.0.1:${info.port}`);
+});

--- a/apps/workbench/server/index.ts
+++ b/apps/workbench/server/index.ts
@@ -2,11 +2,22 @@ import { serve } from "@hono/node-server";
 import { openDb } from "../db/client.js";
 import { createApp } from "./app.js";
 import { createConnectionStore } from "./services/connection-store.js";
+import { createSessionStore } from "./services/session-store.js";
+import { createPhaseATools } from "./agent/tools/index.js";
+import { consoleLogger } from "./agent/tool-log.js";
 
 const port = Number(process.env.WORKBENCH_PORT ?? 5175);
 const db = openDb();
 const connections = createConnectionStore(db);
-const app = createApp({ connections });
+const sessions = createSessionStore(db);
+const registry = createPhaseATools();
+
+const app = createApp({
+  connections,
+  sessions,
+  registry,
+  logger: consoleLogger(),
+});
 
 serve({ fetch: app.fetch, port }, (info) => {
   console.log(`workbench server listening on http://127.0.0.1:${info.port}`);

--- a/apps/workbench/server/routes/connections.test.ts
+++ b/apps/workbench/server/routes/connections.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { jsonResponse, makeTestApp } from "../test-utils.js";
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()?.();
+});
+
+function newApp(fetchFn?: typeof fetch) {
+  const t = makeTestApp({ fetchFn });
+  cleanups.push(t.cleanup);
+  return t;
+}
+
+describe("connections routes", () => {
+  it("lists empty initially", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ connections: [] });
+  });
+
+  it("creates a fhir_clinical / none connection and returns the row without authToken", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Local HAPI",
+        kind: "fhir_clinical",
+        baseUrl: "http://localhost:8080/fhir",
+        authType: "none",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.connection).toMatchObject({
+      id: "conn_0001",
+      name: "Local HAPI",
+      kind: "fhir_clinical",
+      baseUrl: "http://localhost:8080/fhir",
+      authType: "none",
+      hasAuthToken: false,
+    });
+    expect(body.connection.authToken).toBeUndefined();
+  });
+
+  it("rejects unsupported connection kind", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "OMOP",
+        kind: "omop",
+        baseUrl: "http://localhost:5432",
+        authType: "none",
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_input");
+  });
+
+  it("rejects unsupported auth type (e.g. SMART)", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Smart",
+        kind: "fhir_clinical",
+        baseUrl: "https://smart.example/fhir",
+        authType: "smart",
+        authToken: "x",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects bearer auth without a token", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "no-token",
+        kind: "fhir_clinical",
+        baseUrl: "https://example.test/fhir",
+        authType: "bearer",
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_input");
+  });
+
+  it("rejects none auth with a token (defensive)", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "weird",
+        kind: "fhir_clinical",
+        baseUrl: "https://example.test/fhir",
+        authType: "none",
+        authToken: "x",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("404s for an unknown id", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections/missing");
+    expect(res.status).toBe(404);
+  });
+
+  it("tests a connection: probes /metadata and persists the CapabilityStatement summary", async () => {
+    let probeUrl: string | undefined;
+    const fakeFetch: typeof fetch = async (input) => {
+      probeUrl = String(input);
+      return jsonResponse({
+        resourceType: "CapabilityStatement",
+        fhirVersion: "4.0.1",
+        software: { name: "HAPI", version: "8" },
+      });
+    };
+    const { app } = newApp(fakeFetch);
+
+    const create = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "HAPI",
+        kind: "fhir_clinical",
+        baseUrl: "https://hapi.example/fhir",
+        authType: "none",
+      }),
+    });
+    const { connection } = await create.json();
+
+    const test = await app.request(`/api/connections/${connection.id}/test`, {
+      method: "POST",
+    });
+    expect(test.status).toBe(200);
+    const body = await test.json();
+    expect(probeUrl).toBe("https://hapi.example/fhir/metadata");
+    expect(body.capability).toMatchObject({
+      ok: true,
+      fhirVersion: "4.0.1",
+      software: "HAPI 8",
+    });
+    expect(body.connection).toMatchObject({
+      lastCapabilityStatus: "ok",
+      lastCapabilityFhirVersion: "4.0.1",
+      lastCapabilitySoftware: "HAPI 8",
+    });
+    expect(body.connection.lastCapabilityJson).toContain("CapabilityStatement");
+  });
+
+  it("test() persists an error when /metadata fails", async () => {
+    const fakeFetch: typeof fetch = async () =>
+      new Response("denied", { status: 403, statusText: "Forbidden" });
+    const { app } = newApp(fakeFetch);
+
+    const create = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Locked",
+        kind: "fhir_clinical",
+        baseUrl: "https://locked.example/fhir",
+        authType: "bearer",
+        authToken: "wrong",
+      }),
+    });
+    const { connection } = await create.json();
+
+    const test = await app.request(`/api/connections/${connection.id}/test`, {
+      method: "POST",
+    });
+    expect(test.status).toBe(200);
+    const body = await test.json();
+    expect(body.capability).toEqual({ ok: false, error: "HTTP 403 Forbidden" });
+    expect(body.connection.lastCapabilityStatus).toBe("error");
+    expect(body.connection.lastCapabilityError).toBe("HTTP 403 Forbidden");
+  });
+
+  it("deletes a connection", async () => {
+    const { app } = newApp();
+    const create = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "tmp",
+        kind: "fhir_clinical",
+        baseUrl: "http://localhost:8080/fhir",
+        authType: "none",
+      }),
+    });
+    const { connection } = await create.json();
+
+    const del = await app.request(`/api/connections/${connection.id}`, {
+      method: "DELETE",
+    });
+    expect(del.status).toBe(204);
+
+    const check = await app.request(`/api/connections/${connection.id}`);
+    expect(check.status).toBe(404);
+  });
+
+  it("never returns the auth token in any response", async () => {
+    const { app } = newApp();
+    const create = await app.request("/api/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "secret",
+        kind: "fhir_clinical",
+        baseUrl: "https://example.test/fhir",
+        authType: "bearer",
+        authToken: "super-secret-token",
+      }),
+    });
+    const created = JSON.stringify(await create.json());
+    expect(created).not.toContain("super-secret-token");
+
+    const list = await app.request("/api/connections");
+    expect(JSON.stringify(await list.json())).not.toContain("super-secret-token");
+  });
+});

--- a/apps/workbench/server/routes/connections.ts
+++ b/apps/workbench/server/routes/connections.ts
@@ -1,0 +1,51 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { CreateConnectionInput } from "../schemas.js";
+import type { ConnectionStore } from "../services/connection-store.js";
+
+export function connectionsRoutes(store: ConnectionStore) {
+  const app = new Hono();
+
+  app.get("/", (c) => c.json({ connections: store.list() }));
+
+  app.post("/", async (c) => {
+    const body = await safeJson(c);
+    const parsed = CreateConnectionInput.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: "invalid_input", issues: parsed.error.issues }, 400);
+    }
+    const row = store.create(parsed.data);
+    return c.json({ connection: row }, 201);
+  });
+
+  app.get("/:id", (c) => {
+    const id = c.req.param("id");
+    const row = store.get(id);
+    if (!row) return c.json({ error: "not_found" }, 404);
+    return c.json({ connection: row });
+  });
+
+  app.post("/:id/test", async (c) => {
+    const id = c.req.param("id");
+    const out = await store.test(id);
+    if (!out) return c.json({ error: "not_found" }, 404);
+    return c.json({ connection: out.row, capability: out.result });
+  });
+
+  app.delete("/:id", (c) => {
+    const id = c.req.param("id");
+    const deleted = store.delete(id);
+    if (!deleted) return c.json({ error: "not_found" }, 404);
+    return c.body(null, 204);
+  });
+
+  return app;
+}
+
+async function safeJson(c: Context): Promise<unknown> {
+  try {
+    return await c.req.json();
+  } catch {
+    return null;
+  }
+}

--- a/apps/workbench/server/routes/fhir.test.ts
+++ b/apps/workbench/server/routes/fhir.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { jsonResponse, makeTestApp } from "../test-utils.js";
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()?.();
+});
+
+function newApp(fetchFn?: typeof fetch) {
+  const t = makeTestApp({ fetchFn });
+  cleanups.push(t.cleanup);
+  return t;
+}
+
+async function createConn(
+  app: ReturnType<typeof makeTestApp>["app"],
+  overrides: Partial<{
+    name: string;
+    baseUrl: string;
+    authType: "none" | "bearer";
+    authToken: string;
+  }> = {},
+) {
+  const res = await app.request("/api/connections", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: overrides.name ?? "test",
+      kind: "fhir_clinical",
+      baseUrl: overrides.baseUrl ?? "https://upstream.test/fhir",
+      authType: overrides.authType ?? "none",
+      ...(overrides.authToken ? { authToken: overrides.authToken } : {}),
+    }),
+  });
+  expect(res.status).toBe(201);
+  const body = await res.json();
+  return body.connection.id as string;
+}
+
+describe("/api/connections/:cid/fhir", () => {
+  it("forwards Patient search to the upstream and returns the Bundle", async () => {
+    let observedUrl = "";
+    let observedAuth = "";
+    const fakeFetch: typeof fetch = async (input, init) => {
+      observedUrl = String(input);
+      observedAuth = new Headers(init?.headers).get("Authorization") ?? "";
+      return jsonResponse({ resourceType: "Bundle", type: "searchset", entry: [] });
+    };
+    const { app } = newApp(fakeFetch);
+    const cid = await createConn(app, {
+      authType: "bearer",
+      authToken: "tok",
+    });
+
+    const res = await app.request(
+      `/api/connections/${cid}/fhir/Patient?name=Hopper`,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ resourceType: "Bundle" });
+    expect(observedUrl).toBe(
+      "https://upstream.test/fhir/Patient?name=Hopper&_count=20",
+    );
+    expect(observedAuth).toBe("Bearer tok");
+  });
+
+  it("returns 400 for a resource type outside the allow-list", async () => {
+    const { app } = newApp();
+    const cid = await createConn(app);
+    const res = await app.request(`/api/connections/${cid}/fhir/Procedure`);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("resource_type_not_allowed");
+    expect(body.allowed).toContain("Patient");
+  });
+
+  it("returns 404 when the connection does not exist", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/connections/missing/fhir/Patient");
+    expect(res.status).toBe(404);
+  });
+
+  it("never forwards disallowed search params upstream", async () => {
+    let observedUrl = "";
+    const fakeFetch: typeof fetch = async (input) => {
+      observedUrl = String(input);
+      return jsonResponse({ resourceType: "Bundle", entry: [] });
+    };
+    const { app } = newApp(fakeFetch);
+    const cid = await createConn(app);
+
+    const res = await app.request(
+      `/api/connections/${cid}/fhir/Patient?_include=Patient:link&name=Grace`,
+    );
+    expect(res.status).toBe(200);
+    expect(observedUrl).not.toContain("_include");
+    expect(observedUrl).toContain("name=Grace");
+  });
+
+  it("never returns the auth token in any response", async () => {
+    const { app } = newApp(async () =>
+      jsonResponse({ resourceType: "Bundle", entry: [] }),
+    );
+    const cid = await createConn(app, {
+      authType: "bearer",
+      authToken: "super-secret-2026",
+    });
+    const res = await app.request(`/api/connections/${cid}/fhir/Patient`);
+    expect(res.status).toBe(200);
+    expect(JSON.stringify(await res.json())).not.toContain("super-secret-2026");
+  });
+
+  it("reads a single resource by id (Patient/abc-123)", async () => {
+    let observedUrl = "";
+    const fakeFetch: typeof fetch = async (input) => {
+      observedUrl = String(input);
+      return jsonResponse({ resourceType: "Patient", id: "abc-123" });
+    };
+    const { app } = newApp(fakeFetch);
+    const cid = await createConn(app);
+    const res = await app.request(`/api/connections/${cid}/fhir/Patient/abc-123`);
+    expect(res.status).toBe(200);
+    expect(observedUrl).toBe("https://upstream.test/fhir/Patient/abc-123");
+  });
+
+  it("rejects POSTs to the proxy (Phase A is read-only)", async () => {
+    const { app } = newApp();
+    const cid = await createConn(app);
+    const res = await app.request(`/api/connections/${cid}/fhir/Patient`, {
+      method: "POST",
+      headers: { "Content-Type": "application/fhir+json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("propagates upstream non-2xx with status and body", async () => {
+    const fakeFetch: typeof fetch = async () =>
+      new Response(
+        JSON.stringify({
+          resourceType: "OperationOutcome",
+          issue: [{ severity: "error" }],
+        }),
+        { status: 401, headers: { "Content-Type": "application/fhir+json" } },
+      );
+    const { app } = newApp(fakeFetch);
+    const cid = await createConn(app);
+    const res = await app.request(`/api/connections/${cid}/fhir/Patient`);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/upstream HTTP 401/);
+    expect(body.body).toMatchObject({ resourceType: "OperationOutcome" });
+  });
+});

--- a/apps/workbench/server/routes/fhir.ts
+++ b/apps/workbench/server/routes/fhir.ts
@@ -1,0 +1,82 @@
+import { Hono } from "hono";
+import { ResourceType } from "../schemas.js";
+import type { ConnectionStore } from "../services/connection-store.js";
+import { proxyRead, proxySearch, type ProxyResult } from "../services/fhir-proxy.js";
+
+interface Deps {
+  store: ConnectionStore;
+  fetchFn?: typeof fetch;
+}
+
+/**
+ * Read-only FHIR proxy. Mounts at `/api/connections/:cid/fhir`.
+ *
+ *   GET /:resourceType            — forwarded search (allow-listed params only)
+ *   GET /:resourceType/:id        — single resource read
+ *
+ * Anything else (POST/PUT/PATCH/DELETE on this prefix) hits Hono's 404
+ * because Phase A is read-only. The connection's auth token never crosses
+ * this boundary either way — it only goes upstream as `Authorization`.
+ */
+export function fhirRoutes(deps: Deps) {
+  const app = new Hono();
+  const fetchFn = deps.fetchFn ?? fetch;
+
+  app.get("/:resourceType", async (c) => {
+    const cid = c.req.param("cid");
+    if (!cid) return jsonError(404, "connection_not_found");
+    const conn = deps.store.getInternal(cid);
+    if (!conn) return jsonError(404, "connection_not_found");
+
+    const rt = ResourceType.safeParse(c.req.param("resourceType"));
+    if (!rt.success) return resourceTypeError();
+
+    const params = new URLSearchParams();
+    for (const [k, v] of Object.entries(c.req.queries())) {
+      for (const value of v) params.append(k, value);
+    }
+
+    const result = await proxySearch(conn, rt.data, params, fetchFn);
+    return toResponse(result);
+  });
+
+  app.get("/:resourceType/:id", async (c) => {
+    const cid = c.req.param("cid");
+    const id = c.req.param("id");
+    if (!cid) return jsonError(404, "connection_not_found");
+    if (!id) return jsonError(400, "missing_id");
+    const conn = deps.store.getInternal(cid);
+    if (!conn) return jsonError(404, "connection_not_found");
+
+    const rt = ResourceType.safeParse(c.req.param("resourceType"));
+    if (!rt.success) return resourceTypeError();
+
+    const result = await proxyRead(conn, rt.data, id, fetchFn);
+    return toResponse(result);
+  });
+
+  return app;
+}
+
+function toResponse(result: ProxyResult): Response {
+  if (result.ok) return jsonBody(result.status, result.body);
+  return jsonBody(result.status, { error: result.error, body: result.body ?? null });
+}
+
+function jsonBody(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function jsonError(status: number, error: string): Response {
+  return jsonBody(status, { error });
+}
+
+function resourceTypeError(): Response {
+  return jsonBody(400, {
+    error: "resource_type_not_allowed",
+    allowed: ResourceType.options,
+  });
+}

--- a/apps/workbench/server/routes/sessions.test.ts
+++ b/apps/workbench/server/routes/sessions.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { jsonResponse, makeTestApp } from "../test-utils.js";
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()?.();
+});
+
+function newApp(fetchFn?: typeof fetch) {
+  const t = makeTestApp({ fetchFn });
+  cleanups.push(t.cleanup);
+  return t;
+}
+
+async function createConn(
+  app: ReturnType<typeof makeTestApp>["app"],
+  overrides: Partial<{
+    name: string;
+    baseUrl: string;
+    authType: "none" | "bearer";
+    authToken: string;
+  }> = {},
+) {
+  const res = await app.request("/api/connections", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: overrides.name ?? "test",
+      kind: "fhir_clinical",
+      baseUrl: overrides.baseUrl ?? "https://upstream.test/fhir",
+      authType: overrides.authType ?? "none",
+      ...(overrides.authToken ? { authToken: overrides.authToken } : {}),
+    }),
+  });
+  expect(res.status).toBe(201);
+  const body = await res.json();
+  return body.connection.id as string;
+}
+
+async function createSession(
+  app: ReturnType<typeof makeTestApp>["app"],
+  connectionId: string,
+  patientId: string,
+) {
+  const res = await app.request("/api/sessions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ connectionId, patientId }),
+  });
+  expect(res.status).toBe(201);
+  const body = await res.json();
+  return body.session.id as string;
+}
+
+describe("/api/sessions", () => {
+  it("creates a session bound to a connection + patient", async () => {
+    const { app } = newApp();
+    const cid = await createConn(app);
+    const res = await app.request("/api/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ connectionId: cid, patientId: "pat-1" }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.session).toMatchObject({
+      connectionId: cid,
+      patientId: "pat-1",
+    });
+  });
+
+  it("rejects an invalid FHIR id at the boundary", async () => {
+    const { app } = newApp();
+    const cid = await createConn(app);
+    const res = await app.request("/api/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ connectionId: cid, patientId: "../bad" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when creating against an unknown connection", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ connectionId: "nope", patientId: "pat-1" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("lists registered tools at /api/sessions/tools", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/sessions/tools");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const names = body.tools.map((t: { name: string }) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "getPatient",
+        "searchConditionsForPatient",
+        "searchMedicationRequestsForPatient",
+        "searchAllergyIntolerancesForPatient",
+        "searchEncountersForPatient",
+        "searchObservationsForPatient",
+      ]),
+    );
+  });
+});
+
+describe("POST /api/sessions/:sid/tools/:toolName", () => {
+  it("invokes a tool and returns the envelope on success (HTTP 200)", async () => {
+    const { app } = newApp(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/Patient/pat-1")) {
+        return jsonResponse({ resourceType: "Patient", id: "pat-1" });
+      }
+      return jsonResponse({ resourceType: "Bundle", entry: [] });
+    });
+    const cid = await createConn(app);
+    const sid = await createSession(app, cid, "pat-1");
+
+    const res = await app.request(
+      `/api/sessions/${sid}/tools/getPatient`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ patientId: "pat-1" }),
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      ok: true,
+      tool: "getPatient",
+      toolVersion: "1",
+    });
+    expect(body.data).toMatchObject({ resourceType: "Patient", id: "pat-1" });
+  });
+
+  it("returns 404 for an unknown tool name with reason: 'unknown_tool'", async () => {
+    const { app } = newApp();
+    const cid = await createConn(app);
+    const sid = await createSession(app, cid, "pat-1");
+
+    const res = await app.request(`/api/sessions/${sid}/tools/noSuch`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ patientId: "pat-1" }),
+    });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({
+      ok: false,
+      reason: "unknown_tool",
+    });
+  });
+
+  it("returns 403 with reason: 'unauthorized_patient' when body patientId differs from session", async () => {
+    const { app } = newApp();
+    const cid = await createConn(app);
+    const sid = await createSession(app, cid, "pat-1");
+
+    const res = await app.request(
+      `/api/sessions/${sid}/tools/getPatient`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ patientId: "ANOTHER" }),
+      },
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      ok: false,
+      reason: "unauthorized_patient",
+    });
+  });
+
+  it("returns 400 with reason: 'invalid_input' for missing patientId", async () => {
+    const { app } = newApp();
+    const cid = await createConn(app);
+    const sid = await createSession(app, cid, "pat-1");
+
+    const res = await app.request(
+      `/api/sessions/${sid}/tools/getPatient`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      },
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      ok: false,
+      reason: "invalid_input",
+    });
+  });
+
+  it("returns 404 with reason: 'session_not_found' for unknown session", async () => {
+    const { app } = newApp();
+    const res = await app.request("/api/sessions/no-session/tools/getPatient", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ patientId: "pat-1" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("logs the tool call (in-memory logger captures every invocation)", async () => {
+    const t = newApp(async () =>
+      jsonResponse({ resourceType: "Patient", id: "pat-1" }),
+    );
+    const cid = await createConn(t.app);
+    const sid = await createSession(t.app, cid, "pat-1");
+
+    await t.app.request(`/api/sessions/${sid}/tools/getPatient`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ patientId: "pat-1" }),
+    });
+    await t.app.request(`/api/sessions/${sid}/tools/getPatient`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ patientId: "ANOTHER" }),
+    });
+    expect(t.logger.entries).toHaveLength(2);
+    const first = t.logger.entries[0];
+    const second = t.logger.entries[1];
+    expect(first?.envelope.ok).toBe(true);
+    expect(second?.envelope.ok).toBe(false);
+    if (second && !second.envelope.ok) {
+      expect(second.envelope.reason).toBe("unauthorized_patient");
+    }
+  });
+
+  it("never returns the connection's auth token in any envelope", async () => {
+    const t = newApp(async () =>
+      jsonResponse({ resourceType: "Patient", id: "pat-1" }),
+    );
+    const cid = await createConn(t.app, {
+      authType: "bearer",
+      authToken: "super-secret-tok",
+    });
+    const sid = await createSession(t.app, cid, "pat-1");
+
+    const res = await t.app.request(
+      `/api/sessions/${sid}/tools/getPatient`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ patientId: "pat-1" }),
+      },
+    );
+    const text = await res.text();
+    expect(text).not.toContain("super-secret-tok");
+  });
+});

--- a/apps/workbench/server/routes/sessions.ts
+++ b/apps/workbench/server/routes/sessions.ts
@@ -1,0 +1,126 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import type { ConnectionStore } from "../services/connection-store.js";
+import type { SessionStore } from "../services/session-store.js";
+import type { ToolRegistry } from "../agent/registry.js";
+import type { ToolLogger } from "../agent/tool-log.js";
+import { ConnectionId } from "../schemas.js";
+
+const CreateSessionInput = z.object({
+  connectionId: ConnectionId,
+  patientId: z
+    .string()
+    .min(1)
+    .max(64)
+    .regex(/^[A-Za-z0-9\-.]{1,64}$/, "invalid FHIR id"),
+});
+
+interface Deps {
+  sessions: SessionStore;
+  connections: ConnectionStore;
+  registry: ToolRegistry;
+  fetchFn?: typeof fetch;
+  logger?: ToolLogger;
+}
+
+export function sessionsRoutes(deps: Deps) {
+  const app = new Hono();
+
+  app.get("/", (c) => c.json({ sessions: deps.sessions.list() }));
+
+  app.get("/tools", (c) => c.json({ tools: deps.registry.list() }));
+
+  app.post("/", async (c) => {
+    const body = await safeJson(c);
+    const parsed = CreateSessionInput.safeParse(body);
+    if (!parsed.success) {
+      return jsonBody(400, {
+        error: "invalid_input",
+        issues: parsed.error.issues,
+      });
+    }
+    const conn = deps.connections.getInternal(parsed.data.connectionId);
+    if (!conn) return jsonBody(404, { error: "connection_not_found" });
+
+    const session = deps.sessions.create(parsed.data);
+    return jsonBody(201, { session });
+  });
+
+  app.get("/:sid", (c) => {
+    const sid = c.req.param("sid");
+    if (!sid) return jsonBody(404, { error: "session_not_found" });
+    const session = deps.sessions.get(sid);
+    if (!session) return jsonBody(404, { error: "session_not_found" });
+    return jsonBody(200, { session });
+  });
+
+  app.delete("/:sid", (c) => {
+    const sid = c.req.param("sid");
+    if (!sid) return jsonBody(404, { error: "session_not_found" });
+    return deps.sessions.delete(sid)
+      ? new Response(null, { status: 204 })
+      : jsonBody(404, { error: "session_not_found" });
+  });
+
+  app.post("/:sid/tools/:toolName", async (c) => {
+    const sid = c.req.param("sid");
+    const toolName = c.req.param("toolName");
+    if (!sid || !toolName) {
+      return jsonBody(404, { error: "not_found" });
+    }
+    const session = deps.sessions.get(sid);
+    if (!session) return jsonBody(404, { error: "session_not_found" });
+
+    const conn = deps.connections.getInternal(session.connectionId);
+    if (!conn) return jsonBody(404, { error: "connection_not_found" });
+
+    const rawInput = (await safeJson(c)) ?? {};
+
+    const envelope = await deps.registry.run({
+      toolName,
+      rawInput,
+      session,
+      connection: conn,
+      fetchFn: deps.fetchFn,
+      logger: deps.logger,
+    });
+
+    // The envelope is itself the body; HTTP status mirrors error reason so
+    // the agent / UI can treat 4xx/5xx generically while the envelope's
+    // `reason` field stays the source of truth for branching.
+    const status = envelope.ok
+      ? 200
+      : envelope.reason === "unknown_tool"
+        ? 404
+        : envelope.reason === "invalid_input"
+          ? 400
+          : envelope.reason === "unauthorized_patient"
+            ? 403
+            : envelope.reason === "session_not_found" ||
+                envelope.reason === "connection_not_found"
+              ? 404
+              : envelope.reason === "timeout"
+                ? 504
+                : 502;
+    return jsonBody(status, envelope);
+  });
+
+  return app;
+}
+
+import type { Context } from "hono";
+
+async function safeJson(c: Context): Promise<unknown> {
+  try {
+    return await c.req.json();
+  } catch {
+    return null;
+  }
+}
+
+function jsonBody(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/apps/workbench/server/schemas.ts
+++ b/apps/workbench/server/schemas.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+/**
+ * Phase A allow-lists. Both are enforced at the validation boundary so any
+ * unknown value (e.g. `kind: "omop"` or `authType: "smart"`) is rejected
+ * before it can touch the DB.
+ */
+export const ConnectionKind = z.enum(["fhir_clinical"]);
+export type ConnectionKind = z.infer<typeof ConnectionKind>;
+
+export const AuthType = z.enum(["none", "bearer"]);
+export type AuthType = z.infer<typeof AuthType>;
+
+export const CreateConnectionInput = z
+  .object({
+    name: z.string().min(1).max(120),
+    kind: ConnectionKind,
+    baseUrl: z.string().url().min(1),
+    authType: AuthType,
+    authToken: z.string().min(1).max(4096).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.authType === "bearer" && !value.authToken) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["authToken"],
+        message: "authToken is required when authType is 'bearer'",
+      });
+    }
+    if (value.authType === "none" && value.authToken) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["authToken"],
+        message: "authToken must be omitted when authType is 'none'",
+      });
+    }
+  });
+
+export type CreateConnectionInput = z.infer<typeof CreateConnectionInput>;
+
+export const ConnectionId = z.string().min(1).max(64);

--- a/apps/workbench/server/schemas.ts
+++ b/apps/workbench/server/schemas.ts
@@ -39,3 +39,45 @@ export const CreateConnectionInput = z
 export type CreateConnectionInput = z.infer<typeof CreateConnectionInput>;
 
 export const ConnectionId = z.string().min(1).max(64);
+
+/**
+ * Phase A FHIR resource allow-list for the user-facing read proxy and the
+ * patient-summary agent's typed tool registry (PR 4). Anything outside this
+ * list is a 400 at the API boundary — there is no path that lets the client
+ * (or, in PR 6, the agent) probe arbitrary FHIR resources.
+ */
+export const ResourceType = z.enum([
+  "Patient",
+  "Condition",
+  "MedicationRequest",
+  "AllergyIntolerance",
+  "Encounter",
+  "Observation",
+]);
+export type ResourceType = z.infer<typeof ResourceType>;
+
+/**
+ * Per-resource allow-list of search parameters the proxy will forward. Every
+ * other param (including `_include`, `_revinclude`, `_has`, `_filter`,
+ * `_elements`, `_summary`, `_format`) is dropped before forwarding upstream
+ * so a caller cannot expand the response shape, change content negotiation,
+ * or chain into resources outside the allow-list.
+ *
+ * `_count`, `_sort`, `_id`, and the per-resource params named in TASKS.md
+ * are the only things that survive.
+ */
+export const SEARCH_PARAM_ALLOWLIST: Record<ResourceType, ReadonlyArray<string>> = {
+  Patient: ["name", "family", "given", "identifier", "birthdate", "gender", "_id", "_count", "_sort"],
+  Condition: ["patient", "clinical-status", "category", "code", "_id", "_count", "_sort"],
+  MedicationRequest: ["patient", "status", "intent", "_id", "_count", "_sort"],
+  AllergyIntolerance: ["patient", "clinical-status", "_id", "_count", "_sort"],
+  Encounter: ["patient", "status", "date", "_id", "_count", "_sort"],
+  Observation: ["patient", "category", "code", "date", "status", "_id", "_count", "_sort"],
+};
+
+/**
+ * Globally bounded `_count` so a buggy or malicious client can't ask the
+ * upstream FHIR server for a 100k-page Bundle.
+ */
+export const MAX_COUNT = 100;
+

--- a/apps/workbench/server/services/connection-store.ts
+++ b/apps/workbench/server/services/connection-store.ts
@@ -38,6 +38,17 @@ export function createConnectionStore(
       return row ? redact(row) : null;
     },
 
+    /**
+     * Server-internal lookup that returns the raw row including `authToken`.
+     * Never exposed over HTTP. Used by the FHIR proxy to attach the
+     * configured auth header to the upstream request.
+     */
+    getInternal(id: string): DataConnection | null {
+      return (
+        db.select().from(dataConnection).where(eq(dataConnection.id, id)).get() ?? null
+      );
+    },
+
     create(input: CreateConnectionInput): ConnectionRow {
       const id = generateId();
       const ts = now();

--- a/apps/workbench/server/services/connection-store.ts
+++ b/apps/workbench/server/services/connection-store.ts
@@ -1,0 +1,103 @@
+import { eq } from "drizzle-orm";
+import { dataConnection, type DataConnection } from "../../db/schema.js";
+import type { WorkbenchDb } from "../../db/client.js";
+import type { CreateConnectionInput } from "../schemas.js";
+import {
+  probeCapabilityStatement,
+  type CapabilityProbeResult,
+} from "./fhir-connection.js";
+
+export type ConnectionRow = Omit<DataConnection, "authToken"> & {
+  hasAuthToken: boolean;
+};
+
+/**
+ * The auth token never leaves the server. The frontend only sees whether one
+ * is configured, never the token itself.
+ */
+function redact(row: DataConnection): ConnectionRow {
+  const { authToken, ...rest } = row;
+  return { ...rest, hasAuthToken: Boolean(authToken) };
+}
+
+export function createConnectionStore(
+  db: WorkbenchDb,
+  options: { generateId?: () => string; now?: () => string; fetchFn?: typeof fetch } = {},
+) {
+  const generateId = options.generateId ?? defaultId;
+  const now = options.now ?? (() => new Date().toISOString());
+  const fetchFn = options.fetchFn ?? fetch;
+
+  return {
+    list(): ConnectionRow[] {
+      return db.select().from(dataConnection).all().map(redact);
+    },
+
+    get(id: string): ConnectionRow | null {
+      const row = db.select().from(dataConnection).where(eq(dataConnection.id, id)).get();
+      return row ? redact(row) : null;
+    },
+
+    create(input: CreateConnectionInput): ConnectionRow {
+      const id = generateId();
+      const ts = now();
+      db.insert(dataConnection)
+        .values({
+          id,
+          name: input.name,
+          kind: input.kind,
+          baseUrl: input.baseUrl,
+          authType: input.authType,
+          authToken: input.authType === "bearer" ? (input.authToken ?? null) : null,
+          createdAt: ts,
+          updatedAt: ts,
+        })
+        .run();
+      const row = db.select().from(dataConnection).where(eq(dataConnection.id, id)).get();
+      if (!row) throw new Error("connection insert failed");
+      return redact(row);
+    },
+
+    delete(id: string): boolean {
+      const result = db.delete(dataConnection).where(eq(dataConnection.id, id)).run();
+      return result.changes > 0;
+    },
+
+    async test(id: string): Promise<{ row: ConnectionRow; result: CapabilityProbeResult } | null> {
+      const row = db.select().from(dataConnection).where(eq(dataConnection.id, id)).get();
+      if (!row) return null;
+
+      const result = await probeCapabilityStatement(row, fetchFn);
+      const ts = now();
+
+      const updates: Partial<DataConnection> = {
+        lastCapabilityAt: ts,
+        updatedAt: ts,
+      };
+      if (result.ok) {
+        updates.lastCapabilityStatus = "ok";
+        updates.lastCapabilityFhirVersion = result.fhirVersion;
+        updates.lastCapabilitySoftware = result.software;
+        updates.lastCapabilityJson = JSON.stringify(result.raw);
+        updates.lastCapabilityError = null;
+      } else {
+        updates.lastCapabilityStatus = "error";
+        updates.lastCapabilityError = result.error;
+      }
+
+      db.update(dataConnection).set(updates).where(eq(dataConnection.id, id)).run();
+      const updated = db.select().from(dataConnection).where(eq(dataConnection.id, id)).get();
+      if (!updated) throw new Error("connection vanished after update");
+      return { row: redact(updated), result };
+    },
+  };
+}
+
+export type ConnectionStore = ReturnType<typeof createConnectionStore>;
+
+function defaultId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `conn_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/apps/workbench/server/services/fhir-connection.test.ts
+++ b/apps/workbench/server/services/fhir-connection.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  authHeadersFor,
+  probeCapabilityStatement,
+} from "./fhir-connection.js";
+
+const BASE = "https://example.test/fhir";
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/fhir+json" },
+    ...init,
+  });
+}
+
+describe("authHeadersFor", () => {
+  it("returns no headers for `none` auth", () => {
+    expect(authHeadersFor({ authType: "none", authToken: null })).toEqual({});
+  });
+
+  it("returns Bearer for `bearer` auth with a token", () => {
+    expect(
+      authHeadersFor({ authType: "bearer", authToken: "abc" }),
+    ).toEqual({ Authorization: "Bearer abc" });
+  });
+
+  it("returns no headers for `bearer` auth missing a token (defensive)", () => {
+    expect(authHeadersFor({ authType: "bearer", authToken: null })).toEqual({});
+  });
+
+  it("returns no headers for an unknown authType (defensive)", () => {
+    expect(
+      authHeadersFor({
+        authType: "smart" as never,
+        authToken: "abc",
+      }),
+    ).toEqual({});
+  });
+});
+
+describe("probeCapabilityStatement", () => {
+  it("returns ok with parsed metadata on a valid CapabilityStatement", async () => {
+    const fakeFetch: typeof fetch = async (input, init) => {
+      expect(String(input)).toBe(`${BASE}/metadata`);
+      const headers = new Headers(init?.headers);
+      expect(headers.get("Accept")).toBe("application/fhir+json");
+      expect(headers.get("Authorization")).toBe("Bearer s3cret");
+      return jsonResponse({
+        resourceType: "CapabilityStatement",
+        fhirVersion: "4.0.1",
+        software: { name: "HAPI FHIR Server", version: "8.0.0" },
+      });
+    };
+
+    const result = await probeCapabilityStatement(
+      { baseUrl: BASE, authType: "bearer", authToken: "s3cret" },
+      fakeFetch,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      fhirVersion: "4.0.1",
+      software: "HAPI FHIR Server 8.0.0",
+      raw: expect.objectContaining({ resourceType: "CapabilityStatement" }),
+    });
+  });
+
+  it("returns error on non-2xx response", async () => {
+    const fakeFetch: typeof fetch = async () =>
+      new Response("nope", { status: 401, statusText: "Unauthorized" });
+
+    const result = await probeCapabilityStatement(
+      { baseUrl: BASE, authType: "none", authToken: null },
+      fakeFetch,
+    );
+
+    expect(result).toEqual({ ok: false, error: "HTTP 401 Unauthorized" });
+  });
+
+  it("returns error when body is not a CapabilityStatement", async () => {
+    const fakeFetch: typeof fetch = async () =>
+      jsonResponse({ resourceType: "OperationOutcome" });
+
+    const result = await probeCapabilityStatement(
+      { baseUrl: BASE, authType: "none", authToken: null },
+      fakeFetch,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error).toMatch(/unexpected resource: got OperationOutcome/);
+  });
+
+  it("returns error on network failure", async () => {
+    const fakeFetch: typeof fetch = async () => {
+      throw new Error("connection refused");
+    };
+
+    const result = await probeCapabilityStatement(
+      { baseUrl: BASE, authType: "none", authToken: null },
+      fakeFetch,
+    );
+
+    expect(result).toEqual({ ok: false, error: "network error: connection refused" });
+  });
+
+  it("strips trailing slash from base URL before appending /metadata", async () => {
+    let observedUrl: string | undefined;
+    const fakeFetch: typeof fetch = async (input) => {
+      observedUrl = String(input);
+      return jsonResponse({ resourceType: "CapabilityStatement" });
+    };
+
+    await probeCapabilityStatement(
+      { baseUrl: `${BASE}/`, authType: "none", authToken: null },
+      fakeFetch,
+    );
+
+    expect(observedUrl).toBe(`${BASE}/metadata`);
+  });
+});

--- a/apps/workbench/server/services/fhir-connection.ts
+++ b/apps/workbench/server/services/fhir-connection.ts
@@ -1,0 +1,97 @@
+import type { DataConnection } from "../../db/schema.js";
+
+export type CapabilityProbeResult =
+  | {
+      ok: true;
+      fhirVersion: string | null;
+      software: string | null;
+      raw: unknown;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+/**
+ * Build the auth headers for a connection. Phase A only supports `none` and
+ * `bearer`; any other value is treated as `none` so a misconfigured row
+ * cannot leak a header.
+ */
+export function authHeadersFor(
+  conn: Pick<DataConnection, "authType" | "authToken">,
+): Record<string, string> {
+  if (conn.authType === "bearer" && conn.authToken) {
+    return { Authorization: `Bearer ${conn.authToken}` };
+  }
+  return {};
+}
+
+/**
+ * Fetch a CapabilityStatement from the configured FHIR server.
+ *
+ * This is a thin wrapper around `fetch`; we deliberately do not reuse
+ * `@fhir-place/react-fhir`'s `FetchFhirClient` here because it is an
+ * abstraction over patient/resource reads, and the metadata endpoint is a
+ * one-shot probe that we want to inspect at the HTTP level (status code,
+ * content-type, body parse errors).
+ *
+ * `fetchFn` is injectable so tests can substitute a stub without a global
+ * mock.
+ */
+export async function probeCapabilityStatement(
+  conn: Pick<DataConnection, "baseUrl" | "authType" | "authToken">,
+  fetchFn: typeof fetch = fetch,
+  signal?: AbortSignal,
+): Promise<CapabilityProbeResult> {
+  const url = `${conn.baseUrl.replace(/\/$/, "")}/metadata`;
+  let response: Response;
+  try {
+    response = await fetchFn(url, {
+      method: "GET",
+      headers: {
+        Accept: "application/fhir+json",
+        ...authHeadersFor(conn),
+      },
+      ...(signal ? { signal } : {}),
+    });
+  } catch (err) {
+    return { ok: false, error: `network error: ${stringifyError(err)}` };
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: `HTTP ${response.status} ${response.statusText || ""}`.trim(),
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (err) {
+    return { ok: false, error: `invalid JSON: ${stringifyError(err)}` };
+  }
+
+  const cap = body as Record<string, unknown> | null;
+  if (!cap || cap["resourceType"] !== "CapabilityStatement") {
+    return {
+      ok: false,
+      error: `unexpected resource: got ${String(cap?.["resourceType"] ?? "null")}`,
+    };
+  }
+
+  const software = cap["software"] as { name?: string; version?: string } | undefined;
+  return {
+    ok: true,
+    fhirVersion: typeof cap["fhirVersion"] === "string" ? (cap["fhirVersion"] as string) : null,
+    software: software?.name
+      ? `${software.name}${software.version ? ` ${software.version}` : ""}`
+      : null,
+    raw: body,
+  };
+}
+
+function stringifyError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/apps/workbench/server/services/fhir-proxy.test.ts
+++ b/apps/workbench/server/services/fhir-proxy.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterSearchParams,
+  proxyRead,
+  proxySearch,
+} from "./fhir-proxy.js";
+
+const CONN = {
+  baseUrl: "https://hapi.test/fhir",
+  authType: "bearer" as const,
+  authToken: "tok",
+};
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/fhir+json" },
+    ...init,
+  });
+}
+
+describe("filterSearchParams", () => {
+  it("keeps allow-listed Patient params and drops unknowns", () => {
+    const out = filterSearchParams(
+      "Patient",
+      new URLSearchParams("name=Hopper&gender=female&favorite-color=blue"),
+    );
+    expect(out.get("name")).toBe("Hopper");
+    expect(out.get("gender")).toBe("female");
+    expect(out.has("favorite-color")).toBe(false);
+    expect(out.get("_count")).toBe("20");
+  });
+
+  it("drops _include / _revinclude / _has / _format on every resource", () => {
+    const out = filterSearchParams(
+      "Observation",
+      new URLSearchParams(
+        "patient=Patient/abc&_include=Observation:subject&_revinclude=Encounter:subject&_has=Encounter&_format=xml",
+      ),
+    );
+    expect(out.get("patient")).toBe("Patient/abc");
+    expect(out.has("_include")).toBe(false);
+    expect(out.has("_revinclude")).toBe(false);
+    expect(out.has("_has")).toBe(false);
+    expect(out.has("_format")).toBe(false);
+  });
+
+  it("clamps _count to MAX_COUNT", () => {
+    const out = filterSearchParams("Patient", new URLSearchParams("_count=1000"));
+    expect(out.get("_count")).toBe("100");
+  });
+
+  it("drops a non-numeric or non-positive _count and falls back to default 20", () => {
+    expect(
+      filterSearchParams("Patient", new URLSearchParams("_count=not-a-number")).get(
+        "_count",
+      ),
+    ).toBe("20");
+    expect(
+      filterSearchParams("Patient", new URLSearchParams("_count=-5")).get("_count"),
+    ).toBe("20");
+  });
+
+  it("preserves repeated values for the same key", () => {
+    const out = filterSearchParams(
+      "Condition",
+      new URLSearchParams([
+        ["category", "problem-list-item"],
+        ["category", "encounter-diagnosis"],
+        ["patient", "Patient/abc"],
+      ]),
+    );
+    expect(out.getAll("category")).toEqual(["problem-list-item", "encounter-diagnosis"]);
+  });
+
+  it("Condition's allow-list rejects Patient-only params (e.g. birthdate)", () => {
+    const out = filterSearchParams("Condition", new URLSearchParams("birthdate=1980"));
+    expect(out.has("birthdate")).toBe(false);
+  });
+});
+
+describe("proxySearch", () => {
+  it("forwards a Patient search with auth headers and returns the upstream Bundle", async () => {
+    let observed: { url: string; headers: Record<string, string> } | undefined;
+    const fakeFetch: typeof fetch = async (input, init) => {
+      const headers = new Headers(init?.headers);
+      observed = {
+        url: String(input),
+        headers: {
+          accept: headers.get("Accept") ?? "",
+          authorization: headers.get("Authorization") ?? "",
+        },
+      };
+      return jsonResponse({ resourceType: "Bundle", type: "searchset", entry: [] });
+    };
+    const result = await proxySearch(
+      CONN,
+      "Patient",
+      new URLSearchParams("name=Hopper&_count=5"),
+      fakeFetch,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.body).toMatchObject({ resourceType: "Bundle" });
+    expect(observed?.url).toMatch(/^https:\/\/hapi\.test\/fhir\/Patient\?/);
+    expect(observed?.url).toContain("name=Hopper");
+    expect(observed?.url).toContain("_count=5");
+    expect(observed?.headers.accept).toBe("application/fhir+json");
+    expect(observed?.headers.authorization).toBe("Bearer tok");
+  });
+
+  it("strips disallowed params before forwarding", async () => {
+    let observedUrl = "";
+    const fakeFetch: typeof fetch = async (input) => {
+      observedUrl = String(input);
+      return jsonResponse({ resourceType: "Bundle", entry: [] });
+    };
+    await proxySearch(
+      CONN,
+      "Patient",
+      new URLSearchParams("name=Hopper&_include=Patient:link"),
+      fakeFetch,
+    );
+    expect(observedUrl).not.toContain("_include");
+    expect(observedUrl).toContain("name=Hopper");
+  });
+
+  it("propagates a non-2xx upstream as ok:false with the body", async () => {
+    const fakeFetch: typeof fetch = async () =>
+      new Response(
+        JSON.stringify({
+          resourceType: "OperationOutcome",
+          issue: [{ severity: "error", code: "forbidden" }],
+        }),
+        { status: 403, headers: { "Content-Type": "application/fhir+json" } },
+      );
+    const result = await proxySearch(CONN, "Patient", new URLSearchParams(), fakeFetch);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(403);
+      expect(result.body).toMatchObject({ resourceType: "OperationOutcome" });
+    }
+  });
+
+  it("returns 502 on network failure", async () => {
+    const fakeFetch: typeof fetch = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    const result = await proxySearch(CONN, "Patient", new URLSearchParams(), fakeFetch);
+    expect(result).toMatchObject({ ok: false, status: 502 });
+    if (!result.ok) expect(result.error).toMatch(/ECONNREFUSED/);
+  });
+});
+
+describe("proxyRead", () => {
+  it("rejects an id that contains path traversal characters", async () => {
+    const result = await proxyRead(
+      CONN,
+      "Patient",
+      "../OperationDefinition/foo",
+      async () => new Response("{}"),
+    );
+    expect(result).toMatchObject({ ok: false, status: 400 });
+  });
+
+  it("accepts a valid FHIR id and forwards to the upstream", async () => {
+    let observedUrl = "";
+    const fakeFetch: typeof fetch = async (input) => {
+      observedUrl = String(input);
+      return jsonResponse({ resourceType: "Patient", id: "abc-123" });
+    };
+    const result = await proxyRead(CONN, "Patient", "abc-123", fakeFetch);
+    expect(result.ok).toBe(true);
+    expect(observedUrl).toBe("https://hapi.test/fhir/Patient/abc-123");
+  });
+});

--- a/apps/workbench/server/services/fhir-proxy.ts
+++ b/apps/workbench/server/services/fhir-proxy.ts
@@ -1,0 +1,127 @@
+import type { DataConnection } from "../../db/schema.js";
+import {
+  MAX_COUNT,
+  ResourceType,
+  SEARCH_PARAM_ALLOWLIST,
+} from "../schemas.js";
+import { authHeadersFor } from "./fhir-connection.js";
+
+export type ProxyResult =
+  | { ok: true; status: number; body: unknown }
+  | {
+      ok: false;
+      status: number;
+      error: string;
+      body?: unknown;
+    };
+
+interface ProxyTarget {
+  baseUrl: string;
+  authType: DataConnection["authType"];
+  authToken: DataConnection["authToken"];
+}
+
+/**
+ * Drop any search parameter that isn't on the allow-list for this resource
+ * type. Per-resource lists live in `schemas.ts` so the boundary is one
+ * place to inspect.
+ *
+ * Multiple values per key are preserved (FHIR uses repeats and commas).
+ */
+export function filterSearchParams(
+  resourceType: ResourceType,
+  raw: URLSearchParams,
+): URLSearchParams {
+  const allowed = new Set(SEARCH_PARAM_ALLOWLIST[resourceType]);
+  const out = new URLSearchParams();
+  for (const [key, value] of raw) {
+    if (!allowed.has(key)) continue;
+    if (key === "_count") {
+      const n = Number.parseInt(value, 10);
+      if (!Number.isFinite(n) || n <= 0) continue;
+      out.append("_count", String(Math.min(n, MAX_COUNT)));
+      continue;
+    }
+    out.append(key, value);
+  }
+  if (!out.has("_count")) out.set("_count", "20");
+  return out;
+}
+
+export async function proxySearch(
+  conn: ProxyTarget,
+  resourceType: ResourceType,
+  rawParams: URLSearchParams,
+  fetchFn: typeof fetch = fetch,
+): Promise<ProxyResult> {
+  const params = filterSearchParams(resourceType, rawParams);
+  const qs = params.toString();
+  const url = `${conn.baseUrl.replace(/\/$/, "")}/${resourceType}${qs ? `?${qs}` : ""}`;
+  return executeGet(url, conn, fetchFn);
+}
+
+export async function proxyRead(
+  conn: ProxyTarget,
+  resourceType: ResourceType,
+  resourceId: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<ProxyResult> {
+  if (!isValidFhirId(resourceId)) {
+    return {
+      ok: false,
+      status: 400,
+      error: `invalid id: ${resourceId}`,
+    };
+  }
+  const url = `${conn.baseUrl.replace(/\/$/, "")}/${resourceType}/${resourceId}`;
+  return executeGet(url, conn, fetchFn);
+}
+
+/**
+ * FHIR `id` regex from the R4 spec — `[A-Za-z0-9\-\.]{1,64}`. Validated at
+ * the proxy boundary so we never put untrusted data into a path segment.
+ */
+function isValidFhirId(id: string): boolean {
+  return /^[A-Za-z0-9\-.]{1,64}$/.test(id);
+}
+
+async function executeGet(
+  url: string,
+  conn: ProxyTarget,
+  fetchFn: typeof fetch,
+): Promise<ProxyResult> {
+  let response: Response;
+  try {
+    response = await fetchFn(url, {
+      method: "GET",
+      headers: {
+        Accept: "application/fhir+json",
+        ...authHeadersFor(conn),
+      },
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      status: 502,
+      error: `network error: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  let body: unknown = null;
+  try {
+    body = await response.json();
+  } catch {
+    // body stays null; some FHIR errors are bodyless
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      error: `upstream HTTP ${response.status}`,
+      body,
+    };
+  }
+
+  return { ok: true, status: response.status, body };
+}

--- a/apps/workbench/server/services/fhir-proxy.ts
+++ b/apps/workbench/server/services/fhir-proxy.ts
@@ -53,11 +53,12 @@ export async function proxySearch(
   resourceType: ResourceType,
   rawParams: URLSearchParams,
   fetchFn: typeof fetch = fetch,
+  signal?: AbortSignal,
 ): Promise<ProxyResult> {
   const params = filterSearchParams(resourceType, rawParams);
   const qs = params.toString();
   const url = `${conn.baseUrl.replace(/\/$/, "")}/${resourceType}${qs ? `?${qs}` : ""}`;
-  return executeGet(url, conn, fetchFn);
+  return executeGet(url, conn, fetchFn, signal);
 }
 
 export async function proxyRead(
@@ -65,6 +66,7 @@ export async function proxyRead(
   resourceType: ResourceType,
   resourceId: string,
   fetchFn: typeof fetch = fetch,
+  signal?: AbortSignal,
 ): Promise<ProxyResult> {
   if (!isValidFhirId(resourceId)) {
     return {
@@ -74,7 +76,7 @@ export async function proxyRead(
     };
   }
   const url = `${conn.baseUrl.replace(/\/$/, "")}/${resourceType}/${resourceId}`;
-  return executeGet(url, conn, fetchFn);
+  return executeGet(url, conn, fetchFn, signal);
 }
 
 /**
@@ -89,6 +91,7 @@ async function executeGet(
   url: string,
   conn: ProxyTarget,
   fetchFn: typeof fetch,
+  signal?: AbortSignal,
 ): Promise<ProxyResult> {
   let response: Response;
   try {
@@ -98,6 +101,7 @@ async function executeGet(
         Accept: "application/fhir+json",
         ...authHeadersFor(conn),
       },
+      ...(signal ? { signal } : {}),
     });
   } catch (err) {
     return {

--- a/apps/workbench/server/services/session-store.ts
+++ b/apps/workbench/server/services/session-store.ts
@@ -1,0 +1,67 @@
+import { eq } from "drizzle-orm";
+import { agentSession, type AgentSession } from "../../db/schema.js";
+import type { WorkbenchDb } from "../../db/client.js";
+
+export interface CreateSessionInput {
+  connectionId: string;
+  patientId: string;
+}
+
+export function createSessionStore(
+  db: WorkbenchDb,
+  options: { generateId?: () => string; now?: () => string } = {},
+) {
+  const generateId = options.generateId ?? defaultId;
+  const now = options.now ?? (() => new Date().toISOString());
+
+  return {
+    list(): AgentSession[] {
+      return db.select().from(agentSession).all();
+    },
+
+    get(id: string): AgentSession | null {
+      return (
+        db.select().from(agentSession).where(eq(agentSession.id, id)).get() ??
+        null
+      );
+    },
+
+    create(input: CreateSessionInput): AgentSession {
+      const id = generateId();
+      const ts = now();
+      db.insert(agentSession)
+        .values({
+          id,
+          connectionId: input.connectionId,
+          patientId: input.patientId,
+          createdAt: ts,
+          updatedAt: ts,
+        })
+        .run();
+      const row = db
+        .select()
+        .from(agentSession)
+        .where(eq(agentSession.id, id))
+        .get();
+      if (!row) throw new Error("session insert failed");
+      return row;
+    },
+
+    delete(id: string): boolean {
+      const result = db
+        .delete(agentSession)
+        .where(eq(agentSession.id, id))
+        .run();
+      return result.changes > 0;
+    },
+  };
+}
+
+export type SessionStore = ReturnType<typeof createSessionStore>;
+
+function defaultId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `sess_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/apps/workbench/server/test-utils.ts
+++ b/apps/workbench/server/test-utils.ts
@@ -5,7 +5,10 @@ import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 import { openDb } from "../db/client.js";
 import { createConnectionStore } from "./services/connection-store.js";
+import { createSessionStore } from "./services/session-store.js";
 import { createApp } from "./app.js";
+import { createPhaseATools } from "./agent/tools/index.js";
+import { inMemoryLogger } from "./agent/tool-log.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const migrationsDir = join(here, "..", "db", "migrations");
@@ -15,7 +18,9 @@ export function makeTestApp(options: { fetchFn?: typeof fetch } = {}) {
   const url = join(dir, "test.sqlite");
 
   const sqlite = new Database(url);
-  for (const file of readdirSync(migrationsDir).filter((f) => f.endsWith(".sql")).sort()) {
+  for (const file of readdirSync(migrationsDir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort()) {
     sqlite.exec(readFileSync(join(migrationsDir, file), "utf8"));
   }
   sqlite.close();
@@ -28,11 +33,30 @@ export function makeTestApp(options: { fetchFn?: typeof fetch } = {}) {
     now: () => "2026-04-30T00:00:00.000Z",
     fetchFn: options.fetchFn,
   });
-  const app = createApp({ connections, fetchFn: options.fetchFn });
+
+  let sessionCounter = 0;
+  const sessions = createSessionStore(db, {
+    generateId: () => `sess_${String(++sessionCounter).padStart(4, "0")}`,
+    now: () => "2026-04-30T00:00:00.000Z",
+  });
+
+  const registry = createPhaseATools();
+  const logger = inMemoryLogger();
+
+  const app = createApp({
+    connections,
+    sessions,
+    registry,
+    fetchFn: options.fetchFn,
+    logger,
+  });
 
   return {
     app,
     connections,
+    sessions,
+    registry,
+    logger,
     cleanup() {
       rmSync(dir, { recursive: true, force: true });
     },

--- a/apps/workbench/server/test-utils.ts
+++ b/apps/workbench/server/test-utils.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { openDb } from "../db/client.js";
+import { createConnectionStore } from "./services/connection-store.js";
+import { createApp } from "./app.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(here, "..", "db", "migrations");
+
+export function makeTestApp(options: { fetchFn?: typeof fetch } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "workbench-server-"));
+  const url = join(dir, "test.sqlite");
+
+  const sqlite = new Database(url);
+  for (const file of readdirSync(migrationsDir).filter((f) => f.endsWith(".sql")).sort()) {
+    sqlite.exec(readFileSync(join(migrationsDir, file), "utf8"));
+  }
+  sqlite.close();
+
+  const db = openDb(url);
+
+  let counter = 0;
+  const connections = createConnectionStore(db, {
+    generateId: () => `conn_${String(++counter).padStart(4, "0")}`,
+    now: () => "2026-04-30T00:00:00.000Z",
+    fetchFn: options.fetchFn,
+  });
+  const app = createApp({ connections });
+
+  return {
+    app,
+    connections,
+    cleanup() {
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+export function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/fhir+json" },
+    ...init,
+  });
+}

--- a/apps/workbench/server/test-utils.ts
+++ b/apps/workbench/server/test-utils.ts
@@ -28,7 +28,7 @@ export function makeTestApp(options: { fetchFn?: typeof fetch } = {}) {
     now: () => "2026-04-30T00:00:00.000Z",
     fetchFn: options.fetchFn,
   });
-  const app = createApp({ connections });
+  const app = createApp({ connections, fetchFn: options.fetchFn });
 
   return {
     app,

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -1,30 +1,50 @@
-import { Route, Routes } from "react-router-dom";
+import { Link, NavLink, Route, Routes } from "react-router-dom";
 import { SyntheticOnlyBanner } from "./components/SyntheticOnlyBanner.js";
 import { HomePage } from "./pages/HomePage.js";
-import { FHIR_BASE_URL, USE_MOCK } from "./config.js";
+import { ConnectionsListPage } from "./pages/ConnectionsListPage.js";
+import { ConnectionDetailPage } from "./pages/ConnectionDetailPage.js";
+import { NewConnectionPage } from "./pages/NewConnectionPage.js";
+
+const navItem =
+  "rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900";
+const navItemActive =
+  "rounded-md bg-slate-100 px-3 py-1.5 text-sm font-medium text-slate-900";
 
 export function App() {
   return (
     <div className="min-h-screen">
       <SyntheticOnlyBanner />
       <header className="border-b border-slate-200 bg-white px-6 py-3">
-        <div className="flex items-baseline justify-between gap-4">
-          <div>
-            <span className="text-lg font-semibold text-slate-900">
-              fhir-place
+        <div className="flex items-center justify-between gap-4">
+          <Link to="/" className="text-lg font-semibold text-slate-900">
+            fhir-place{" "}
+            <span className="text-sm font-normal text-slate-500">
+              · agent workbench · phase a
             </span>
-            <span className="ml-2 text-sm text-slate-500">
-              agent workbench · phase a
-            </span>
-          </div>
-          <div className="text-xs text-slate-500" data-testid="base-url">
-            {USE_MOCK ? "mock" : "live"} · {FHIR_BASE_URL}
-          </div>
+          </Link>
+          <nav className="flex items-center gap-1">
+            <NavLink
+              to="/"
+              end
+              className={({ isActive }) => (isActive ? navItemActive : navItem)}
+            >
+              Home
+            </NavLink>
+            <NavLink
+              to="/connections"
+              className={({ isActive }) => (isActive ? navItemActive : navItem)}
+            >
+              Connections
+            </NavLink>
+          </nav>
         </div>
       </header>
       <main className="mx-auto max-w-5xl p-6">
         <Routes>
           <Route path="/" element={<HomePage />} />
+          <Route path="/connections" element={<ConnectionsListPage />} />
+          <Route path="/connections/new" element={<NewConnectionPage />} />
+          <Route path="/connections/:id" element={<ConnectionDetailPage />} />
         </Routes>
       </main>
     </div>

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -8,6 +8,7 @@ import { PatientsPage } from "./pages/PatientsPage.js";
 import { PatientPage } from "./pages/PatientPage.js";
 import { ResourcePage } from "./pages/ResourcePage.js";
 import { SessionPage } from "./pages/SessionPage.js";
+import { AnswerPreviewPage } from "./pages/AnswerPreviewPage.js";
 
 const navItem =
   "rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900";
@@ -59,6 +60,11 @@ export function App() {
             element={<ResourcePage />}
           />
           <Route path="/sessions/:sid" element={<SessionPage />} />
+          <Route
+            path="/sessions/:sid/answer-preview"
+            element={<AnswerPreviewPage />}
+          />
+          <Route path="/answer-preview" element={<AnswerPreviewPage />} />
         </Routes>
       </main>
     </div>

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -7,6 +7,7 @@ import { NewConnectionPage } from "./pages/NewConnectionPage.js";
 import { PatientsPage } from "./pages/PatientsPage.js";
 import { PatientPage } from "./pages/PatientPage.js";
 import { ResourcePage } from "./pages/ResourcePage.js";
+import { SessionPage } from "./pages/SessionPage.js";
 
 const navItem =
   "rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900";
@@ -57,6 +58,7 @@ export function App() {
             path="/connections/:cid/patients/:pid/:resourceType/:resourceId"
             element={<ResourcePage />}
           />
+          <Route path="/sessions/:sid" element={<SessionPage />} />
         </Routes>
       </main>
     </div>

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -1,0 +1,32 @@
+import { Route, Routes } from "react-router-dom";
+import { SyntheticOnlyBanner } from "./components/SyntheticOnlyBanner.js";
+import { HomePage } from "./pages/HomePage.js";
+import { FHIR_BASE_URL, USE_MOCK } from "./config.js";
+
+export function App() {
+  return (
+    <div className="min-h-screen">
+      <SyntheticOnlyBanner />
+      <header className="border-b border-slate-200 bg-white px-6 py-3">
+        <div className="flex items-baseline justify-between gap-4">
+          <div>
+            <span className="text-lg font-semibold text-slate-900">
+              fhir-place
+            </span>
+            <span className="ml-2 text-sm text-slate-500">
+              agent workbench · phase a
+            </span>
+          </div>
+          <div className="text-xs text-slate-500" data-testid="base-url">
+            {USE_MOCK ? "mock" : "live"} · {FHIR_BASE_URL}
+          </div>
+        </div>
+      </header>
+      <main className="mx-auto max-w-5xl p-6">
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -4,6 +4,9 @@ import { HomePage } from "./pages/HomePage.js";
 import { ConnectionsListPage } from "./pages/ConnectionsListPage.js";
 import { ConnectionDetailPage } from "./pages/ConnectionDetailPage.js";
 import { NewConnectionPage } from "./pages/NewConnectionPage.js";
+import { PatientsPage } from "./pages/PatientsPage.js";
+import { PatientPage } from "./pages/PatientPage.js";
+import { ResourcePage } from "./pages/ResourcePage.js";
 
 const navItem =
   "rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900";
@@ -45,6 +48,15 @@ export function App() {
           <Route path="/connections" element={<ConnectionsListPage />} />
           <Route path="/connections/new" element={<NewConnectionPage />} />
           <Route path="/connections/:id" element={<ConnectionDetailPage />} />
+          <Route path="/connections/:cid/patients" element={<PatientsPage />} />
+          <Route
+            path="/connections/:cid/patients/:pid"
+            element={<PatientPage />}
+          />
+          <Route
+            path="/connections/:cid/patients/:pid/:resourceType/:resourceId"
+            element={<ResourcePage />}
+          />
         </Routes>
       </main>
     </div>

--- a/apps/workbench/src/agent/AgentAnswerRenderer.test.tsx
+++ b/apps/workbench/src/agent/AgentAnswerRenderer.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { AgentAnswerRenderer } from "./AgentAnswerRenderer.js";
+import { SAMPLE_AGENT_ANSWER } from "./fixtures.js";
+import type { AgentAnswer } from "./answer-schema.js";
+
+function render(answer: AgentAnswer): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <AgentAnswerRenderer answer={answer} />
+    </MemoryRouter>,
+  );
+}
+
+describe("AgentAnswerRenderer", () => {
+  it("renders the prompt, summary, and section counts", () => {
+    const html = render(SAMPLE_AGENT_ANSWER);
+    expect(html).toContain("Summarise this patient.");
+    expect(html).toContain("78-year-old female");
+    expect(html).toMatch(/data-testid="claims-section"/);
+    expect(html).toMatch(/data-testid="missing-data-section"/);
+    expect(html).toMatch(/data-testid="cannot-determine-section"/);
+    expect(html).toMatch(/data-testid="tool-calls-section"/);
+  });
+
+  it("renders one <li data-testid=claim> per supported claim", () => {
+    const html = render(SAMPLE_AGENT_ANSWER);
+    const matches = html.match(/data-testid="claim"/g);
+    expect(matches).toHaveLength(SAMPLE_AGENT_ANSWER.claims.length);
+  });
+
+  it("links every evidence chip to the resource viewer", () => {
+    const html = render(SAMPLE_AGENT_ANSWER);
+    expect(html).toContain(
+      'href="/connections/conn-sample/patients/pat-sample/Condition/cond-dm2"',
+    );
+    expect(html).toContain(
+      'href="/connections/conn-sample/patients/pat-sample/MedicationRequest/mr-metformin"',
+    );
+    expect(html).toContain(
+      'href="/connections/conn-sample/patients/pat-sample/Encounter/enc-2024-10"',
+    );
+  });
+
+  it(
+    "renders missing-data and cannot-determine entries (first-class, not " +
+      "buried in a free-text blob)",
+    () => {
+      const html = render(SAMPLE_AGENT_ANSWER);
+      expect(html).toContain("no allergy data recorded");
+      expect(html).toContain("Is the patient&#x27;s diabetes well controlled?");
+    },
+  );
+
+  it("renders an empty-state hint when a section has zero entries", () => {
+    const blank: AgentAnswer = {
+      ...SAMPLE_AGENT_ANSWER,
+      claims: [],
+      missingData: [],
+      cannotDetermine: [],
+      toolCalls: [],
+    };
+    const html = render(blank);
+    expect(html).toContain('data-testid="claims-section-empty"');
+    expect(html).toContain('data-testid="missing-data-section-empty"');
+    expect(html).toContain('data-testid="cannot-determine-section-empty"');
+    expect(html).toContain('data-testid="tool-calls-section-empty"');
+  });
+
+  it("shows ok / error badges in the tool-call timeline", () => {
+    const answer: AgentAnswer = {
+      ...SAMPLE_AGENT_ANSWER,
+      toolCalls: [
+        {
+          tool: "getPatient",
+          toolVersion: "1",
+          ok: true,
+          durationMs: 5,
+        },
+        {
+          tool: "searchObservationsForPatient",
+          toolVersion: "1",
+          ok: false,
+          reason: "upstream_error",
+          durationMs: 9,
+        },
+      ],
+    };
+    const html = render(answer);
+    expect(html).toContain("ok ·");
+    expect(html).toContain("upstream_error · 9ms");
+  });
+
+  it("never renders raw Markdown — supported claims appear as text + chips", () => {
+    const html = render(SAMPLE_AGENT_ANSWER);
+    expect(html).not.toContain("**");
+    expect(html).not.toContain("#### ");
+  });
+});

--- a/apps/workbench/src/agent/AgentAnswerRenderer.tsx
+++ b/apps/workbench/src/agent/AgentAnswerRenderer.tsx
@@ -1,0 +1,218 @@
+import {
+  evidenceCountsByType,
+  resourceViewerHref,
+} from "./answer-extractors.js";
+import {
+  AGENT_ANSWER_SCHEMA_VERSION,
+  type AgentAnswer,
+} from "./answer-schema.js";
+import { EvidenceChip } from "./EvidenceChip.js";
+
+/**
+ * Render a *validated* `AgentAnswer`. Callers must run the input through
+ * `parseAgentAnswer` first; this component never sees raw / unparsed
+ * model output. Supported claims, missing-data, and cannot-determine
+ * are first-class top-level sections.
+ */
+export function AgentAnswerRenderer({ answer }: { answer: AgentAnswer }) {
+  const counts = evidenceCountsByType(answer);
+  const totalEvidence = Object.values(counts).reduce((s, n) => s + n, 0);
+  const supportedClaimsCount = answer.claims.length;
+
+  return (
+    <article
+      data-testid="agent-answer"
+      data-schema-version={answer.schemaVersion}
+      className="space-y-4"
+    >
+      <header className="space-y-2">
+        <p className="text-xs uppercase tracking-wide text-slate-500">
+          AgentAnswer · v{AGENT_ANSWER_SCHEMA_VERSION}
+        </p>
+        <h1 className="text-2xl font-semibold text-slate-900">
+          {answer.prompt}
+        </h1>
+        {answer.summary && (
+          <p
+            data-testid="answer-summary"
+            className="rounded-md border border-slate-200 bg-white p-3 text-sm text-slate-800"
+          >
+            {answer.summary}
+          </p>
+        )}
+        <dl className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500">
+          <div>
+            <dt className="inline">session</dt>{" "}
+            <dd className="inline font-mono">{answer.sessionId}</dd>
+          </div>
+          <div>
+            <dt className="inline">patient</dt>{" "}
+            <dd className="inline font-mono">{answer.patientId}</dd>
+          </div>
+          {answer.model && (
+            <div>
+              <dt className="inline">model</dt>{" "}
+              <dd className="inline font-mono">{answer.model}</dd>
+            </div>
+          )}
+          {answer.promptVersion && (
+            <div>
+              <dt className="inline">prompt</dt>{" "}
+              <dd className="inline font-mono">{answer.promptVersion}</dd>
+            </div>
+          )}
+          <div>
+            <dt className="inline">supported claims</dt>{" "}
+            <dd className="inline font-mono">{supportedClaimsCount}</dd>
+          </div>
+          <div>
+            <dt className="inline">distinct evidence</dt>{" "}
+            <dd className="inline font-mono">{totalEvidence}</dd>
+          </div>
+        </dl>
+      </header>
+
+      <Section
+        title="Supported claims"
+        emptyHint="The agent did not assert any supported claims for this prompt."
+        count={answer.claims.length}
+        testId="claims-section"
+      >
+        <ul className="space-y-3">
+          {answer.claims.map((claim) => (
+            <li
+              key={claim.id}
+              data-testid="claim"
+              data-claim-id={claim.id}
+              className="rounded-md border border-slate-200 bg-white p-3"
+            >
+              <p className="text-sm text-slate-800">{claim.text}</p>
+              <ul className="mt-2 flex flex-wrap gap-1.5">
+                {claim.evidence.map((ref, i) => (
+                  <li key={`${ref.reference}-${i}`}>
+                    <EvidenceChip
+                      reference={ref}
+                      href={resourceViewerHref(answer, ref) ?? undefined}
+                    />
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      </Section>
+
+      <Section
+        title="Missing data"
+        emptyHint="No missing data was flagged for this prompt."
+        count={answer.missingData.length}
+        testId="missing-data-section"
+      >
+        <ul className="space-y-2">
+          {answer.missingData.map((entry, i) => (
+            <li
+              key={i}
+              data-testid="missing-data-entry"
+              className="rounded-md border border-slate-200 bg-white p-3 text-sm text-slate-800"
+            >
+              {entry.description}
+            </li>
+          ))}
+        </ul>
+      </Section>
+
+      <Section
+        title="Cannot determine"
+        emptyHint="No questions were marked cannot-determine for this prompt."
+        count={answer.cannotDetermine.length}
+        testId="cannot-determine-section"
+      >
+        <ul className="space-y-2">
+          {answer.cannotDetermine.map((entry, i) => (
+            <li
+              key={i}
+              data-testid="cannot-determine-entry"
+              className="rounded-md border border-slate-200 bg-white p-3 text-sm"
+            >
+              <p className="font-medium text-slate-900">{entry.question}</p>
+              <p className="mt-1 text-slate-700">{entry.why}</p>
+            </li>
+          ))}
+        </ul>
+      </Section>
+
+      <Section
+        title="Tool calls"
+        emptyHint="No tool calls were recorded."
+        count={answer.toolCalls.length}
+        testId="tool-calls-section"
+      >
+        <ol className="divide-y divide-slate-200 rounded-md border border-slate-200 bg-white">
+          {answer.toolCalls.map((call, i) => (
+            <li
+              key={i}
+              data-testid="tool-call"
+              className="flex items-center justify-between gap-4 px-3 py-2 text-sm"
+            >
+              <span className="min-w-0 truncate">
+                <span className="font-mono text-slate-900">
+                  {call.tool}@{call.toolVersion}
+                </span>
+                {typeof call.count === "number" && (
+                  <span className="ml-2 text-slate-500">
+                    {call.count}
+                    {call.truncated ? "+" : ""} resources
+                  </span>
+                )}
+              </span>
+              <span className="shrink-0">
+                {call.ok ? (
+                  <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800">
+                    ok · {call.durationMs}ms
+                  </span>
+                ) : (
+                  <span className="rounded-full bg-rose-100 px-2 py-0.5 text-xs font-medium text-rose-800">
+                    {call.reason ?? "error"} · {call.durationMs}ms
+                  </span>
+                )}
+              </span>
+            </li>
+          ))}
+        </ol>
+      </Section>
+    </article>
+  );
+}
+
+function Section({
+  title,
+  count,
+  emptyHint,
+  testId,
+  children,
+}: {
+  title: string;
+  count: number;
+  emptyHint: string;
+  testId: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section data-testid={testId} className="space-y-2">
+      <header className="flex items-center justify-between">
+        <h2 className="text-base font-semibold text-slate-900">{title}</h2>
+        <span className="text-xs text-slate-500">{count}</span>
+      </header>
+      {count === 0 ? (
+        <p
+          data-testid={`${testId}-empty`}
+          className="rounded-md border border-dashed border-slate-300 bg-white p-3 text-sm text-slate-600"
+        >
+          {emptyHint}
+        </p>
+      ) : (
+        children
+      )}
+    </section>
+  );
+}

--- a/apps/workbench/src/agent/EvidenceChip.tsx
+++ b/apps/workbench/src/agent/EvidenceChip.tsx
@@ -1,0 +1,52 @@
+import { Link } from "react-router-dom";
+import {
+  parseResourceReference,
+  type ResourceReference,
+} from "./answer-schema.js";
+
+const TYPE_TONE: Record<string, string> = {
+  Patient: "bg-slate-100 text-slate-800",
+  Condition: "bg-amber-100 text-amber-900",
+  MedicationRequest: "bg-sky-100 text-sky-900",
+  AllergyIntolerance: "bg-rose-100 text-rose-900",
+  Encounter: "bg-violet-100 text-violet-900",
+  Observation: "bg-emerald-100 text-emerald-900",
+};
+
+export function EvidenceChip({
+  reference,
+  href,
+}: {
+  reference: ResourceReference;
+  /** Resource viewer URL; if omitted, the chip is non-clickable. */
+  href?: string;
+}) {
+  const parsed = parseResourceReference(reference.reference);
+  const tone = parsed
+    ? (TYPE_TONE[parsed.resourceType] ?? "bg-slate-100 text-slate-700")
+    : "bg-slate-100 text-slate-700";
+
+  const inner = (
+    <span
+      data-testid="evidence-chip"
+      data-resource-type={parsed?.resourceType ?? "unknown"}
+      data-reference={reference.reference}
+      className={`inline-flex max-w-full items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${tone}`}
+      title={reference.display ?? reference.reference}
+    >
+      <span className="truncate">
+        {reference.display ?? reference.reference}
+      </span>
+      <code className="ml-1 shrink-0 rounded bg-white/60 px-1 py-px font-mono text-[10px] text-slate-700">
+        {reference.reference}
+      </code>
+    </span>
+  );
+
+  if (!href) return inner;
+  return (
+    <Link to={href} className="inline-flex max-w-full hover:opacity-90">
+      {inner}
+    </Link>
+  );
+}

--- a/apps/workbench/src/agent/answer-extractors.test.ts
+++ b/apps/workbench/src/agent/answer-extractors.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  citedReferences,
+  dedupeReferences,
+  duplicateClaimIds,
+  evidenceCountsByType,
+  resourceViewerHref,
+  unsupportedClaimCount,
+  uniqueEvidence,
+} from "./answer-extractors.js";
+import { SAMPLE_AGENT_ANSWER } from "./fixtures.js";
+import type { AgentAnswer } from "./answer-schema.js";
+
+describe("citedReferences", () => {
+  it("returns one entry per claim's evidence in claim order", () => {
+    const refs = citedReferences(SAMPLE_AGENT_ANSWER);
+    expect(refs.map((r) => r.reference)).toEqual([
+      "Condition/cond-dm2",
+      "MedicationRequest/mr-metformin",
+      "Encounter/enc-2024-10",
+    ]);
+  });
+});
+
+describe("dedupeReferences", () => {
+  it("collapses duplicates while preserving first-seen order", () => {
+    const out = dedupeReferences([
+      { reference: "Condition/a" },
+      { reference: "Condition/b" },
+      { reference: "Condition/a" },
+    ]);
+    expect(out.map((r) => r.reference)).toEqual([
+      "Condition/a",
+      "Condition/b",
+    ]);
+  });
+});
+
+describe("evidenceCountsByType", () => {
+  it("counts distinct cited resources by FHIR type", () => {
+    expect(evidenceCountsByType(SAMPLE_AGENT_ANSWER)).toEqual({
+      Patient: 0,
+      Condition: 1,
+      MedicationRequest: 1,
+      AllergyIntolerance: 0,
+      Encounter: 1,
+      Observation: 0,
+    });
+  });
+
+  it("does not double-count when the same reference appears in two claims", () => {
+    const answer: AgentAnswer = {
+      ...SAMPLE_AGENT_ANSWER,
+      claims: [
+        ...SAMPLE_AGENT_ANSWER.claims,
+        {
+          id: "c4",
+          text: "Same condition referenced again.",
+          evidence: [{ reference: "Condition/cond-dm2" }],
+        },
+      ],
+    };
+    expect(evidenceCountsByType(answer).Condition).toBe(1);
+  });
+});
+
+describe("unsupportedClaimCount", () => {
+  it("is 0 for any schema-valid answer", () => {
+    expect(unsupportedClaimCount(SAMPLE_AGENT_ANSWER.claims)).toBe(0);
+  });
+
+  it("counts claims with empty evidence (used as a sanity metric in evals)", () => {
+    expect(
+      unsupportedClaimCount([
+        { evidence: [{ reference: "Condition/a" }] },
+        { evidence: [] },
+        { evidence: [] },
+      ]),
+    ).toBe(2);
+  });
+});
+
+describe("duplicateClaimIds", () => {
+  it("returns ids that appear more than once", () => {
+    const answer: AgentAnswer = {
+      ...SAMPLE_AGENT_ANSWER,
+      claims: [
+        { id: "c1", text: "first", evidence: [{ reference: "Condition/a" }] },
+        { id: "c1", text: "again", evidence: [{ reference: "Condition/b" }] },
+        { id: "c2", text: "ok", evidence: [{ reference: "Condition/c" }] },
+      ],
+    };
+    expect(duplicateClaimIds(answer)).toEqual(["c1"]);
+  });
+});
+
+describe("resourceViewerHref", () => {
+  it(
+    "builds `/connections/:cid/patients/:pid/<Type>/<id>` from an evidence " +
+      "ref",
+    () => {
+      expect(
+        resourceViewerHref(SAMPLE_AGENT_ANSWER, {
+          reference: "Condition/cond-dm2",
+        }),
+      ).toBe(
+        "/connections/conn-sample/patients/pat-sample/Condition/cond-dm2",
+      );
+    },
+  );
+
+  it("returns null for a malformed reference", () => {
+    expect(
+      resourceViewerHref(SAMPLE_AGENT_ANSWER, {
+        reference: "Procedure/x",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("uniqueEvidence", () => {
+  it("dedupes within a single claim", () => {
+    const claim = {
+      id: "c",
+      text: "x",
+      evidence: [
+        { reference: "Condition/a" },
+        { reference: "Condition/a" },
+        { reference: "Condition/b" },
+      ],
+    };
+    expect(uniqueEvidence(claim).map((r) => r.reference)).toEqual([
+      "Condition/a",
+      "Condition/b",
+    ]);
+  });
+});

--- a/apps/workbench/src/agent/answer-extractors.ts
+++ b/apps/workbench/src/agent/answer-extractors.ts
@@ -1,0 +1,91 @@
+import {
+  parseResourceReference,
+  type AgentAnswer,
+  type AnswerResourceType,
+  type EvidenceBackedClaim,
+  type ResourceReference,
+} from "./answer-schema.js";
+
+/**
+ * Flat list of every cited reference across every claim, in claim order.
+ * Duplicates are preserved so callers can see "this Condition was cited
+ * three times". Use `dedupeReferences` to collapse.
+ */
+export function citedReferences(answer: AgentAnswer): ResourceReference[] {
+  return answer.claims.flatMap((c) => c.evidence);
+}
+
+export function dedupeReferences(refs: ResourceReference[]): ResourceReference[] {
+  const seen = new Set<string>();
+  const out: ResourceReference[] = [];
+  for (const r of refs) {
+    if (seen.has(r.reference)) continue;
+    seen.add(r.reference);
+    out.push(r);
+  }
+  return out;
+}
+
+/**
+ * Map of resource type → number of distinct resources cited. Useful for
+ * the renderer's "evidence summary" section and for PR 8's eval metrics.
+ */
+export function evidenceCountsByType(
+  answer: AgentAnswer,
+): Record<AnswerResourceType, number> {
+  const initial: Record<AnswerResourceType, number> = {
+    Patient: 0,
+    Condition: 0,
+    MedicationRequest: 0,
+    AllergyIntolerance: 0,
+    Encounter: 0,
+    Observation: 0,
+  };
+  for (const ref of dedupeReferences(citedReferences(answer))) {
+    const parsed = parseResourceReference(ref.reference);
+    if (parsed) initial[parsed.resourceType] += 1;
+  }
+  return initial;
+}
+
+/**
+ * The number of supported claims that don't cite any evidence. This must
+ * always return 0 for a schema-valid answer — the schema enforces
+ * `evidence.min(1)`. PR 8's eval harness reports this as a sanity metric
+ * for non-validated outputs (e.g. raw LLM JSON before parse).
+ */
+export function unsupportedClaimCount(
+  claims: ReadonlyArray<{ evidence: readonly unknown[] }>,
+): number {
+  return claims.filter((c) => c.evidence.length === 0).length;
+}
+
+/** Distinct claim ids cited by their text. Surfaces accidental dupes. */
+export function duplicateClaimIds(answer: AgentAnswer): string[] {
+  const seen = new Set<string>();
+  const dups = new Set<string>();
+  for (const c of answer.claims) {
+    if (seen.has(c.id)) dups.add(c.id);
+    else seen.add(c.id);
+  }
+  return [...dups];
+}
+
+/**
+ * The renderer wants to link `Condition/abc-123` to the resource viewer at
+ * `/connections/:cid/patients/:pid/Condition/abc-123`. Returns null for a
+ * malformed reference (which the schema would already have rejected).
+ */
+export function resourceViewerHref(
+  answer: AgentAnswer,
+  ref: ResourceReference,
+): string | null {
+  const parsed = parseResourceReference(ref.reference);
+  if (!parsed) return null;
+  return `/connections/${encodeURIComponent(answer.connectionId)}/patients/${encodeURIComponent(answer.patientId)}/${parsed.resourceType}/${encodeURIComponent(parsed.id)}`;
+}
+
+/** Convenience: the unique evidence references in citation order. */
+export function uniqueEvidence(claim: EvidenceBackedClaim): ResourceReference[] {
+  return dedupeReferences(claim.evidence);
+}

--- a/apps/workbench/src/agent/answer-schema.test.ts
+++ b/apps/workbench/src/agent/answer-schema.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentAnswer,
+  EvidenceBackedClaim,
+  RESOURCE_REFERENCE_REGEX,
+  ResourceReference,
+  parseAgentAnswer,
+  parseResourceReference,
+} from "./answer-schema.js";
+import { SAMPLE_AGENT_ANSWER } from "./fixtures.js";
+
+describe("RESOURCE_REFERENCE_REGEX", () => {
+  it.each([
+    "Patient/abc-123",
+    "Condition/cond-dm2",
+    "MedicationRequest/mr-1",
+    "AllergyIntolerance/al.1",
+    "Encounter/enc-2024-10",
+    "Observation/obs-9",
+  ])("accepts %s", (ref) => {
+    expect(RESOURCE_REFERENCE_REGEX.test(ref)).toBe(true);
+  });
+
+  it.each([
+    "Procedure/abc-123",
+    "DocumentReference/doc-1",
+    "patient/abc-123",
+    "Patient",
+    "Patient/",
+    "Patient/foo bar",
+    "Patient/../OperationDefinition",
+    `Patient/${"a".repeat(65)}`,
+  ])("rejects %s", (ref) => {
+    expect(RESOURCE_REFERENCE_REGEX.test(ref)).toBe(false);
+  });
+});
+
+describe("parseResourceReference", () => {
+  it("parses a valid reference", () => {
+    expect(parseResourceReference("Condition/abc-123")).toEqual({
+      resourceType: "Condition",
+      id: "abc-123",
+    });
+  });
+
+  it("returns null for an invalid reference", () => {
+    expect(parseResourceReference("Procedure/abc")).toBeNull();
+    expect(parseResourceReference("nonsense")).toBeNull();
+  });
+});
+
+describe("ResourceReference schema", () => {
+  it("validates `Condition/abc-123` with optional display", () => {
+    const result = ResourceReference.safeParse({
+      reference: "Condition/abc-123",
+      display: "Type 2 diabetes",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a reference outside the Phase A allow-list", () => {
+    expect(
+      ResourceReference.safeParse({ reference: "Procedure/abc-123" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("EvidenceBackedClaim schema", () => {
+  it("rejects a claim with zero evidence (the load-bearing safety property)", () => {
+    const result = EvidenceBackedClaim.safeParse({
+      id: "c1",
+      text: "The patient has diabetes.",
+      evidence: [],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) => i.path.join(".") === "evidence"),
+      ).toBe(true);
+    }
+  });
+
+  it("accepts a claim with one valid reference", () => {
+    expect(
+      EvidenceBackedClaim.safeParse({
+        id: "c1",
+        text: "Documented Type 2 diabetes.",
+        evidence: [{ reference: "Condition/abc-123" }],
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe("AgentAnswer schema", () => {
+  it("accepts the sample fixture", () => {
+    expect(AgentAnswer.safeParse(SAMPLE_AGENT_ANSWER).success).toBe(true);
+  });
+
+  it("rejects a different schemaVersion", () => {
+    const bad = { ...SAMPLE_AGENT_ANSWER, schemaVersion: "0" };
+    expect(AgentAnswer.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejects an answer with a supported claim that has no evidence", () => {
+    const bad = {
+      ...SAMPLE_AGENT_ANSWER,
+      claims: [
+        {
+          id: "bad",
+          text: "I think this patient has diabetes.",
+          evidence: [],
+        },
+      ],
+    };
+    const result = AgentAnswer.safeParse(bad);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join("."));
+      expect(paths.some((p) => p.startsWith("claims.0.evidence"))).toBe(true);
+    }
+  });
+
+  it(
+    "rejects an answer whose claim cites a Procedure (outside the Phase A " +
+      "allow-list)",
+    () => {
+      const bad = {
+        ...SAMPLE_AGENT_ANSWER,
+        claims: [
+          {
+            id: "c1",
+            text: "Recent procedure.",
+            evidence: [{ reference: "Procedure/p1" }],
+          },
+        ],
+      };
+      expect(AgentAnswer.safeParse(bad).success).toBe(false);
+    },
+  );
+
+  it(
+    "treats `missingData` and `cannotDetermine` as required top-level " +
+      "arrays — even when empty, the keys must be present",
+    () => {
+      const { missingData, ...withoutMissing } = SAMPLE_AGENT_ANSWER;
+      expect(missingData).toBeDefined();
+      expect(AgentAnswer.safeParse(withoutMissing).success).toBe(false);
+    },
+  );
+
+  it("rejects an empty prompt", () => {
+    const bad = { ...SAMPLE_AGENT_ANSWER, prompt: "" };
+    expect(AgentAnswer.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe("parseAgentAnswer", () => {
+  it("returns ok on the fixture", () => {
+    const result = parseAgentAnswer(SAMPLE_AGENT_ANSWER);
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns ok=false with the issues array for an invalid input", () => {
+    const result = parseAgentAnswer({ schemaVersion: "1" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.issues.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/workbench/src/agent/answer-schema.ts
+++ b/apps/workbench/src/agent/answer-schema.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+
+/**
+ * The Phase A allow-listed FHIR resource types (mirrors the server-side
+ * allow-list in `apps/workbench/server/schemas.ts`). An evidence reference
+ * outside this list is rejected at the schema boundary.
+ */
+export const ANSWER_RESOURCE_TYPES = [
+  "Patient",
+  "Condition",
+  "MedicationRequest",
+  "AllergyIntolerance",
+  "Encounter",
+  "Observation",
+] as const;
+export type AnswerResourceType = (typeof ANSWER_RESOURCE_TYPES)[number];
+
+const RESOURCE_TYPE_GROUP = `(?:${ANSWER_RESOURCE_TYPES.join("|")})`;
+const FHIR_ID = String.raw`[A-Za-z0-9\-.]{1,64}`;
+export const RESOURCE_REFERENCE_REGEX = new RegExp(
+  `^${RESOURCE_TYPE_GROUP}/${FHIR_ID}$`,
+);
+
+/**
+ * A single FHIR resource the answer cites. The reference is a relative URL
+ * (`Condition/abc-123`) so it round-trips to the resource viewer in PR 3
+ * without any URL rewriting.
+ */
+export const ResourceReference = z.object({
+  reference: z
+    .string()
+    .regex(
+      RESOURCE_REFERENCE_REGEX,
+      "expected `<AllowedType>/<fhir-id>` (e.g. `Condition/abc-123`)",
+    ),
+  display: z.string().max(200).optional(),
+});
+export type ResourceReference = z.infer<typeof ResourceReference>;
+
+/**
+ * Parsed view of a `ResourceReference.reference` string. Use
+ * `parseResourceReference` rather than splitting by hand — anything past
+ * the first `/` is part of the id.
+ */
+export interface ParsedResourceReference {
+  resourceType: AnswerResourceType;
+  id: string;
+}
+
+export function parseResourceReference(
+  ref: string,
+): ParsedResourceReference | null {
+  if (!RESOURCE_REFERENCE_REGEX.test(ref)) return null;
+  const slash = ref.indexOf("/");
+  return {
+    resourceType: ref.slice(0, slash) as AnswerResourceType,
+    id: ref.slice(slash + 1),
+  };
+}
+
+/**
+ * A claim the agent supports about the patient. Phase A's hard rule is
+ * that supported claims MUST cite at least one resource — the schema
+ * enforces this via `.min(1)`, so a malformed answer fails validation
+ * before render rather than producing an unverified statement.
+ *
+ * Missing-data and cannot-determine statements live in their own
+ * top-level fields, not here, so an "I don't know" cannot be smuggled
+ * through as an evidence-less claim.
+ */
+export const EvidenceBackedClaim = z.object({
+  id: z.string().min(1).max(64),
+  text: z.string().min(1).max(2000),
+  evidence: z
+    .array(ResourceReference)
+    .min(1, "supported claims must cite at least one resource"),
+});
+export type EvidenceBackedClaim = z.infer<typeof EvidenceBackedClaim>;
+
+export const MissingDataEntry = z.object({
+  description: z.string().min(1).max(500),
+});
+export type MissingDataEntry = z.infer<typeof MissingDataEntry>;
+
+export const CannotDetermineEntry = z.object({
+  question: z.string().min(1).max(500),
+  why: z.string().min(1).max(500),
+});
+export type CannotDetermineEntry = z.infer<typeof CannotDetermineEntry>;
+
+/**
+ * A redacted summary of a single tool call from the agent loop. Mirrors
+ * the shape of `ToolEnvelope` (PR 4) but excludes raw inputs and full
+ * data — just the audit-relevant fields. Persistence lands in PR 7.
+ */
+export const ToolCallSummary = z.object({
+  tool: z.string().min(1),
+  toolVersion: z.string().min(1),
+  ok: z.boolean(),
+  reason: z.string().optional(),
+  count: z.number().int().nonnegative().optional(),
+  truncated: z.boolean().optional(),
+  durationMs: z.number().nonnegative(),
+  resourceIds: z.array(z.string()).optional(),
+});
+export type ToolCallSummary = z.infer<typeof ToolCallSummary>;
+
+export const AGENT_ANSWER_SCHEMA_VERSION = "1" as const;
+
+export const AgentAnswer = z.object({
+  schemaVersion: z.literal(AGENT_ANSWER_SCHEMA_VERSION),
+  sessionId: z.string().min(1),
+  connectionId: z.string().min(1),
+  patientId: z.string().min(1),
+  prompt: z.string().min(1),
+  promptVersion: z.string().min(1).optional(),
+  model: z.string().min(1).optional(),
+  provider: z.string().min(1).optional(),
+  /** Short free-text overview. May be empty / omitted. Never load-bearing. */
+  summary: z.string().max(2000).optional(),
+  claims: z.array(EvidenceBackedClaim),
+  missingData: z.array(MissingDataEntry),
+  cannotDetermine: z.array(CannotDetermineEntry),
+  toolCalls: z.array(ToolCallSummary),
+  createdAt: z.string().min(1),
+});
+export type AgentAnswer = z.infer<typeof AgentAnswer>;
+
+export type AgentAnswerValidation =
+  | { ok: true; answer: AgentAnswer }
+  | { ok: false; error: string; issues: z.ZodIssue[] };
+
+/** Parse + validate. Use this; the renderer trusts its input. */
+export function parseAgentAnswer(input: unknown): AgentAnswerValidation {
+  const result = AgentAnswer.safeParse(input);
+  if (result.success) return { ok: true, answer: result.data };
+  return {
+    ok: false,
+    error: "AgentAnswer failed schema validation",
+    issues: result.error.issues,
+  };
+}

--- a/apps/workbench/src/agent/fixtures.ts
+++ b/apps/workbench/src/agent/fixtures.ts
@@ -1,0 +1,117 @@
+import { type AgentAnswer } from "./answer-schema.js";
+
+/**
+ * A known-good `AgentAnswer` used by tests, the answer-preview page,
+ * and (in PR 8) the eval-harness golden snapshots. The shape demonstrates:
+ *
+ *   - supported claims with FHIR-style relative references,
+ *   - missing-data and cannot-determine as first-class top-level fields,
+ *   - a tool-call timeline mirroring `ToolEnvelope` summaries,
+ *   - resource-type breadth across the Phase A allow-list.
+ */
+export const SAMPLE_AGENT_ANSWER: AgentAnswer = {
+  schemaVersion: "1",
+  sessionId: "sess-sample",
+  connectionId: "conn-sample",
+  patientId: "pat-sample",
+  prompt: "Summarise this patient.",
+  promptVersion: "patient-summary@v0",
+  summary:
+    "78-year-old female with documented type 2 diabetes and hypertension. " +
+    "Allergy data was queried but none was recorded.",
+  claims: [
+    {
+      id: "c1",
+      text: "The patient has documented Type 2 diabetes mellitus.",
+      evidence: [
+        {
+          reference: "Condition/cond-dm2",
+          display: "Type 2 diabetes mellitus (active)",
+        },
+      ],
+    },
+    {
+      id: "c2",
+      text: "The patient is currently prescribed metformin.",
+      evidence: [
+        {
+          reference: "MedicationRequest/mr-metformin",
+          display: "Metformin 500 mg PO BID (active)",
+        },
+      ],
+    },
+    {
+      id: "c3",
+      text: "The patient had a primary-care encounter in October 2024.",
+      evidence: [
+        {
+          reference: "Encounter/enc-2024-10",
+          display: "Primary-care visit · 2024-10-12",
+        },
+      ],
+    },
+  ],
+  missingData: [
+    {
+      description:
+        "No AllergyIntolerance resources were returned for this patient. " +
+        "Treat as 'no allergy data recorded', not 'no known allergies'.",
+    },
+  ],
+  cannotDetermine: [
+    {
+      question: "Is the patient's diabetes well controlled?",
+      why:
+        "No HbA1c laboratory Observation was returned in the last 12 months; " +
+        "controlled / uncontrolled cannot be inferred without that data.",
+    },
+  ],
+  toolCalls: [
+    {
+      tool: "getPatient",
+      toolVersion: "1",
+      ok: true,
+      durationMs: 12,
+      resourceIds: ["Patient/pat-sample"],
+    },
+    {
+      tool: "searchConditionsForPatient",
+      toolVersion: "1",
+      ok: true,
+      count: 2,
+      durationMs: 18,
+      resourceIds: ["Condition/cond-dm2", "Condition/cond-htn"],
+    },
+    {
+      tool: "searchMedicationRequestsForPatient",
+      toolVersion: "1",
+      ok: true,
+      count: 1,
+      durationMs: 14,
+      resourceIds: ["MedicationRequest/mr-metformin"],
+    },
+    {
+      tool: "searchAllergyIntolerancesForPatient",
+      toolVersion: "1",
+      ok: true,
+      count: 0,
+      durationMs: 9,
+    },
+    {
+      tool: "searchEncountersForPatient",
+      toolVersion: "1",
+      ok: true,
+      count: 1,
+      durationMs: 21,
+      resourceIds: ["Encounter/enc-2024-10"],
+    },
+    {
+      tool: "searchObservationsForPatient",
+      toolVersion: "1",
+      ok: true,
+      count: 0,
+      durationMs: 17,
+    },
+  ],
+  createdAt: "2026-04-30T13:00:00.000Z",
+};

--- a/apps/workbench/src/api/connections.ts
+++ b/apps/workbench/src/api/connections.ts
@@ -1,0 +1,85 @@
+export type ConnectionKind = "fhir_clinical";
+export type AuthType = "none" | "bearer";
+
+export interface ConnectionRow {
+  id: string;
+  name: string;
+  kind: ConnectionKind;
+  baseUrl: string;
+  authType: AuthType;
+  hasAuthToken: boolean;
+  createdAt: string;
+  updatedAt: string;
+  lastCapabilityAt: string | null;
+  lastCapabilityStatus: "ok" | "error" | null;
+  lastCapabilityFhirVersion: string | null;
+  lastCapabilitySoftware: string | null;
+  lastCapabilityJson: string | null;
+  lastCapabilityError: string | null;
+}
+
+export interface CreateConnectionInput {
+  name: string;
+  kind: ConnectionKind;
+  baseUrl: string;
+  authType: AuthType;
+  authToken?: string;
+}
+
+export type CapabilityProbeResult =
+  | { ok: true; fhirVersion: string | null; software: string | null; raw: unknown }
+  | { ok: false; error: string };
+
+async function handle<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    let detail = "";
+    try {
+      detail = JSON.stringify(await res.json());
+    } catch {
+      detail = await res.text();
+    }
+    throw new Error(`${res.status} ${res.statusText}: ${detail}`);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+export async function listConnections(): Promise<ConnectionRow[]> {
+  const res = await fetch("/api/connections");
+  const body = await handle<{ connections: ConnectionRow[] }>(res);
+  return body.connections;
+}
+
+export async function getConnection(id: string): Promise<ConnectionRow> {
+  const res = await fetch(`/api/connections/${encodeURIComponent(id)}`);
+  const body = await handle<{ connection: ConnectionRow }>(res);
+  return body.connection;
+}
+
+export async function createConnection(
+  input: CreateConnectionInput,
+): Promise<ConnectionRow> {
+  const res = await fetch("/api/connections", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  const body = await handle<{ connection: ConnectionRow }>(res);
+  return body.connection;
+}
+
+export async function testConnection(
+  id: string,
+): Promise<{ connection: ConnectionRow; capability: CapabilityProbeResult }> {
+  const res = await fetch(`/api/connections/${encodeURIComponent(id)}/test`, {
+    method: "POST",
+  });
+  return handle<{ connection: ConnectionRow; capability: CapabilityProbeResult }>(res);
+}
+
+export async function deleteConnection(id: string): Promise<void> {
+  const res = await fetch(`/api/connections/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+  await handle<void>(res);
+}

--- a/apps/workbench/src/api/fhir.ts
+++ b/apps/workbench/src/api/fhir.ts
@@ -1,0 +1,113 @@
+/**
+ * Frontend client for the read-only FHIR proxy. All requests go through
+ * `/api/connections/:cid/fhir/*` so the auth token never reaches the
+ * browser and the resource-type / search-param allow-lists are enforced
+ * server-side.
+ */
+
+import type {
+  Bundle,
+  Patient,
+  Resource,
+} from "fhir/r4";
+
+export const ALLOWED_RESOURCE_TYPES = [
+  "Patient",
+  "Condition",
+  "MedicationRequest",
+  "AllergyIntolerance",
+  "Encounter",
+  "Observation",
+] as const;
+export type AllowedResourceType = (typeof ALLOWED_RESOURCE_TYPES)[number];
+
+export interface PatientSearchParams {
+  name?: string;
+  identifier?: string;
+  birthdate?: string;
+  gender?: string;
+  count?: number;
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { headers: { Accept: "application/json" } });
+  let body: unknown = null;
+  try {
+    body = await res.json();
+  } catch {
+    // ignore
+  }
+  if (!res.ok) {
+    const detail =
+      body && typeof body === "object"
+        ? JSON.stringify(body)
+        : String(body ?? res.statusText);
+    throw new Error(`${res.status} ${res.statusText}: ${detail}`);
+  }
+  return body as T;
+}
+
+function fhirUrl(connectionId: string, path: string, query?: URLSearchParams) {
+  const base = `/api/connections/${encodeURIComponent(connectionId)}/fhir/${path}`;
+  return query && query.toString() ? `${base}?${query}` : base;
+}
+
+export async function searchPatients(
+  connectionId: string,
+  params: PatientSearchParams,
+): Promise<Bundle> {
+  const q = new URLSearchParams();
+  if (params.name) q.set("name", params.name);
+  if (params.identifier) q.set("identifier", params.identifier);
+  if (params.birthdate) q.set("birthdate", params.birthdate);
+  if (params.gender) q.set("gender", params.gender);
+  q.set("_count", String(Math.min(params.count ?? 20, 100)));
+  return getJson<Bundle>(fhirUrl(connectionId, "Patient", q));
+}
+
+export async function getPatient(
+  connectionId: string,
+  patientId: string,
+): Promise<Patient> {
+  return getJson<Patient>(
+    fhirUrl(connectionId, `Patient/${encodeURIComponent(patientId)}`),
+  );
+}
+
+export async function searchByPatient(
+  connectionId: string,
+  resourceType: Exclude<AllowedResourceType, "Patient">,
+  patientId: string,
+  extra?: Record<string, string>,
+): Promise<Bundle> {
+  const q = new URLSearchParams();
+  q.set("patient", `Patient/${patientId}`);
+  q.set("_count", "50");
+  if (extra) {
+    for (const [k, v] of Object.entries(extra)) q.set(k, v);
+  }
+  return getJson<Bundle>(fhirUrl(connectionId, resourceType, q));
+}
+
+export async function readResource<T extends Resource = Resource>(
+  connectionId: string,
+  resourceType: AllowedResourceType,
+  resourceId: string,
+): Promise<T> {
+  return getJson<T>(
+    fhirUrl(
+      connectionId,
+      `${resourceType}/${encodeURIComponent(resourceId)}`,
+    ),
+  );
+}
+
+export function bundleEntries<T extends Resource = Resource>(
+  bundle: Bundle | undefined,
+): T[] {
+  return (
+    (bundle?.entry
+      ?.map((e) => e.resource as T | undefined)
+      .filter((r): r is T => Boolean(r)) ?? [])
+  );
+}

--- a/apps/workbench/src/api/sessions.ts
+++ b/apps/workbench/src/api/sessions.ts
@@ -1,0 +1,107 @@
+/**
+ * Frontend client for `/api/sessions` and the patient-scoped tool runner.
+ *
+ * Tools are typed and patient-scoped server-side; this client just shapes the
+ * request and surfaces the normalized envelope back to React.
+ */
+
+export interface AgentSession {
+  id: string;
+  connectionId: string;
+  patientId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ToolMeta {
+  name: string;
+  version: string;
+  description: string;
+  resourceAllowlist: string[];
+  resultLimit: number;
+  timeoutMs: number;
+}
+
+export type ToolEnvelope =
+  | {
+      ok: true;
+      tool: string;
+      toolVersion: string;
+      data: unknown;
+      count?: number;
+      truncated?: boolean;
+      durationMs: number;
+    }
+  | {
+      ok: false;
+      tool: string;
+      toolVersion: string;
+      error: string;
+      reason: string;
+      issues?: unknown;
+      upstream?: unknown;
+      durationMs: number;
+    };
+
+async function http<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  let body: unknown = null;
+  try {
+    body = await res.json();
+  } catch {
+    // ignore
+  }
+  if (!res.ok) {
+    const detail =
+      body && typeof body === "object"
+        ? JSON.stringify(body)
+        : String(body ?? res.statusText);
+    throw new Error(`${res.status} ${res.statusText}: ${detail}`);
+  }
+  return body as T;
+}
+
+export async function createSession(
+  connectionId: string,
+  patientId: string,
+): Promise<AgentSession> {
+  const body = await http<{ session: AgentSession }>("/api/sessions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ connectionId, patientId }),
+  });
+  return body.session;
+}
+
+export async function getSession(id: string): Promise<AgentSession> {
+  const body = await http<{ session: AgentSession }>(
+    `/api/sessions/${encodeURIComponent(id)}`,
+  );
+  return body.session;
+}
+
+export async function listTools(): Promise<ToolMeta[]> {
+  const body = await http<{ tools: ToolMeta[] }>("/api/sessions/tools");
+  return body.tools;
+}
+
+/**
+ * Run a tool. Returns the envelope regardless of HTTP status (the envelope's
+ * `ok` and `reason` fields are the source of truth) — only network-level
+ * failures throw.
+ */
+export async function runTool(
+  sessionId: string,
+  toolName: string,
+  input: Record<string, unknown>,
+): Promise<ToolEnvelope> {
+  const res = await fetch(
+    `/api/sessions/${encodeURIComponent(sessionId)}/tools/${encodeURIComponent(toolName)}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    },
+  );
+  return (await res.json()) as ToolEnvelope;
+}

--- a/apps/workbench/src/components/ConnectionStatusBadge.tsx
+++ b/apps/workbench/src/components/ConnectionStatusBadge.tsx
@@ -1,0 +1,27 @@
+import type { ConnectionRow } from "../api/connections.js";
+
+export function ConnectionStatusBadge({ connection }: { connection: ConnectionRow }) {
+  const status = connection.lastCapabilityStatus;
+  if (status === "ok") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800">
+        <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+        connected
+      </span>
+    );
+  }
+  if (status === "error") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-rose-100 px-2 py-0.5 text-xs font-medium text-rose-800">
+        <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-rose-500" />
+        error
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700">
+      <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-slate-400" />
+      untested
+    </span>
+  );
+}

--- a/apps/workbench/src/components/PatientName.test.tsx
+++ b/apps/workbench/src/components/PatientName.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { patientDisplayName, formatHumanName } from "./PatientName.js";
+
+describe("patientDisplayName", () => {
+  it("prefers official > usual > first name", () => {
+    expect(
+      patientDisplayName({
+        resourceType: "Patient",
+        name: [
+          { use: "usual", text: "Grace" },
+          { use: "official", family: "Hopper", given: ["Grace"] },
+        ],
+      }),
+    ).toBe("Grace Hopper");
+  });
+
+  it("falls back to .text when given/family missing", () => {
+    expect(
+      patientDisplayName({
+        resourceType: "Patient",
+        name: [{ text: "Unknown" }],
+      }),
+    ).toBe("Unknown");
+  });
+
+  it("returns (no name) when name array is empty", () => {
+    expect(patientDisplayName({ resourceType: "Patient", name: [] })).toBe(
+      "(no name)",
+    );
+  });
+
+  it("returns (unknown) when patient is undefined", () => {
+    expect(patientDisplayName(undefined)).toBe("(unknown)");
+  });
+});
+
+describe("formatHumanName", () => {
+  it("joins given and family", () => {
+    expect(formatHumanName({ given: ["Jane", "Q."], family: "Doe" })).toBe(
+      "Jane Q. Doe",
+    );
+  });
+
+  it("returns (no name) for an empty HumanName", () => {
+    expect(formatHumanName({})).toBe("(no name)");
+  });
+});

--- a/apps/workbench/src/components/PatientName.tsx
+++ b/apps/workbench/src/components/PatientName.tsx
@@ -1,0 +1,20 @@
+import type { HumanName, Patient } from "fhir/r4";
+
+export function patientDisplayName(patient: Patient | undefined): string {
+  if (!patient) return "(unknown)";
+  const official = patient.name?.find((n) => n.use === "official");
+  const usual = patient.name?.find((n) => n.use === "usual");
+  return formatHumanName(official ?? usual ?? patient.name?.[0]);
+}
+
+export function formatHumanName(name: HumanName | undefined): string {
+  if (!name) return "(no name)";
+  if (name.text) return name.text;
+  const given = (name.given ?? []).join(" ");
+  const family = name.family ?? "";
+  return [given, family].filter(Boolean).join(" ").trim() || "(no name)";
+}
+
+export function PatientName({ patient }: { patient: Patient | undefined }) {
+  return <>{patientDisplayName(patient)}</>;
+}

--- a/apps/workbench/src/components/SyntheticOnlyBanner.test.tsx
+++ b/apps/workbench/src/components/SyntheticOnlyBanner.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SyntheticOnlyBanner } from "./SyntheticOnlyBanner.js";
+
+describe("SyntheticOnlyBanner", () => {
+  it("renders the synthetic-only / not-for-clinical-use warning", () => {
+    const html = renderToStaticMarkup(<SyntheticOnlyBanner />);
+    expect(html).toMatch(/synthetic data only/i);
+    expect(html).toMatch(/not for clinical use/i);
+    expect(html).toMatch(/role="alert"/);
+  });
+});

--- a/apps/workbench/src/components/SyntheticOnlyBanner.tsx
+++ b/apps/workbench/src/components/SyntheticOnlyBanner.tsx
@@ -1,0 +1,12 @@
+export function SyntheticOnlyBanner() {
+  return (
+    <div
+      role="alert"
+      data-testid="synthetic-only-banner"
+      className="border-b border-amber-300 bg-amber-100 px-4 py-2 text-center text-xs font-medium text-amber-900"
+    >
+      <span className="font-semibold">Synthetic data only.</span>{" "}
+      Not for clinical use. Do not enter real patient information.
+    </div>
+  );
+}

--- a/apps/workbench/src/config.ts
+++ b/apps/workbench/src/config.ts
@@ -1,0 +1,10 @@
+export const USE_MOCK =
+  import.meta.env.VITE_USE_MOCK === "true" || import.meta.env.DEV;
+
+const BASE = import.meta.env.BASE_URL;
+
+export const FHIR_BASE_URL: string =
+  import.meta.env.VITE_FHIR_BASE_URL ??
+  (USE_MOCK ? `${BASE}fhir` : "https://hapi.fhir.org/baseR4");
+
+export const ROUTER_BASENAME: string = BASE.replace(/\/$/, "") || "/";

--- a/apps/workbench/src/index.css
+++ b/apps/workbench/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/workbench/src/main.tsx
+++ b/apps/workbench/src/main.tsx
@@ -1,0 +1,26 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { FetchFhirClient, FhirClientProvider } from "@fhir-place/react-fhir";
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { App } from "./App.js";
+import { FHIR_BASE_URL, ROUTER_BASENAME } from "./config.js";
+import "./index.css";
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { staleTime: 30_000, retry: 1 } },
+});
+
+const fhirClient = new FetchFhirClient({ baseUrl: FHIR_BASE_URL });
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <FhirClientProvider client={fhirClient}>
+        <BrowserRouter basename={ROUTER_BASENAME}>
+          <App />
+        </BrowserRouter>
+      </FhirClientProvider>
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/apps/workbench/src/pages/AnswerPreviewPage.tsx
+++ b/apps/workbench/src/pages/AnswerPreviewPage.tsx
@@ -1,0 +1,122 @@
+import { useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { AgentAnswerRenderer } from "../agent/AgentAnswerRenderer.js";
+import {
+  parseAgentAnswer,
+  type AgentAnswerValidation,
+} from "../agent/answer-schema.js";
+import { SAMPLE_AGENT_ANSWER } from "../agent/fixtures.js";
+
+export function AnswerPreviewPage() {
+  const { sid } = useParams<{ sid?: string }>();
+  const [text, setText] = useState<string>(() =>
+    JSON.stringify(SAMPLE_AGENT_ANSWER, null, 2),
+  );
+
+  const validation = useMemo<
+    AgentAnswerValidation | { ok: false; error: string; issues: never[] }
+  >(() => {
+    if (!text.trim())
+      return { ok: false, error: "empty input", issues: [] as never[] };
+    try {
+      return parseAgentAnswer(JSON.parse(text));
+    } catch (e) {
+      return {
+        ok: false,
+        error: `JSON parse error: ${(e as Error).message}`,
+        issues: [] as never[],
+      };
+    }
+  }, [text]);
+
+  return (
+    <section className="space-y-4">
+      {sid && (
+        <Link
+          to={`/sessions/${sid}`}
+          className="text-sm text-slate-600 hover:underline"
+        >
+          ← Back to session
+        </Link>
+      )}
+
+      <header>
+        <h1 className="text-2xl font-semibold text-slate-900">
+          AgentAnswer preview
+        </h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Paste a structured answer below to validate it against the
+          schema and render it. Phase A's hard rule is that supported
+          claims MUST cite at least one resource — invalid answers fail
+          validation here, before render.
+        </p>
+      </header>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <label
+              htmlFor="answer-json"
+              className="text-sm font-medium text-slate-700"
+            >
+              AgentAnswer JSON
+            </label>
+            <button
+              type="button"
+              onClick={() => setText(JSON.stringify(SAMPLE_AGENT_ANSWER, null, 2))}
+              className="text-xs text-slate-600 underline hover:text-slate-900"
+              data-testid="reset-sample"
+            >
+              load sample
+            </button>
+          </div>
+          <textarea
+            id="answer-json"
+            data-testid="answer-json"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            spellCheck={false}
+            className="h-[60vh] w-full rounded-md border border-slate-300 bg-white p-3 font-mono text-xs"
+          />
+          {!validation.ok && (
+            <div
+              data-testid="validation-error"
+              className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800"
+            >
+              <p className="font-semibold">{validation.error}</p>
+              {validation.issues.length > 0 && (
+                <ul className="mt-2 list-disc space-y-1 pl-5 font-mono text-xs">
+                  {validation.issues.map((iss, i) => (
+                    <li key={i}>
+                      <code>{iss.path.join(".") || "(root)"}</code>: {iss.message}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+          {validation.ok && (
+            <p
+              data-testid="validation-ok"
+              className="rounded-md border border-emerald-200 bg-emerald-50 p-2 text-sm text-emerald-800"
+            >
+              Valid AgentAnswer · {validation.answer.claims.length} claims ·{" "}
+              {validation.answer.missingData.length} missing-data ·{" "}
+              {validation.answer.cannotDetermine.length} cannot-determine
+            </p>
+          )}
+        </div>
+
+        <div>
+          {validation.ok ? (
+            <AgentAnswerRenderer answer={validation.answer} />
+          ) : (
+            <div className="rounded-md border border-dashed border-slate-300 bg-white p-6 text-center text-sm text-slate-500">
+              Render appears here once the JSON validates.
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/workbench/src/pages/ConnectionDetailPage.tsx
+++ b/apps/workbench/src/pages/ConnectionDetailPage.tsx
@@ -57,15 +57,24 @@ export function ConnectionDetailPage() {
                 {conn.data.baseUrl}
               </p>
             </div>
-            <button
-              type="button"
-              onClick={() => test.mutate()}
-              disabled={test.isPending}
-              className="shrink-0 rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50"
-              data-testid="test-connection"
-            >
-              {test.isPending ? "Testing…" : "Test connection"}
-            </button>
+            <div className="flex shrink-0 gap-2">
+              <Link
+                to={`/connections/${id}/patients`}
+                className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+                data-testid="browse-patients"
+              >
+                Browse patients
+              </Link>
+              <button
+                type="button"
+                onClick={() => test.mutate()}
+                disabled={test.isPending}
+                className="rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+                data-testid="test-connection"
+              >
+                {test.isPending ? "Testing…" : "Test connection"}
+              </button>
+            </div>
           </header>
 
           <section className="rounded-md border border-slate-200 bg-white p-4 text-sm">

--- a/apps/workbench/src/pages/ConnectionDetailPage.tsx
+++ b/apps/workbench/src/pages/ConnectionDetailPage.tsx
@@ -1,0 +1,126 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useParams } from "react-router-dom";
+import { getConnection, testConnection } from "../api/connections.js";
+import { ConnectionStatusBadge } from "../components/ConnectionStatusBadge.js";
+
+export function ConnectionDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const qc = useQueryClient();
+
+  const conn = useQuery({
+    queryKey: ["connections", id],
+    queryFn: () => getConnection(id!),
+    enabled: Boolean(id),
+  });
+
+  const test = useMutation({
+    mutationFn: () => testConnection(id!),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["connections"] });
+      qc.invalidateQueries({ queryKey: ["connections", id] });
+    },
+  });
+
+  if (!id) return null;
+
+  return (
+    <section className="space-y-4">
+      <Link
+        to="/connections"
+        className="text-sm text-slate-600 hover:underline"
+      >
+        ← All connections
+      </Link>
+
+      {conn.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
+      {conn.isError && (
+        <p className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">
+          {(conn.error as Error).message}
+        </p>
+      )}
+
+      {conn.data && (
+        <>
+          <header className="flex items-start justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-2">
+                <h1 className="text-2xl font-semibold text-slate-900">
+                  {conn.data.name}
+                </h1>
+                <ConnectionStatusBadge connection={conn.data} />
+              </div>
+              <p className="mt-1 text-sm text-slate-600">
+                {conn.data.kind} · {conn.data.authType}
+                {conn.data.hasAuthToken ? " (token)" : ""}
+              </p>
+              <p className="mt-1 break-all font-mono text-xs text-slate-500">
+                {conn.data.baseUrl}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => test.mutate()}
+              disabled={test.isPending}
+              className="shrink-0 rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+              data-testid="test-connection"
+            >
+              {test.isPending ? "Testing…" : "Test connection"}
+            </button>
+          </header>
+
+          <section className="rounded-md border border-slate-200 bg-white p-4 text-sm">
+            <h2 className="mb-2 text-base font-semibold text-slate-900">
+              CapabilityStatement
+            </h2>
+            {conn.data.lastCapabilityStatus === null && (
+              <p className="text-slate-500">
+                Not tested yet. Click <strong>Test connection</strong> to fetch{" "}
+                <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
+                  /metadata
+                </code>
+                .
+              </p>
+            )}
+            {conn.data.lastCapabilityStatus === "ok" && (
+              <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1">
+                <dt className="text-slate-500">Fetched</dt>
+                <dd>{conn.data.lastCapabilityAt}</dd>
+                <dt className="text-slate-500">FHIR version</dt>
+                <dd>{conn.data.lastCapabilityFhirVersion ?? "—"}</dd>
+                <dt className="text-slate-500">Software</dt>
+                <dd>{conn.data.lastCapabilitySoftware ?? "—"}</dd>
+              </dl>
+            )}
+            {conn.data.lastCapabilityStatus === "error" && (
+              <div className="space-y-1">
+                <p className="text-rose-700">{conn.data.lastCapabilityError}</p>
+                <p className="text-xs text-slate-500">
+                  Last attempt: {conn.data.lastCapabilityAt}
+                </p>
+              </div>
+            )}
+          </section>
+
+          {conn.data.lastCapabilityJson && (
+            <details className="rounded-md border border-slate-200 bg-white p-3 text-sm">
+              <summary className="cursor-pointer text-slate-700">
+                Raw CapabilityStatement
+              </summary>
+              <pre className="mt-2 max-h-96 overflow-auto whitespace-pre-wrap break-all rounded bg-slate-50 p-2 text-xs text-slate-700">
+                {pretty(conn.data.lastCapabilityJson)}
+              </pre>
+            </details>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+function pretty(json: string): string {
+  try {
+    return JSON.stringify(JSON.parse(json), null, 2);
+  } catch {
+    return json;
+  }
+}

--- a/apps/workbench/src/pages/ConnectionsListPage.tsx
+++ b/apps/workbench/src/pages/ConnectionsListPage.tsx
@@ -1,0 +1,123 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import {
+  deleteConnection,
+  listConnections,
+  testConnection,
+} from "../api/connections.js";
+import { ConnectionStatusBadge } from "../components/ConnectionStatusBadge.js";
+
+export function ConnectionsListPage() {
+  const qc = useQueryClient();
+  const list = useQuery({
+    queryKey: ["connections"],
+    queryFn: listConnections,
+  });
+
+  const test = useMutation({
+    mutationFn: (id: string) => testConnection(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["connections"] }),
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) => deleteConnection(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["connections"] }),
+  });
+
+  return (
+    <section className="space-y-4">
+      <header className="flex items-end justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-900">FHIR connections</h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Configured FHIR servers the workbench can read from. Synthetic data only.
+          </p>
+        </div>
+        <Link
+          to="/connections/new"
+          className="rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700"
+          data-testid="new-connection"
+        >
+          New connection
+        </Link>
+      </header>
+
+      {list.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
+      {list.isError && (
+        <p className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">
+          Could not load connections: {(list.error as Error).message}
+        </p>
+      )}
+
+      {list.data && list.data.length === 0 && (
+        <div className="rounded-md border border-dashed border-slate-300 bg-white p-6 text-center text-sm text-slate-600">
+          No connections yet.{" "}
+          <Link to="/connections/new" className="font-medium text-slate-900 underline">
+            Add one
+          </Link>{" "}
+          to point the workbench at a synthetic FHIR server.
+        </div>
+      )}
+
+      {list.data && list.data.length > 0 && (
+        <ul className="space-y-2">
+          {list.data.map((conn) => (
+            <li
+              key={conn.id}
+              data-testid="connection-row"
+              className="rounded-md border border-slate-200 bg-white p-4"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <Link
+                      to={`/connections/${conn.id}`}
+                      className="text-base font-semibold text-slate-900 hover:underline"
+                    >
+                      {conn.name}
+                    </Link>
+                    <ConnectionStatusBadge connection={conn} />
+                  </div>
+                  <p className="mt-1 truncate text-xs text-slate-500">
+                    {conn.kind} · {conn.authType}
+                    {conn.hasAuthToken ? " (token)" : ""} · {conn.baseUrl}
+                  </p>
+                  {conn.lastCapabilityStatus === "ok" && (
+                    <p className="mt-1 text-xs text-slate-500">
+                      FHIR {conn.lastCapabilityFhirVersion ?? "?"} ·{" "}
+                      {conn.lastCapabilitySoftware ?? "unknown server"}
+                    </p>
+                  )}
+                  {conn.lastCapabilityStatus === "error" && (
+                    <p className="mt-1 text-xs text-rose-700">
+                      last error: {conn.lastCapabilityError}
+                    </p>
+                  )}
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <button
+                    type="button"
+                    onClick={() => test.mutate(conn.id)}
+                    disabled={test.isPending}
+                    className="rounded-md border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+                  >
+                    {test.isPending && test.variables === conn.id ? "Testing…" : "Test"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (window.confirm(`Delete "${conn.name}"?`)) remove.mutate(conn.id);
+                    }}
+                    className="rounded-md border border-rose-200 bg-white px-2.5 py-1 text-xs font-medium text-rose-700 hover:bg-rose-50"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/workbench/src/pages/HomePage.tsx
+++ b/apps/workbench/src/pages/HomePage.tsx
@@ -1,4 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { listConnections } from "../api/connections.js";
+
 export function HomePage() {
+  const list = useQuery({ queryKey: ["connections"], queryFn: listConnections });
+  const count = list.data?.length ?? 0;
+  const ok = list.data?.filter((c) => c.lastCapabilityStatus === "ok").length ?? 0;
+
   return (
     <section className="space-y-4">
       <header>
@@ -13,16 +21,31 @@ export function HomePage() {
 
       <div className="rounded-md border border-slate-200 bg-white p-4 text-sm text-slate-700">
         <p>
-          This is the Phase A skeleton. Patient search, the typed FHIR tool
-          registry, and the patient-summary agent land in subsequent PRs.
+          Phase A — currently shipped: app skeleton (PR 1) and FHIR
+          DataConnection (PR 2). Patient search, the typed FHIR tool registry,
+          and the patient-summary agent land in subsequent PRs.
         </p>
-        <p className="mt-2">
-          See{" "}
-          <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
-            TASKS.md
-          </code>{" "}
-          at the repo root for the Phase A backlog.
-        </p>
+      </div>
+
+      <div className="rounded-md border border-slate-200 bg-white p-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h2 className="text-base font-semibold text-slate-900">FHIR connections</h2>
+            <p className="mt-1 text-sm text-slate-600">
+              {list.isLoading
+                ? "Loading…"
+                : count === 0
+                  ? "No connections configured yet."
+                  : `${count} connection${count === 1 ? "" : "s"} (${ok} healthy)`}
+            </p>
+          </div>
+          <Link
+            to="/connections"
+            className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Manage
+          </Link>
+        </div>
       </div>
 
       <ul

--- a/apps/workbench/src/pages/HomePage.tsx
+++ b/apps/workbench/src/pages/HomePage.tsx
@@ -1,0 +1,40 @@
+export function HomePage() {
+  return (
+    <section className="space-y-4">
+      <header>
+        <h1 className="text-2xl font-semibold text-slate-900">
+          FHIR Agent Workbench
+        </h1>
+        <p className="mt-1 text-sm text-slate-600">
+          A research workbench for evidence-backed agent answers grounded in
+          synthetic FHIR data.
+        </p>
+      </header>
+
+      <div className="rounded-md border border-slate-200 bg-white p-4 text-sm text-slate-700">
+        <p>
+          This is the Phase A skeleton. Patient search, the typed FHIR tool
+          registry, and the patient-summary agent land in subsequent PRs.
+        </p>
+        <p className="mt-2">
+          See{" "}
+          <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
+            TASKS.md
+          </code>{" "}
+          at the repo root for the Phase A backlog.
+        </p>
+      </div>
+
+      <ul
+        data-testid="phase-a-checklist"
+        className="space-y-1 text-sm text-slate-600"
+      >
+        <li>· Read-only against a configured FHIR server</li>
+        <li>· Synthetic data only</li>
+        <li>· Typed, patient-scoped FHIR tools (deny-by-default)</li>
+        <li>· Evidence-backed structured answers</li>
+        <li>· Persisted tool calls and final answers</li>
+      </ul>
+    </section>
+  );
+}

--- a/apps/workbench/src/pages/NewConnectionPage.tsx
+++ b/apps/workbench/src/pages/NewConnectionPage.tsx
@@ -1,0 +1,154 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  createConnection,
+  type AuthType,
+  type ConnectionKind,
+  type CreateConnectionInput,
+} from "../api/connections.js";
+
+export function NewConnectionPage() {
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+
+  const [name, setName] = useState("");
+  const [baseUrl, setBaseUrl] = useState("http://localhost:8080/fhir");
+  const [authType, setAuthType] = useState<AuthType>("none");
+  const [authToken, setAuthToken] = useState("");
+
+  const create = useMutation({
+    mutationFn: (input: CreateConnectionInput) => createConnection(input),
+    onSuccess: (row) => {
+      qc.invalidateQueries({ queryKey: ["connections"] });
+      navigate(`/connections/${row.id}`);
+    },
+  });
+
+  return (
+    <section className="space-y-4">
+      <header>
+        <h1 className="text-2xl font-semibold text-slate-900">New FHIR connection</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Configure a FHIR server to read from. Phase A supports{" "}
+          <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">fhir_clinical</code>{" "}
+          with{" "}
+          <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">none</code> or{" "}
+          <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">bearer</code>{" "}
+          auth only.
+        </p>
+      </header>
+
+      <form
+        className="space-y-4 rounded-md border border-slate-200 bg-white p-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          const input: CreateConnectionInput = {
+            name: name.trim(),
+            kind: "fhir_clinical" satisfies ConnectionKind,
+            baseUrl: baseUrl.trim(),
+            authType,
+            ...(authType === "bearer" ? { authToken } : {}),
+          };
+          create.mutate(input);
+        }}
+      >
+        <Field label="Name" htmlFor="name">
+          <input
+            id="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            maxLength={120}
+            placeholder="Local HAPI sandbox"
+            className="w-full rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+          />
+        </Field>
+
+        <Field label="Base URL" htmlFor="baseUrl">
+          <input
+            id="baseUrl"
+            type="url"
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+            required
+            placeholder="http://localhost:8080/fhir"
+            className="w-full rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+          />
+        </Field>
+
+        <Field label="Auth type" htmlFor="authType">
+          <select
+            id="authType"
+            value={authType}
+            onChange={(e) => setAuthType(e.target.value as AuthType)}
+            className="w-full rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+          >
+            <option value="none">none</option>
+            <option value="bearer">bearer</option>
+          </select>
+        </Field>
+
+        {authType === "bearer" && (
+          <Field label="Bearer token" htmlFor="authToken">
+            <input
+              id="authToken"
+              type="password"
+              value={authToken}
+              onChange={(e) => setAuthToken(e.target.value)}
+              required
+              maxLength={4096}
+              autoComplete="off"
+              className="w-full rounded-md border border-slate-300 px-3 py-1.5 text-sm font-mono"
+            />
+            <p className="mt-1 text-xs text-slate-500">
+              Stored locally in SQLite. Synthetic environments only.
+            </p>
+          </Field>
+        )}
+
+        {create.isError && (
+          <p className="rounded-md border border-rose-200 bg-rose-50 p-2 text-sm text-rose-800">
+            {(create.error as Error).message}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={create.isPending}
+            className="rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+          >
+            {create.isPending ? "Creating…" : "Create connection"}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label htmlFor={htmlFor} className="mb-1 block text-sm font-medium text-slate-700">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/apps/workbench/src/pages/PatientPage.tsx
+++ b/apps/workbench/src/pages/PatientPage.tsx
@@ -1,5 +1,5 @@
-import { useQueries, useQuery } from "@tanstack/react-query";
-import { Link, useParams } from "react-router-dom";
+import { useMutation, useQueries, useQuery } from "@tanstack/react-query";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   bundleEntries,
   getPatient,
@@ -7,6 +7,7 @@ import {
   type AllowedResourceType,
 } from "../api/fhir.js";
 import { getConnection } from "../api/connections.js";
+import { createSession } from "../api/sessions.js";
 import { patientDisplayName } from "../components/PatientName.js";
 import type { Resource } from "fhir/r4";
 
@@ -20,11 +21,17 @@ const COMPARTMENT_TYPES: ReadonlyArray<Exclude<AllowedResourceType, "Patient">> 
 
 export function PatientPage() {
   const { cid, pid } = useParams<{ cid: string; pid: string }>();
+  const navigate = useNavigate();
 
   const conn = useQuery({
     queryKey: ["connections", cid],
     queryFn: () => getConnection(cid!),
     enabled: Boolean(cid),
+  });
+
+  const startSession = useMutation({
+    mutationFn: () => createSession(cid!, pid!),
+    onSuccess: (s) => navigate(`/sessions/${s.id}`),
   });
 
   const patient = useQuery({
@@ -71,7 +78,21 @@ export function PatientPage() {
             >
               raw JSON
             </Link>
+            <button
+              type="button"
+              onClick={() => startSession.mutate()}
+              disabled={startSession.isPending}
+              data-testid="start-session"
+              className="rounded-md bg-slate-900 px-2.5 py-1 text-xs font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+            >
+              {startSession.isPending ? "Starting…" : "Start agent session"}
+            </button>
           </div>
+          {startSession.isError && (
+            <p className="rounded-md border border-rose-200 bg-rose-50 p-2 text-sm text-rose-800">
+              {(startSession.error as Error).message}
+            </p>
+          )}
           <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
             <dt className="text-slate-500">Patient id</dt>
             <dd className="font-mono">{patient.data.id}</dd>

--- a/apps/workbench/src/pages/PatientPage.tsx
+++ b/apps/workbench/src/pages/PatientPage.tsx
@@ -1,0 +1,208 @@
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { Link, useParams } from "react-router-dom";
+import {
+  bundleEntries,
+  getPatient,
+  searchByPatient,
+  type AllowedResourceType,
+} from "../api/fhir.js";
+import { getConnection } from "../api/connections.js";
+import { patientDisplayName } from "../components/PatientName.js";
+import type { Resource } from "fhir/r4";
+
+const COMPARTMENT_TYPES: ReadonlyArray<Exclude<AllowedResourceType, "Patient">> = [
+  "Condition",
+  "MedicationRequest",
+  "AllergyIntolerance",
+  "Encounter",
+  "Observation",
+];
+
+export function PatientPage() {
+  const { cid, pid } = useParams<{ cid: string; pid: string }>();
+
+  const conn = useQuery({
+    queryKey: ["connections", cid],
+    queryFn: () => getConnection(cid!),
+    enabled: Boolean(cid),
+  });
+
+  const patient = useQuery({
+    queryKey: ["patient", cid, pid],
+    queryFn: () => getPatient(cid!, pid!),
+    enabled: Boolean(cid && pid),
+  });
+
+  const compartments = useQueries({
+    queries: COMPARTMENT_TYPES.map((rt) => ({
+      queryKey: ["compartment", cid, pid, rt],
+      queryFn: () => searchByPatient(cid!, rt, pid!),
+      enabled: Boolean(cid && pid),
+    })),
+  });
+
+  if (!cid || !pid) return null;
+
+  return (
+    <section className="space-y-4">
+      <Link
+        to={`/connections/${cid}/patients`}
+        className="text-sm text-slate-600 hover:underline"
+      >
+        ← All patients{conn.data ? ` · ${conn.data.name}` : ""}
+      </Link>
+
+      {patient.isLoading && <p className="text-sm text-slate-500">Loading patient…</p>}
+      {patient.isError && (
+        <p className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">
+          {(patient.error as Error).message}
+        </p>
+      )}
+
+      {patient.data && (
+        <header className="space-y-2">
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-semibold text-slate-900">
+              {patientDisplayName(patient.data)}
+            </h1>
+            <Link
+              to={`/connections/${cid}/patients/${pid}/Patient/${pid}`}
+              className="rounded-md border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+            >
+              raw JSON
+            </Link>
+          </div>
+          <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
+            <dt className="text-slate-500">Patient id</dt>
+            <dd className="font-mono">{patient.data.id}</dd>
+            <dt className="text-slate-500">Gender</dt>
+            <dd>{patient.data.gender ?? "—"}</dd>
+            <dt className="text-slate-500">Birthdate</dt>
+            <dd>{patient.data.birthDate ?? "—"}</dd>
+            <dt className="text-slate-500">Identifier(s)</dt>
+            <dd>
+              {patient.data.identifier && patient.data.identifier.length > 0
+                ? patient.data.identifier
+                    .map(
+                      (i) =>
+                        `${i.system ? `${i.system}|` : ""}${i.value ?? "—"}`,
+                    )
+                    .join(", ")
+                : "—"}
+            </dd>
+          </dl>
+        </header>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {COMPARTMENT_TYPES.map((rt, i) => (
+          <CompartmentCard
+            key={rt}
+            cid={cid}
+            pid={pid}
+            resourceType={rt}
+            isLoading={compartments[i]?.isLoading ?? false}
+            error={compartments[i]?.error as Error | null | undefined}
+            resources={bundleEntries(compartments[i]?.data)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function CompartmentCard({
+  cid,
+  pid,
+  resourceType,
+  isLoading,
+  error,
+  resources,
+}: {
+  cid: string;
+  pid: string;
+  resourceType: AllowedResourceType;
+  isLoading: boolean;
+  error: Error | null | undefined;
+  resources: Resource[];
+}) {
+  return (
+    <section
+      data-testid={`compartment-${resourceType}`}
+      className="rounded-md border border-slate-200 bg-white p-4 text-sm"
+    >
+      <header className="mb-2 flex items-center justify-between">
+        <h2 className="text-base font-semibold text-slate-900">{resourceType}</h2>
+        <span className="text-xs text-slate-500">
+          {isLoading ? "…" : `${resources.length}`}
+        </span>
+      </header>
+      {error && (
+        <p className="text-rose-700" data-testid={`compartment-${resourceType}-error`}>
+          {error.message}
+        </p>
+      )}
+      {!error && resources.length === 0 && !isLoading && (
+        <p className="text-slate-500">No {resourceType} resources found.</p>
+      )}
+      {resources.length > 0 && (
+        <ul className="divide-y divide-slate-100">
+          {resources.slice(0, 8).map((r) => (
+            <li key={r.id} className="py-1.5">
+              <Link
+                to={`/connections/${cid}/patients/${pid}/${resourceType}/${r.id}`}
+                className="block hover:underline"
+              >
+                <span className="font-mono text-xs text-slate-500">{r.id}</span>{" "}
+                <span className="text-slate-700">{summarise(r)}</span>
+              </Link>
+            </li>
+          ))}
+          {resources.length > 8 && (
+            <li className="pt-2 text-xs text-slate-500">
+              + {resources.length - 8} more
+            </li>
+          )}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+/**
+ * Cheap, type-aware single-line summary. We deliberately don't try to be
+ * comprehensive — the raw JSON page is one click away.
+ */
+function summarise(r: Resource): string {
+  const any = r as unknown as {
+    code?: { text?: string; coding?: Array<{ display?: string }> };
+    medicationCodeableConcept?: { text?: string };
+    medicationReference?: { display?: string };
+    status?: string;
+    period?: { start?: string };
+    onsetDateTime?: string;
+  };
+  switch (r.resourceType) {
+    case "Condition":
+      return [any.status, any.code?.text ?? any.code?.coding?.[0]?.display]
+        .filter(Boolean)
+        .join(" · ");
+    case "MedicationRequest":
+      return [
+        any.status,
+        any.medicationCodeableConcept?.text ??
+          any.code?.text ??
+          any.medicationReference?.display,
+      ]
+        .filter(Boolean)
+        .join(" · ");
+    case "AllergyIntolerance":
+      return any.code?.text ?? any.code?.coding?.[0]?.display ?? "(no code)";
+    case "Encounter":
+      return [any.status, any.period?.start].filter(Boolean).join(" · ");
+    case "Observation":
+      return any.code?.text ?? any.code?.coding?.[0]?.display ?? "(no code)";
+    default:
+      return "";
+  }
+}

--- a/apps/workbench/src/pages/PatientsPage.tsx
+++ b/apps/workbench/src/pages/PatientsPage.tsx
@@ -1,0 +1,189 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+import {
+  bundleEntries,
+  searchPatients,
+  type PatientSearchParams,
+} from "../api/fhir.js";
+import { getConnection } from "../api/connections.js";
+import { patientDisplayName } from "../components/PatientName.js";
+import type { Patient } from "fhir/r4";
+
+export function PatientsPage() {
+  const { cid } = useParams<{ cid: string }>();
+  const [params, setParams] = useSearchParams();
+
+  const initial: PatientSearchParams = {
+    name: params.get("name") ?? "",
+    identifier: params.get("identifier") ?? "",
+    birthdate: params.get("birthdate") ?? "",
+    gender: params.get("gender") ?? "",
+  };
+
+  const [draft, setDraft] = useState<PatientSearchParams>(initial);
+
+  const conn = useQuery({
+    queryKey: ["connections", cid],
+    queryFn: () => getConnection(cid!),
+    enabled: Boolean(cid),
+  });
+
+  const search = useQuery({
+    queryKey: ["patients", cid, params.toString()],
+    queryFn: () => searchPatients(cid!, initial),
+    enabled: Boolean(cid),
+  });
+
+  if (!cid) return null;
+  const patients = bundleEntries<Patient>(search.data);
+
+  return (
+    <section className="space-y-4">
+      <Link
+        to={`/connections/${cid}`}
+        className="text-sm text-slate-600 hover:underline"
+      >
+        ← Back to connection
+      </Link>
+
+      <header>
+        <h1 className="text-2xl font-semibold text-slate-900">
+          Patients{conn.data ? ` · ${conn.data.name}` : ""}
+        </h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Synthetic data only. Search the configured FHIR server for a patient
+          to inspect.
+        </p>
+      </header>
+
+      <form
+        className="grid gap-3 rounded-md border border-slate-200 bg-white p-4 sm:grid-cols-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          const next = new URLSearchParams();
+          if (draft.name) next.set("name", draft.name);
+          if (draft.identifier) next.set("identifier", draft.identifier);
+          if (draft.birthdate) next.set("birthdate", draft.birthdate);
+          if (draft.gender) next.set("gender", draft.gender);
+          setParams(next, { replace: true });
+        }}
+      >
+        <Field label="Name" htmlFor="name">
+          <input
+            id="name"
+            value={draft.name ?? ""}
+            onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+            placeholder="Hopper"
+            className="w-full rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+          />
+        </Field>
+        <Field label="Identifier" htmlFor="identifier">
+          <input
+            id="identifier"
+            value={draft.identifier ?? ""}
+            onChange={(e) => setDraft({ ...draft, identifier: e.target.value })}
+            placeholder="MRN-123 or system|value"
+            className="w-full rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+          />
+        </Field>
+        <Field label="Birthdate" htmlFor="birthdate">
+          <input
+            id="birthdate"
+            type="date"
+            value={draft.birthdate ?? ""}
+            onChange={(e) => setDraft({ ...draft, birthdate: e.target.value })}
+            className="w-full rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+          />
+        </Field>
+        <Field label="Gender" htmlFor="gender">
+          <select
+            id="gender"
+            value={draft.gender ?? ""}
+            onChange={(e) => setDraft({ ...draft, gender: e.target.value })}
+            className="w-full rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+          >
+            <option value="">any</option>
+            <option value="male">male</option>
+            <option value="female">female</option>
+            <option value="other">other</option>
+            <option value="unknown">unknown</option>
+          </select>
+        </Field>
+        <div className="sm:col-span-2 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              setDraft({ name: "", identifier: "", birthdate: "", gender: "" });
+              setParams(new URLSearchParams(), { replace: true });
+            }}
+            className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Clear
+          </button>
+          <button
+            type="submit"
+            className="rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700"
+          >
+            Search
+          </button>
+        </div>
+      </form>
+
+      {search.isLoading && <p className="text-sm text-slate-500">Searching…</p>}
+      {search.isError && (
+        <p className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">
+          {(search.error as Error).message}
+        </p>
+      )}
+
+      {search.data && patients.length === 0 && (
+        <p className="rounded-md border border-dashed border-slate-300 bg-white p-4 text-sm text-slate-600">
+          No patients matched.
+        </p>
+      )}
+
+      {patients.length > 0 && (
+        <ul className="divide-y divide-slate-200 rounded-md border border-slate-200 bg-white">
+          {patients.map((p) => (
+            <li key={p.id} data-testid="patient-row">
+              <Link
+                to={`/connections/${cid}/patients/${p.id}`}
+                className="flex items-center justify-between gap-4 px-4 py-3 hover:bg-slate-50"
+              >
+                <div className="min-w-0">
+                  <p className="font-medium text-slate-900">
+                    {patientDisplayName(p)}
+                  </p>
+                  <p className="mt-0.5 text-xs text-slate-500">
+                    {p.gender ?? "—"} · born {p.birthDate ?? "—"} · id {p.id}
+                  </p>
+                </div>
+                <span className="text-xs text-slate-400">view →</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label htmlFor={htmlFor} className="mb-1 block text-sm font-medium text-slate-700">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/apps/workbench/src/pages/ResourcePage.tsx
+++ b/apps/workbench/src/pages/ResourcePage.tsx
@@ -1,0 +1,68 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link, useParams } from "react-router-dom";
+import {
+  ALLOWED_RESOURCE_TYPES,
+  readResource,
+  type AllowedResourceType,
+} from "../api/fhir.js";
+
+export function ResourcePage() {
+  const { cid, pid, resourceType, resourceId } = useParams<{
+    cid: string;
+    pid: string;
+    resourceType: string;
+    resourceId: string;
+  }>();
+
+  const isAllowed = ALLOWED_RESOURCE_TYPES.includes(
+    resourceType as AllowedResourceType,
+  );
+
+  const resource = useQuery({
+    queryKey: ["resource", cid, resourceType, resourceId],
+    queryFn: () =>
+      readResource(cid!, resourceType as AllowedResourceType, resourceId!),
+    enabled: Boolean(cid && resourceId && isAllowed),
+  });
+
+  if (!cid || !resourceType || !resourceId) return null;
+
+  return (
+    <section className="space-y-4">
+      <Link
+        to={pid ? `/connections/${cid}/patients/${pid}` : `/connections/${cid}`}
+        className="text-sm text-slate-600 hover:underline"
+      >
+        ← Back
+      </Link>
+
+      <header className="flex items-baseline gap-2">
+        <h1 className="text-2xl font-semibold text-slate-900">{resourceType}</h1>
+        <span className="font-mono text-sm text-slate-500">/{resourceId}</span>
+      </header>
+
+      {!isAllowed && (
+        <p className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">
+          Resource type not in Phase A allow-list: {resourceType}
+        </p>
+      )}
+
+      {resource.isLoading && (
+        <p className="text-sm text-slate-500">Loading…</p>
+      )}
+      {resource.isError && (
+        <p className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800">
+          {(resource.error as Error).message}
+        </p>
+      )}
+      {resource.data && (
+        <pre
+          data-testid="resource-json"
+          className="max-h-[70vh] overflow-auto rounded-md border border-slate-200 bg-slate-50 p-3 text-xs text-slate-800"
+        >
+          {JSON.stringify(resource.data, null, 2)}
+        </pre>
+      )}
+    </section>
+  );
+}

--- a/apps/workbench/src/pages/SessionPage.tsx
+++ b/apps/workbench/src/pages/SessionPage.tsx
@@ -63,20 +63,29 @@ export function SessionPage() {
         </Link>
       )}
 
-      <header>
-        <h1 className="text-2xl font-semibold text-slate-900">Agent session</h1>
-        {session.data && (
-          <p className="mt-1 text-sm text-slate-600">
-            session{" "}
-            <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
-              {session.data.id}
-            </code>{" "}
-            · patient{" "}
-            <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
-              {session.data.patientId}
-            </code>
-          </p>
-        )}
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-900">Agent session</h1>
+          {session.data && (
+            <p className="mt-1 text-sm text-slate-600">
+              session{" "}
+              <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
+                {session.data.id}
+              </code>{" "}
+              · patient{" "}
+              <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
+                {session.data.patientId}
+              </code>
+            </p>
+          )}
+        </div>
+        <Link
+          to={`/sessions/${sid}/answer-preview`}
+          className="rounded-md border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+          data-testid="answer-preview-link"
+        >
+          AgentAnswer preview
+        </Link>
       </header>
 
       <p className="rounded-md border border-slate-200 bg-white p-3 text-sm text-slate-700">

--- a/apps/workbench/src/pages/SessionPage.tsx
+++ b/apps/workbench/src/pages/SessionPage.tsx
@@ -1,0 +1,182 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  getSession,
+  listTools,
+  runTool,
+  type ToolEnvelope,
+  type ToolMeta,
+} from "../api/sessions.js";
+
+export function SessionPage() {
+  const { sid } = useParams<{ sid: string }>();
+  const session = useQuery({
+    queryKey: ["session", sid],
+    queryFn: () => getSession(sid!),
+    enabled: Boolean(sid),
+  });
+  const tools = useQuery({ queryKey: ["session-tools"], queryFn: listTools });
+
+  const [selected, setSelected] = useState<string>("getPatient");
+  const [extra, setExtra] = useState<string>("{}");
+  const [history, setHistory] = useState<
+    Array<{ tool: string; input: unknown; envelope: ToolEnvelope }>
+  >([]);
+
+  const selectedMeta = useMemo<ToolMeta | undefined>(
+    () => tools.data?.find((t) => t.name === selected),
+    [tools.data, selected],
+  );
+
+  const run = useMutation({
+    mutationFn: async () => {
+      if (!sid || !session.data) throw new Error("session not loaded");
+      let parsedExtra: Record<string, unknown> = {};
+      if (extra.trim()) {
+        try {
+          parsedExtra = JSON.parse(extra) as Record<string, unknown>;
+        } catch (e) {
+          throw new Error(`invalid extra JSON: ${(e as Error).message}`);
+        }
+      }
+      const input = {
+        patientId: session.data.patientId,
+        ...parsedExtra,
+      };
+      const envelope = await runTool(sid, selected, input);
+      setHistory((h) => [{ tool: selected, input, envelope }, ...h].slice(0, 20));
+      return envelope;
+    },
+  });
+
+  if (!sid) return null;
+
+  return (
+    <section className="space-y-4">
+      {session.data && (
+        <Link
+          to={`/connections/${session.data.connectionId}/patients/${session.data.patientId}`}
+          className="text-sm text-slate-600 hover:underline"
+        >
+          ← Back to patient
+        </Link>
+      )}
+
+      <header>
+        <h1 className="text-2xl font-semibold text-slate-900">Agent session</h1>
+        {session.data && (
+          <p className="mt-1 text-sm text-slate-600">
+            session{" "}
+            <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
+              {session.data.id}
+            </code>{" "}
+            · patient{" "}
+            <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
+              {session.data.patientId}
+            </code>
+          </p>
+        )}
+      </header>
+
+      <p className="rounded-md border border-slate-200 bg-white p-3 text-sm text-slate-700">
+        Tools are deny-by-default and patient-scoped. The session's authorized
+        patient ID is injected automatically; supplying a different{" "}
+        <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
+          patientId
+        </code>{" "}
+        in the extra JSON will be rejected at the boundary with{" "}
+        <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
+          unauthorized_patient
+        </code>
+        . PR 6 will run an LLM against this same surface; this page is a
+        humans-only debug runner.
+      </p>
+
+      <section className="rounded-md border border-slate-200 bg-white p-4">
+        <div className="grid gap-3 sm:grid-cols-[1fr_2fr]">
+          <label className="text-sm font-medium text-slate-700">
+            Tool
+            <select
+              value={selected}
+              onChange={(e) => setSelected(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+              data-testid="tool-select"
+            >
+              {tools.data?.map((t) => (
+                <option key={t.name} value={t.name}>
+                  {t.name}@{t.version}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm font-medium text-slate-700">
+            Extra input (JSON, merged with patientId)
+            <textarea
+              value={extra}
+              onChange={(e) => setExtra(e.target.value)}
+              rows={4}
+              className="mt-1 block w-full rounded-md border border-slate-300 px-3 py-1.5 font-mono text-xs"
+              placeholder='{ "limit": 5 }'
+              data-testid="tool-extra"
+            />
+          </label>
+        </div>
+        {selectedMeta && (
+          <p className="mt-2 text-xs text-slate-500">{selectedMeta.description}</p>
+        )}
+        <div className="mt-3 flex justify-end">
+          <button
+            type="button"
+            onClick={() => run.mutate()}
+            disabled={run.isPending || !session.data}
+            className="rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+            data-testid="run-tool"
+          >
+            {run.isPending ? "Running…" : "Run"}
+          </button>
+        </div>
+        {run.isError && (
+          <p className="mt-2 rounded-md border border-rose-200 bg-rose-50 p-2 text-sm text-rose-800">
+            {(run.error as Error).message}
+          </p>
+        )}
+      </section>
+
+      {history.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-base font-semibold text-slate-900">Tool calls</h2>
+          {history.map((h, i) => (
+            <article
+              key={i}
+              data-testid="tool-call-entry"
+              className="rounded-md border border-slate-200 bg-white p-3 text-sm"
+            >
+              <header className="mb-1 flex items-center justify-between gap-2">
+                <span className="font-medium text-slate-900">
+                  {h.tool}@{h.envelope.toolVersion}
+                </span>
+                {h.envelope.ok ? (
+                  <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800">
+                    ok
+                    {typeof h.envelope.count === "number"
+                      ? ` · ${h.envelope.count}${h.envelope.truncated ? "+" : ""}`
+                      : ""}{" "}
+                    · {h.envelope.durationMs}ms
+                  </span>
+                ) : (
+                  <span className="rounded-full bg-rose-100 px-2 py-0.5 text-xs font-medium text-rose-800">
+                    {h.envelope.reason} · {h.envelope.durationMs}ms
+                  </span>
+                )}
+              </header>
+              <pre className="max-h-72 overflow-auto rounded bg-slate-50 p-2 text-xs text-slate-700">
+                {JSON.stringify(h.envelope, null, 2)}
+              </pre>
+            </article>
+          ))}
+        </section>
+      )}
+    </section>
+  );
+}

--- a/apps/workbench/tailwind.config.js
+++ b/apps/workbench/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{ts,tsx}",
+    "../../packages/react-fhir/src/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/apps/workbench/tsconfig.json
+++ b/apps/workbench/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "../../packages/react-fhir" }]
+}

--- a/apps/workbench/tsconfig.node.json
+++ b/apps/workbench/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true,
+    "types": ["node"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["db", "scripts", "drizzle.config.ts", "vite.config.ts", "vitest.config.ts"]
+}

--- a/apps/workbench/tsconfig.node.json
+++ b/apps/workbench/tsconfig.node.json
@@ -7,5 +7,5 @@
     "module": "ESNext",
     "moduleResolution": "Bundler"
   },
-  "include": ["db", "scripts", "drizzle.config.ts", "vite.config.ts", "vitest.config.ts"]
+  "include": ["db", "scripts", "server", "drizzle.config.ts", "vite.config.ts", "vitest.config.ts"]
 }

--- a/apps/workbench/vite.config.ts
+++ b/apps/workbench/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  base: process.env.VITE_BASE_PATH ?? "/",
+  server: {
+    port: 5174,
+    host: "127.0.0.1",
+  },
+});

--- a/apps/workbench/vite.config.ts
+++ b/apps/workbench/vite.config.ts
@@ -1,11 +1,19 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const SERVER_PORT = process.env.WORKBENCH_PORT ?? "5175";
+
 export default defineConfig({
   plugins: [react()],
   base: process.env.VITE_BASE_PATH ?? "/",
   server: {
     port: 5174,
     host: "127.0.0.1",
+    proxy: {
+      "/api": {
+        target: `http://127.0.0.1:${SERVER_PORT}`,
+        changeOrigin: false,
+      },
+    },
   },
 });

--- a/apps/workbench/vitest.config.ts
+++ b/apps/workbench/vitest.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
     name: "workbench",
     environment: "node",
     globals: true,
-    include: ["src/**/*.test.{ts,tsx}", "db/**/*.test.ts", "scripts/**/*.test.ts"],
+    include: [
+      "src/**/*.test.{ts,tsx}",
+      "db/**/*.test.ts",
+      "scripts/**/*.test.ts",
+      "server/**/*.test.ts",
+    ],
   },
 });

--- a/apps/workbench/vitest.config.ts
+++ b/apps/workbench/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "workbench",
+    environment: "node",
+    globals: true,
+    include: ["src/**/*.test.{ts,tsx}", "db/**/*.test.ts", "scripts/**/*.test.ts"],
+  },
+});

--- a/docs/agent-answer.md
+++ b/docs/agent-answer.md
@@ -1,0 +1,129 @@
+# AgentAnswer — the Source of Truth for Agent Output
+
+Phase A's hard constraint is that the agent's output is a structured,
+validated, evidence-backed object — never raw Markdown. PR 5 ships the
+schema, the renderer, and the helpers. PR 6 will produce instances of
+this shape from an LLM; PR 7 will persist them.
+
+## The shape
+
+```ts
+interface AgentAnswer {
+  schemaVersion: "1";
+  sessionId: string;
+  connectionId: string;
+  patientId: string;
+  prompt: string;
+  promptVersion?: string;
+  model?: string;
+  provider?: string;
+  summary?: string;                       // never load-bearing
+  claims: EvidenceBackedClaim[];          // supported claims (must cite resources)
+  missingData: MissingDataEntry[];        // first-class, not an absence
+  cannotDetermine: CannotDetermineEntry[]; // first-class, not "I don't know" in prose
+  toolCalls: ToolCallSummary[];           // mirror of PR 4 envelopes
+  createdAt: string;
+}
+
+interface EvidenceBackedClaim {
+  id: string;
+  text: string;
+  evidence: ResourceReference[];   // .min(1) — load-bearing
+}
+
+interface ResourceReference {
+  reference: string;               // `<AllowedType>/<fhir-id>` only
+  display?: string;
+}
+
+interface MissingDataEntry { description: string; }
+interface CannotDetermineEntry { question: string; why: string; }
+
+interface ToolCallSummary {
+  tool: string;
+  toolVersion: string;
+  ok: boolean;
+  reason?: string;       // ToolErrorReason if not ok
+  count?: number;        // for searches
+  truncated?: boolean;
+  durationMs: number;
+  resourceIds?: string[];
+}
+```
+
+## Hard rules (enforced by Zod)
+
+1. **Supported claims must cite at least one resource.**
+   `EvidenceBackedClaim.evidence.min(1)` is non-optional. A claim without
+   evidence fails validation before render.
+2. **Evidence references must be FHIR-style relative URLs against the
+   Phase A allow-list.** The regex is `(<AllowedType>)/(<fhir-id>)`
+   where `<AllowedType>` is one of:
+   `Patient | Condition | MedicationRequest | AllergyIntolerance |
+   Encounter | Observation`. Anything else → invalid.
+3. **`missingData` and `cannotDetermine` are required top-level arrays.**
+   Even when empty, the keys must be present. "I don't know" cannot be
+   smuggled in as a free-text claim.
+4. **`schemaVersion` is `"1"` exactly.** Older or future versions are
+   rejected. Bumping the version is an explicit breaking change.
+
+## Why this shape
+
+- **Refs are FHIR-native, not opaque ids.** `Condition/abc-123` round-
+  trips into the resource viewer (PR 3) without URL rewriting. Click an
+  evidence chip → see the underlying resource.
+- **Audit shape mirrors `Provenance` / `AuditEvent`.** PR 7 will persist
+  these as is, plus a row that maps each `claim.id` to its supporting
+  resource ids — same vocab the FHIR audit-log resources use, even
+  though we never write them back.
+- **Missing / cannot-determine are first-class.** A blank `missingData`
+  array is meaningfully different from "the agent didn't think about
+  it". Fixed schema → comparable evals (PR 8).
+- **Free-text `summary` is allowed but never load-bearing.** The
+  evaluator never reads it; the renderer never branches on it. It exists
+  so a quick scroll yields a readable paragraph.
+
+## Files
+
+| File | What it is |
+| --- | --- |
+| `src/agent/answer-schema.ts` | Zod schemas + `parseAgentAnswer`. Ground truth. |
+| `src/agent/answer-extractors.ts` | `citedReferences`, `dedupeReferences`, `evidenceCountsByType`, `unsupportedClaimCount`, `resourceViewerHref`, etc. |
+| `src/agent/AgentAnswerRenderer.tsx` | Renders a *validated* `AgentAnswer`. Never sees raw input. |
+| `src/agent/EvidenceChip.tsx` | Type-coloured chip linking to the resource viewer. |
+| `src/agent/fixtures.ts` | A known-good `SAMPLE_AGENT_ANSWER`. Used by tests, the preview page, and (in PR 8) golden snapshots. |
+| `src/pages/AnswerPreviewPage.tsx` | Paste / edit JSON → live validate → render. |
+
+## How the renderer is invoked
+
+```tsx
+const v = parseAgentAnswer(rawJson);
+if (!v.ok) return <ValidationErrors issues={v.issues} />;
+return <AgentAnswerRenderer answer={v.answer} />;
+```
+
+The renderer does not validate, does not parse, does not branch on
+shape mismatches. Anything that reaches the renderer has already passed
+schema validation; anything that fails goes through the
+`AnswerPreviewPage` validation-error UI.
+
+## Phase A icebox
+
+- Free-text Markdown rendering of model output without validation.
+- A "natural-language only" answer mode without claims / refs.
+- Confidence weights on claims — could be a Phase B addition; not now.
+- Streaming partial answers — the renderer is designed for whole answers.
+- Cross-patient claims — every reference is patient-scoped.
+
+## What this changes for downstream PRs
+
+- **PR 6 (agent loop):** the model is constrained to emit JSON that
+  parses against `AgentAnswer`. The orchestrator validates before
+  render; on failure, retries or partial-answer fallback.
+- **PR 7 (audit log):** each `AgentAnswer` is persisted as-is on
+  `agent_session`; `evidence_claim` and `tool_call` rows map back to
+  the structured fields.
+- **PR 8 (evals):** `unsupportedClaimCount`, `evidenceCountsByType`, and
+  schema validity are cheap metrics that ride this schema.
+- **PR 9 (failure gallery):** every gallery case is a stored
+  `AgentAnswer` rendered by the same component the live agent uses.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,40 @@
+# Architecture
+
+> Placeholder. Filled out incrementally as Phase A PRs land. Locked down in
+> PR 10 (Demo Hardening and Write-Up).
+
+## Components (planned)
+
+| Component | Where it lives | Status |
+| --- | --- | --- |
+| Workbench UI shell | `apps/workbench/src/` | PR 1 ✅ |
+| SQLite + Drizzle local DB | `apps/workbench/db/` | PR 1 ✅ (skeleton) |
+| FHIR DataConnection | `apps/workbench/db/`, `apps/workbench/src/` | PR 2 |
+| Patient search + resource viewer | `apps/workbench/src/` | PR 3 |
+| Typed FHIR tool registry | TBD (`apps/workbench/src/agent/tools/`) | PR 4 |
+| `AgentAnswer` schema + renderer | TBD | PR 5 |
+| Patient-summary agent loop | TBD | PR 6 |
+| Audit logging | `apps/workbench/db/` | PR 7 |
+| Eval harness | TBD | PR 8 |
+| Failure gallery | `apps/workbench/src/pages/` | PR 9 |
+
+## Boundary between frontend and node-only code
+
+The workbench is one package but two TypeScript projects:
+
+- `tsconfig.json` covers `src/` (browser, `vite/client` types).
+- `tsconfig.node.json` covers `db/`, `scripts/`, and `*.config.ts` (node).
+
+`db/` and `scripts/` must never be imported from `src/`. Server-side
+enforcement of patient scope (PR 4) lives behind a future API surface; the
+frontend never opens SQLite directly.
+
+## FHIR-native choices (carried into later PRs)
+
+- Evidence references in `EvidenceBackedClaim` use FHIR relative URLs
+  (`Condition/abc`) so they can be resolved by the resource viewer.
+- Audit log shape mirrors `AuditEvent` + `Provenance` so write-back is a
+  no-op flip later, even though Phase A never writes back.
+- Eval fixtures are stored as FHIR `Bundle` resources, not bespoke JSON.
+- Tool envelopes return `Bundle` `searchset` on success and
+  `OperationOutcome` on error, not a parallel error shape.

--- a/docs/data-connections.md
+++ b/docs/data-connections.md
@@ -1,0 +1,89 @@
+# Data Connections
+
+A `data_connection` points the workbench at a FHIR server it can read from.
+Phase A is read-only and synthetic-only.
+
+## Phase A allow-list
+
+| Field | Allowed values |
+| --- | --- |
+| `kind` | `fhir_clinical` |
+| `authType` | `none`, `bearer` |
+
+Anything else (OMOP, claims, wearable, SMART on FHIR, OAuth client_credentials,
+mTLS) is rejected at the validation boundary in `server/schemas.ts`. There
+is no DB-only path for unsupported values.
+
+## Where things live
+
+| File | What it is |
+| --- | --- |
+| `apps/workbench/db/schema.ts` | Drizzle table `data_connection` |
+| `apps/workbench/db/migrations/0001_data_connection.sql` | Initial migration |
+| `apps/workbench/server/schemas.ts` | Zod input schemas (Phase A allow-list) |
+| `apps/workbench/server/services/fhir-connection.ts` | `/metadata` probe |
+| `apps/workbench/server/services/connection-store.ts` | CRUD + capability persistence |
+| `apps/workbench/server/routes/connections.ts` | Hono routes |
+| `apps/workbench/src/api/connections.ts` | Frontend API client |
+| `apps/workbench/src/pages/Connections*Page.tsx` | UI |
+
+## HTTP API
+
+| Method | Path | What it does |
+| --- | --- | --- |
+| `GET` | `/api/connections` | List connections (auth tokens redacted) |
+| `POST` | `/api/connections` | Create a connection |
+| `GET` | `/api/connections/:id` | Get one connection |
+| `POST` | `/api/connections/:id/test` | Fetch `/metadata`, persist the result |
+| `DELETE` | `/api/connections/:id` | Remove a connection |
+
+Auth tokens **never** leave the server. The frontend only sees
+`hasAuthToken: true | false` on each row.
+
+The `test` endpoint:
+
+1. Loads the connection by id.
+2. Calls `${baseUrl}/metadata` with `Accept: application/fhir+json` and (if
+   bearer) an `Authorization` header.
+3. Verifies the response is a `CapabilityStatement`.
+4. Persists `lastCapabilityAt`, `lastCapabilityStatus`,
+   `lastCapabilityFhirVersion`, `lastCapabilitySoftware`, and
+   `lastCapabilityJson` on success; persists `lastCapabilityError` on
+   failure.
+
+## Local development
+
+The frontend (Vite) and the API (Hono) run as two processes. From the repo
+root, in two terminals:
+
+```bash
+pnpm --filter @fhir-place/workbench server
+pnpm --filter @fhir-place/workbench dev
+```
+
+Vite dev (port 5174) proxies `/api` to the Hono server (port 5175). Override
+the API port with `WORKBENCH_PORT`.
+
+```bash
+WORKBENCH_PORT=6000 pnpm --filter @fhir-place/workbench server
+WORKBENCH_PORT=6000 pnpm --filter @fhir-place/workbench dev
+```
+
+The SQLite DB file is `apps/workbench/workbench.sqlite` by default. Override
+with `WORKBENCH_DB_URL=/some/path.sqlite`.
+
+Run migrations (idempotent) before the first server start:
+
+```bash
+pnpm --filter @fhir-place/workbench db:setup
+```
+
+## What is **not** supported (Phase A icebox)
+
+- SMART on FHIR auth (`authType: "smart"` is rejected)
+- OAuth client_credentials, mTLS, custom auth headers
+- BigQuery, OMOP, claims, wearable connection types
+- Connection-level scoping by patient compartment (that lives at the tool
+  layer in PR 4, not here)
+- Encryption at rest for stored bearer tokens — Phase A is synthetic-only
+  single-user local; document it, don't pretend to solve it

--- a/docs/fhir-tools.md
+++ b/docs/fhir-tools.md
@@ -1,0 +1,130 @@
+# Typed FHIR Tool Registry
+
+Phase A's typed, patient-scoped, deny-by-default tool layer. Sits on top
+of the read-only FHIR proxy from PR 3 ([`docs/patient-viewer.md`](./patient-viewer.md))
+and is the surface PR 6's patient-summary agent will be allowed to call.
+
+## Hard rules (enforced server-side, every call)
+
+1. **Patient-scoped sessions.** A tool runs inside an `agent_session` row
+   that carries exactly one authorized `patient_id`. Sessions are created
+   explicitly via `POST /api/sessions`.
+2. **Typed inputs.** Every tool has a Zod input schema with `patientId`
+   required. Anything that fails the schema → `reason: "invalid_input"`.
+3. **Deny-by-default patient scope.** If the request body's `patientId`
+   doesn't match the session's `patient_id` → `reason:
+   "unauthorized_patient"` (HTTP 403). There is no path that lets a tool
+   touch a different patient.
+4. **Resource allow-list.** Each tool declares the FHIR resources it
+   reads. Searches go through the same allow-list-enforcing proxy as
+   PR 3, so the per-resource search-param policy still applies.
+5. **Result limits + timeouts.** Each tool declares `resultLimit` and
+   `timeoutMs`. The runner truncates arrays past `resultLimit` and sets
+   `truncated: true`. Timeouts return `reason: "timeout"` (HTTP 504).
+6. **Normalized envelope.** Every call — success or failure — comes back
+   in the same `ToolEnvelope` shape (see below).
+7. **Logged.** Every call (input + envelope + start/complete timestamps)
+   goes through a `ToolLogger`. Phase A ships an in-memory implementation;
+   PR 7 swaps in DB persistence.
+
+## The six Phase A tools
+
+All six accept `patientId` (required, FHIR `id`); search tools also
+accept `limit?: number` (1–50, default 20).
+
+| Tool | Extra input | Reads | Notes |
+| --- | --- | --- | --- |
+| `getPatient` | — | `Patient/:id` | Single resource read. |
+| `searchConditionsForPatient` | `clinicalStatus?` | `Condition?patient=&clinical-status=` | `clinicalStatus` is the FHIR enum (`active`, `recurrence`, `relapse`, `inactive`, `remission`, `resolved`). |
+| `searchMedicationRequestsForPatient` | `status?` | `MedicationRequest?patient=&status=` | `status` is the FHIR medication-request status enum. |
+| `searchAllergyIntolerancesForPatient` | — | `AllergyIntolerance?patient=` | Returns `[]` when none exist; **must NOT** be summarised as "no known allergies" — see PR 6 / `docs/safety.md`. |
+| `searchEncountersForPatient` | `dateRange?` | `Encounter?patient=&date=ge…&date=le…` | `dateRange.from` / `to` are `YYYY-MM-DD`. |
+| `searchObservationsForPatient` | `category?`, `dateRange?` | `Observation?patient=&category=&date=…` | `category` is the conservative allow-list `{ vital-signs, laboratory, social-history, exam, therapy, activity }`. |
+
+## HTTP API
+
+| Method | Path | What it does |
+| --- | --- | --- |
+| `POST` | `/api/sessions` | Create a session bound to `(connectionId, patientId)`. |
+| `GET` | `/api/sessions` | List sessions. |
+| `GET` | `/api/sessions/:sid` | Get one session. |
+| `DELETE` | `/api/sessions/:sid` | Delete a session. |
+| `GET` | `/api/sessions/tools` | List registered tools (name, version, description, allow-list, result limit, timeout). |
+| `POST` | `/api/sessions/:sid/tools/:toolName` | Run a tool. Body is the typed input. |
+
+`patient_id` is validated against the FHIR R4 `id` regex
+`[A-Za-z0-9\-\.]{1,64}` at the session-create boundary.
+
+## Envelope
+
+```ts
+type ToolEnvelope =
+  | { ok: true,  tool, toolVersion, data, count?, truncated?, durationMs }
+  | { ok: false, tool, toolVersion, error, reason, issues?, upstream?, durationMs };
+
+type ToolErrorReason =
+  | "unknown_tool"
+  | "invalid_input"
+  | "session_not_found"
+  | "connection_not_found"
+  | "unauthorized_patient"
+  | "upstream_error"
+  | "timeout"
+  | "internal_error";
+```
+
+HTTP status mirrors `reason` so clients can branch generically while the
+envelope's `reason` field stays the source of truth:
+
+| Reason | HTTP |
+| --- | --- |
+| (ok) | 200 |
+| `unknown_tool` | 404 |
+| `invalid_input` | 400 |
+| `unauthorized_patient` | 403 |
+| `session_not_found` / `connection_not_found` | 404 |
+| `timeout` | 504 |
+| `upstream_error` / `internal_error` | 502 |
+
+## Where things live
+
+| File | What it is |
+| --- | --- |
+| `apps/workbench/db/schema.ts` (`agent_session`) | Table for the session row. |
+| `apps/workbench/db/migrations/0002_agent_session.sql` | Migration. |
+| `apps/workbench/server/services/session-store.ts` | Session CRUD. |
+| `apps/workbench/server/agent/envelope.ts` | `ToolEnvelope` + helpers. |
+| `apps/workbench/server/agent/registry.ts` | Registry, `ToolDef`, runner. |
+| `apps/workbench/server/agent/tool-log.ts` | `ToolLogger` + in-memory / console implementations. |
+| `apps/workbench/server/agent/tools/_shared.ts` | `dateRangeSchema`, limit clamping, bundle unwrapping. |
+| `apps/workbench/server/agent/tools/*.ts` | The six tool definitions. |
+| `apps/workbench/server/routes/sessions.ts` | HTTP routes. |
+| `apps/workbench/src/api/sessions.ts` | Frontend client. |
+| `apps/workbench/src/pages/SessionPage.tsx` | Humans-only debug runner. |
+
+## Why this layer exists
+
+Phase A's working constraint is *typed, patient-scoped, deny-by-default*.
+The proxy from PR 3 is the FHIR allow-list. The tool registry adds:
+
+- **Domain inputs** that rule out FHIR-syntax mistakes (e.g. agent
+  emitting `clinicalStatus: "indeterminate"` → 400, not silently ignored).
+- **Result-limit and timeout enforcement** the proxy doesn't (and
+  shouldn't) do.
+- **A patient-scope chokepoint** the proxy alone can't enforce — the
+  proxy doesn't know which patient is "yours" for this run.
+- **A logging hook** PR 7's audit log can subscribe to without changing
+  any tool.
+
+PR 6's agent calls **only** these tools, never the proxy directly, never
+fetch directly, never the DB. The agent sees the envelope; nothing else.
+
+## Phase A icebox
+
+- Tool composition / chaining inside the registry — the agent does that.
+- DB-backed `tool_call` persistence — PR 7.
+- Per-tool authorization beyond patient scope (e.g. role-based) — Phase A
+  is a single-user local research tool.
+- Tools that mutate the FHIR server.
+- Tools that read resources outside the proxy allow-list.
+- Free-form FHIR query tools.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,0 +1,47 @@
+# Limitations
+
+> Placeholder. Filled out incrementally as Phase A PRs land. Finalised in
+> PR 10 (Demo Hardening and Write-Up).
+
+## What the workbench cannot do
+
+- **Cannot be used clinically.** Synthetic data only. Not a clinical decision
+  support tool. No PHI path.
+- **Cannot write to the FHIR server.** Read-only by design. Write-back is
+  Phase A icebox.
+- **Cannot generate arbitrary FHIR queries.** The agent can only call the
+  registered, typed, patient-scoped tools.
+- **Cannot answer questions outside the selected patient's scope.** Tools
+  reject missing or unauthorized patient IDs.
+- **Cannot follow instructions embedded in resource text.** Resource content
+  is data, not instruction.
+- **Cannot be relied on for completeness.** When evidence is insufficient,
+  the agent emits a cannot-determine claim, not a guess.
+
+## Phase A icebox (intentionally excluded)
+
+- SMART on FHIR auth
+- Real PHI handling
+- HIPAA compliance claims
+- Write-back / mutation
+- Draft / queue / approval workflows
+- Prior authorization
+- Care-gap detection
+- Quality-measure explanation
+- CQL execution, `$evaluate-measure`
+- DocumentReference text extraction
+- MCP server
+- BigQuery / OMOP / claims-style FHIR / wearable connection types
+- Memory, multi-agent planning
+- Clinician preview mode
+- Arbitrary FHIR query generation
+- Arbitrary code execution by the agent
+
+## Known incompletenesses (Phase A)
+
+- The eval suite is small (PR 8 ships ≥ 2 cases). It is not a benchmark.
+- The audit log mirrors `AuditEvent` / `Provenance` shape but is not written
+  back to the FHIR server.
+- One LLM provider is wired up (PR 6); no automatic provider failover.
+- No multi-user authentication. The workbench is a local-first single-user
+  research tool.

--- a/docs/patient-viewer.md
+++ b/docs/patient-viewer.md
@@ -1,0 +1,102 @@
+# Patient Search and Resource Viewer
+
+The workbench's user-facing read path. The FHIR connection abstraction
+(PR 2, [`docs/data-connections.md`](./data-connections.md)) gives us *a*
+FHIR server. This doc covers how the user finds a synthetic patient and
+inspects their core resources.
+
+## URL shape
+
+The selected patient lives in the URL. Refresh-safe, shareable, and means
+no extra React context is needed:
+
+```
+/connections/:cid/patients                            — search & list
+/connections/:cid/patients/:pid                       — patient detail + compartment
+/connections/:cid/patients/:pid/:resourceType/:id     — raw JSON viewer
+```
+
+`:cid` is a `data_connection.id`. `:pid` is the FHIR `Patient.id` on the
+upstream server. `:resourceType` and `:id` are validated server-side
+against the Phase A allow-list (see below).
+
+## Read path
+
+```
+Browser ──GET /api/connections/:cid/fhir/<...>──► Hono
+                                                   │
+                                                   ├── load connection (incl. authToken)
+                                                   ├── validate resourceType in allow-list
+                                                   ├── filter search params via allow-list
+                                                   └──GET <baseUrl>/<...>──► Upstream FHIR
+```
+
+The auth token never reaches the browser. The frontend never opens the
+upstream FHIR server directly.
+
+## Phase A allow-lists
+
+Both lists live in [`apps/workbench/server/schemas.ts`](../apps/workbench/server/schemas.ts).
+
+### Resource types
+
+```
+Patient · Condition · MedicationRequest · AllergyIntolerance · Encounter · Observation
+```
+
+Anything else (e.g. `Procedure`, `DocumentReference`, `Practitioner`) is a
+400 at the proxy boundary. There is no path that lets the browser — or, in
+PR 6, the agent — probe arbitrary FHIR resources.
+
+### Search parameters (per resource)
+
+| Resource | Allowed parameters |
+| --- | --- |
+| `Patient` | `name`, `family`, `given`, `identifier`, `birthdate`, `gender`, `_id`, `_count`, `_sort` |
+| `Condition` | `patient`, `clinical-status`, `category`, `code`, `_id`, `_count`, `_sort` |
+| `MedicationRequest` | `patient`, `status`, `intent`, `_id`, `_count`, `_sort` |
+| `AllergyIntolerance` | `patient`, `clinical-status`, `_id`, `_count`, `_sort` |
+| `Encounter` | `patient`, `status`, `date`, `_id`, `_count`, `_sort` |
+| `Observation` | `patient`, `category`, `code`, `date`, `status`, `_id`, `_count`, `_sort` |
+
+Anything else — including `_include`, `_revinclude`, `_has`, `_filter`,
+`_elements`, `_summary`, `_format` — is silently dropped before
+forwarding upstream so a caller cannot expand the response shape, change
+content negotiation, or chain into resources outside the allow-list.
+
+`_count` is clamped to `MAX_COUNT = 100` and defaults to `20`.
+
+## HTTP API
+
+| Method | Path | What it does |
+| --- | --- | --- |
+| `GET` | `/api/connections/:cid/fhir/:resourceType` | Forwarded search (allow-listed params only) |
+| `GET` | `/api/connections/:cid/fhir/:resourceType/:id` | Single resource read |
+
+Phase A is read-only. `POST`/`PUT`/`PATCH`/`DELETE` on this prefix get a
+404 by routing-table omission (Hono never registers them).
+
+## What the user sees
+
+- **`PatientsPage`** — name / identifier / birthdate / gender form.
+  Search params live in the URL so the search is shareable and
+  refresh-safe. Clear wipes both the form and the URL.
+- **`PatientPage`** — demographics panel + six compartment cards
+  (`Condition`, `MedicationRequest`, `AllergyIntolerance`, `Encounter`,
+  `Observation`). Each card lists up to 8 entries with a per-resource
+  one-line summary; "+ N more" overflow.
+- **`ResourcePage`** — raw FHIR JSON for one resource, shown verbatim from
+  the upstream. The synthetic-only banner stays at the top of every page.
+
+## What is **not** here (Phase A icebox)
+
+- Free-text search across resource bodies.
+- Arbitrary FHIR query generation (no path lets a user or the agent type a
+  raw search-string and have it forwarded as-is).
+- DocumentReference text extraction.
+- Anything that mutates the upstream FHIR server.
+- SMART on FHIR launch from the patient context — Phase A is server-token
+  only.
+- Compartment-aware "patient resources" via FHIR `$everything` — we only
+  use plain `?patient=Patient/:id` searches because they're trivially
+  bounded by the allow-list.

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -1,0 +1,54 @@
+# Safety
+
+> Placeholder. Filled out incrementally as Phase A PRs land. Finalised in
+> PR 10 (Demo Hardening and Write-Up).
+
+## What this project is, and isn't
+
+This is a **research workbench** for evidence-backed agent answers grounded in
+**synthetic FHIR data**. It is not:
+
+- a clinical decision support tool,
+- a SMART on FHIR app,
+- a HIPAA-compliant system,
+- a chatbot for real patients.
+
+Every UI surface must carry the synthetic-only / not-for-clinical-use banner.
+
+## The safety layers (all must hold)
+
+1. **Synthetic-only inputs.** The supported deployment mode is a local FHIR
+   server seeded with synthetic data, or the public HAPI sandbox. There is no
+   PHI path.
+2. **Read-only.** Phase A never writes to the FHIR server. Write-back is icebox.
+3. **Typed, patient-scoped tools.** The agent cannot generate arbitrary FHIR
+   queries. It can only call the registered tools, each of which:
+   - validates input against a typed schema,
+   - requires a patient ID,
+   - is server-side scoped to the selected patient,
+   - is deny-by-default for missing or unauthorized patient IDs,
+   - has explicit result limits and timeouts.
+4. **Resource text is data, not instruction.** Anything fetched from the FHIR
+   server is wrapped before it reaches a system prompt or tool-name position.
+5. **Structured answers.** The agent's final output validates against the
+   `AgentAnswer` schema. Supported claims must cite source resources;
+   missing-data and cannot-determine are first-class fields, not absences.
+6. **Audit log everything.** Every run, every tool call, every final answer
+   is persisted and can be replay-inspected.
+7. **Evals before "done".** Phase A is not done until the eval harness covers
+   the named hard cases (no-allergy-data, missing-labs, prompt injection in
+   resource text, out-of-scope patient).
+
+## Hard negatives
+
+The following are explicitly **not** Phase A:
+
+SMART on FHIR auth, real PHI, HIPAA claims, write-back, draft / queue /
+approval, prior auth, care-gap detection, quality-measure explanation, CQL,
+`$evaluate-measure`, DocumentReference text extraction, MCP server,
+BigQuery/OMOP/claims/wearable connections, memory, multi-agent planning,
+clinician preview mode, arbitrary FHIR query generation by the agent,
+arbitrary code execution by the agent.
+
+If a future request seems to require any of these, stop and confirm before
+shipping.

--- a/openspec/changes/add-agent-tool-registry/acceptance.md
+++ b/openspec/changes/add-agent-tool-registry/acceptance.md
@@ -1,0 +1,49 @@
+# Acceptance — `add-agent-tool-registry`
+
+This change is accepted when **all** of the following hold:
+
+- [ ] `pnpm --filter @fhir-place/workbench db:setup` applies migration
+      `0002_agent_session.sql` cleanly.
+- [ ] `GET /api/sessions/tools` returns the six Phase A tools with their
+      metadata.
+- [ ] `POST /api/sessions` with `(connectionId, patientId)`:
+      - 201 + the row on success;
+      - 400 for an invalid FHIR id;
+      - 404 for an unknown connection.
+- [ ] `POST /api/sessions/:sid/tools/getPatient` with the matching
+      `patientId` returns 200 + an envelope with `ok: true` and the
+      Patient resource.
+- [ ] The same call with a different `patientId` returns HTTP 403 + an
+      envelope with `ok: false`, `reason: "unauthorized_patient"`.
+- [ ] An unknown tool name returns 404 + `reason: "unknown_tool"`.
+- [ ] Missing `patientId` returns 400 + `reason: "invalid_input"` with
+      structured Zod issues.
+- [ ] An unknown enum value (e.g. `clinicalStatus: "indeterminate"`,
+      `category: "survey"`, `status: "tentative"`) returns 400 +
+      `reason: "invalid_input"`.
+- [ ] `_count`-style truncation: a tool whose `execute` returns more
+      than `resultLimit` items returns the first `resultLimit` items
+      with `truncated: true`.
+- [ ] A tool that exceeds `timeoutMs` returns HTTP 504 + `reason:
+      "timeout"`.
+- [ ] The connection's `authToken` does not appear in any envelope or
+      response body — verified by a route test.
+- [ ] The in-memory logger receives one entry per invocation, including
+      failed ones, with `sessionId`, `patientId`, `tool`, `toolVersion`,
+      `input`, and `envelope`.
+- [ ] The frontend `PatientPage` has a "Start agent session" button
+      that creates the session and navigates to `/sessions/:sid`.
+- [ ] `/sessions/:sid` renders a tool selector, an extra-input JSON
+      field, and a tool-call history.
+- [ ] The synthetic-only banner is visible on every new page.
+- [ ] `pnpm -r typecheck` exits 0.
+- [ ] `pnpm -r test:run` exits 0; the suite includes 13 + 12 + 11 new
+      tests.
+- [ ] `pnpm --filter @fhir-place/workbench build` produces a Vite
+      bundle.
+- [ ] `docs/fhir-tools.md` describes the hard rules, tools, HTTP API,
+      envelope, file layout, and Phase A icebox.
+- [ ] No Phase A icebox item is introduced. Specifically: no LLM, no
+      arbitrary FHIR query generation, no write-back, no PHI path, no
+      tool composition inside the registry, no SMART, no tools outside
+      the six allow-listed types.

--- a/openspec/changes/add-agent-tool-registry/proposal.md
+++ b/openspec/changes/add-agent-tool-registry/proposal.md
@@ -1,0 +1,108 @@
+# Proposal — `add-agent-tool-registry`
+
+## Summary
+
+PR 4 of Phase A. Adds the typed, patient-scoped, deny-by-default tool
+layer the patient-summary agent (PR 6) will run against. Six tools land:
+`getPatient` plus five `searchXForPatient` tools covering the Phase A
+compartment. Sessions carry exactly one authorized patient id; every
+tool call validates that scope before doing any FHIR work.
+
+## Motivation
+
+PR 3 gives us a chokepoint that enforces a FHIR resource and search-param
+allow-list. That's necessary but not sufficient for the agent. The
+registry adds:
+
+- **Domain inputs** so the agent emits typed values (`clinicalStatus`,
+  `category`, `dateRange`) instead of FHIR-syntax strings.
+- **Patient-scope enforcement** the proxy can't do alone — the proxy has
+  no notion of "the patient *this run* is allowed to touch."
+- **Result limits and timeouts** at the tool boundary, on top of the
+  proxy's `_count` clamp.
+- **A normalized envelope** so success and every flavor of failure share
+  one shape with a machine-readable `reason`.
+- **A logging hook** PR 7 can subscribe to without changing any tool.
+
+PR 6 will call **only** these tools — never the proxy directly, never
+`fetch`, never the DB.
+
+## Scope
+
+In:
+
+- New table `agent_session(id, connection_id, patient_id, created_at,
+  updated_at)` and migration `0002_agent_session.sql`.
+- `ToolEnvelope` + `ToolErrorReason` shared types.
+- `ToolLogger` interface with in-memory and console implementations.
+- `ToolDef` + `createRegistry()` runner: input validation, patient-scope
+  check, timeout via `AbortSignal`, array truncation at `resultLimit`,
+  internal-error catch, mandatory logging hook invocation.
+- Six tool definitions:
+  - `getPatient`
+  - `searchConditionsForPatient` (`clinicalStatus?`, `limit?`)
+  - `searchMedicationRequestsForPatient` (`status?`, `limit?`)
+  - `searchAllergyIntolerancesForPatient` (`limit?`)
+  - `searchEncountersForPatient` (`dateRange?`, `limit?`)
+  - `searchObservationsForPatient` (`category?`, `dateRange?`, `limit?`)
+- HTTP routes:
+  - `POST/GET/DELETE /api/sessions` and `/api/sessions/:sid`
+  - `GET /api/sessions/tools`
+  - `POST /api/sessions/:sid/tools/:toolName`
+- Frontend: a "Start agent session" button on the patient page and a
+  humans-only debug `SessionPage` for running tools by hand.
+- Docs at `docs/fhir-tools.md`.
+
+Out:
+
+- LLM, prompt, agent loop (PR 6).
+- `tool_call` DB persistence (PR 7) — the logging hook is shaped for it
+  but stays in-memory in PR 4.
+- Tool composition / chaining inside the registry — the agent does that.
+- Tools outside the Phase A compartment.
+
+## Architecture decisions
+
+- **Sessions are explicit and patient-scoped, not implicit.** A user
+  starts a session with one click; the patient id is locked at session
+  create. The alternative (deriving patient scope from request headers
+  or cookies) hides the trust boundary; an explicit row makes audit
+  obvious.
+- **Patient id required in tool input *and* validated against the
+  session.** Belt and braces: tool inputs declare what they need; the
+  runner enforces scope. A mismatch returns
+  `reason: "unauthorized_patient"`. PR 6's agent never has a way to
+  forge or override this.
+- **Tools call the proxy.** All FHIR I/O goes through the same chokepoint
+  PR 3 introduced. Tools translate domain → URL params; the proxy
+  enforces FHIR allow-lists; the runner enforces patient scope.
+- **Normalized envelope, not exceptions.** Success and every failure
+  reason are in the same shape so the agent / UI can branch on `reason`
+  without try/catch.
+- **HTTP status mirrors reason.** Tests assert both. The envelope's
+  `reason` is the source of truth; HTTP status is for clients that don't
+  parse the body.
+
+## Safety
+
+- Tools the agent can call are explicitly enumerated; there is no
+  reflection, dynamic import, or registry mutation at runtime.
+- Tool input must include `patientId`. The runner rejects mismatch with
+  the session before any execution.
+- Tools cannot fetch directly — they receive `ctx.fetch` which the
+  shared helpers route through `proxySearch` / `proxyRead`.
+- The connection's auth token is never exposed to tools or returned in
+  any envelope. The tool's `ctx.connection` includes it, but the
+  envelope is built without it.
+- Logger throws never break tool execution.
+- Timeouts use `AbortSignal`; tools cannot ignore the signal because the
+  shared `runPatientSearch` / `runRead` thread it through to `fetch`.
+
+## Non-goals
+
+- An agent loop. PR 6.
+- DB persistence of tool calls. PR 7.
+- Free-form FHIR query tools.
+- Tools that mutate the upstream FHIR server.
+- Tool authentication (role-based, OAuth scopes, etc.). Phase A is
+  single-user.

--- a/openspec/changes/add-agent-tool-registry/requirements.md
+++ b/openspec/changes/add-agent-tool-registry/requirements.md
@@ -1,0 +1,86 @@
+# Requirements — `add-agent-tool-registry`
+
+## Functional
+
+- F1. The DB has an `agent_session(id, connection_id, patient_id,
+  created_at, updated_at)` table referencing `data_connection(id)` with
+  cascade delete.
+- F2. `POST /api/sessions` creates a session given `(connectionId,
+  patientId)`. `patientId` is validated against the FHIR R4 `id` regex.
+- F3. `POST /api/sessions/:sid/tools/:toolName` runs `toolName` against
+  the session's connection. The body is the typed tool input. The
+  response is a `ToolEnvelope`.
+- F4. `GET /api/sessions/tools` returns the list of registered tools
+  with their metadata (name, version, description, resource allow-list,
+  result limit, timeout).
+- F5. The Phase A registry contains exactly:
+  - `getPatient`
+  - `searchConditionsForPatient`
+  - `searchMedicationRequestsForPatient`
+  - `searchAllergyIntolerancesForPatient`
+  - `searchEncountersForPatient`
+  - `searchObservationsForPatient`
+- F6. Each tool's input is a Zod schema with `patientId` required.
+  Search tools accept an optional `limit` (1–50, default 20).
+- F7. Tools that accept `dateRange` validate `from` / `to` as
+  `YYYY-MM-DD` and forward them as `date=geFROM&date=leTO` query
+  repeats.
+
+## Non-functional
+
+- N1. Tools never call `fetch` directly. The shared helpers route every
+  call through `proxySearch` / `proxyRead`.
+- N2. The connection's `authToken` is never returned in any envelope.
+  Verified by a route test.
+- N3. Tools cannot mutate the upstream FHIR server. There is no PUT /
+  POST / DELETE path through the tool layer.
+- N4. The runner is the single chokepoint for: input validation, patient
+  scope, timeout, truncation, error normalization, and logging.
+- N5. The runner attaches an `AbortSignal` to every fetch. Timeouts come
+  back as `reason: "timeout"`, never as a stack trace.
+- N6. Logger errors are caught; they cannot break tool execution.
+
+## Tests
+
+- T1. Registry runner:
+  - returns `unknown_tool` for an unregistered name;
+  - returns `invalid_input` with structured Zod issues for bad input;
+  - returns `unauthorized_patient` when input.patientId ≠
+    session.patientId;
+  - returns `ok` envelope with `durationMs` on the happy path;
+  - logs every call (ok and error);
+  - times out and returns `reason: "timeout"`;
+  - truncates array data above `resultLimit` and sets `truncated: true`;
+  - rejects duplicate tool names at construction;
+  - propagates `upstream_error` from `execute`;
+  - returns `internal_error` on non-Abort thrown errors;
+  - never breaks when the logger throws.
+- T2. Per tool:
+  - `getPatient` reads `/Patient/:id` and returns the resource.
+  - `searchConditionsForPatient` forwards `patient` + `clinical-status`,
+    rejects an unknown `clinicalStatus`, returns `[]` cleanly when no
+    entries.
+  - `searchMedicationRequestsForPatient` forwards `status`, rejects
+    unsupported status.
+  - `searchAllergyIntolerancesForPatient` returns `[]` when none exist;
+    the tool docstring says this MUST NOT be summarised as "no known
+    allergies" upstream of this tool.
+  - `searchEncountersForPatient` forwards `dateRange` as `date=ge…` and
+    `date=le…` query repeats; rejects malformed dates.
+  - `searchObservationsForPatient` forwards `category` + `dateRange`;
+    rejects unsupported categories.
+- T3. Routes:
+  - `POST /api/sessions` returns 201 with the row and 400 / 404 for
+    invalid id / unknown connection.
+  - `POST /api/sessions/:sid/tools/:toolName` maps envelope reason to
+    HTTP status (200 / 400 / 403 / 404 / 502 / 504).
+  - The in-memory logger captures every invocation with the patient id
+    and session id.
+  - The auth token never appears in any envelope.
+
+## Documentation
+
+- D1. `docs/fhir-tools.md` documents the hard rules, the six tools, the
+  HTTP API, the envelope shape, the file layout, and the Phase A icebox.
+- D2. The PR description points reviewers to `docs/fhir-tools.md` and
+  references the OpenSpec change.

--- a/openspec/changes/add-agent-tool-registry/tasks.md
+++ b/openspec/changes/add-agent-tool-registry/tasks.md
@@ -1,0 +1,37 @@
+# Tasks — `add-agent-tool-registry`
+
+- [x] Add `agent_session` table to `db/schema.ts`.
+- [x] Add migration `db/migrations/0002_agent_session.sql`.
+- [x] Add `server/services/session-store.ts` (CRUD, injectable
+      `generateId` / `now`).
+- [x] Add `server/agent/envelope.ts` with `ToolEnvelope`,
+      `ToolErrorReason`, `ok()`, `err()`.
+- [x] Add `server/agent/tool-log.ts` with `ToolLogger`,
+      `inMemoryLogger()`, `consoleLogger()`.
+- [x] Add `server/agent/registry.ts` with `ToolDef`, `createRegistry()`,
+      and `PatientIdField`.
+- [x] Add `server/agent/tools/_shared.ts` with `dateRangeSchema`,
+      `appendDateRange`, `clampLimit`, `runPatientSearch`, `runRead`.
+- [x] Add `server/agent/tools/get-patient.ts` and the five
+      `search*-for-patient.ts` tool definitions.
+- [x] Add `server/agent/tools/index.ts` exporting `PHASE_A_TOOLS` and
+      `createPhaseATools()`.
+- [x] Thread `AbortSignal` through `proxySearch` / `proxyRead` for tool
+      timeouts.
+- [x] Add `server/routes/sessions.ts` with `POST/GET/DELETE
+      /api/sessions`, `GET /api/sessions/tools`, and
+      `POST /api/sessions/:sid/tools/:toolName`.
+- [x] Wire sessions, registry, and logger into `server/app.ts` and
+      `server/index.ts`.
+- [x] Backend tests:
+      - `server/agent/registry.test.ts` (13 tests)
+      - `server/agent/tools/tools.test.ts` (12 tests)
+      - `server/routes/sessions.test.ts` (11 tests)
+- [x] Frontend client `src/api/sessions.ts`.
+- [x] Frontend `SessionPage` (humans-only debug runner).
+- [x] "Start agent session" button on `PatientPage`.
+- [x] Wire `/sessions/:sid` route in `App.tsx`.
+- [x] Add `docs/fhir-tools.md`.
+- [x] Add OpenSpec change `add-agent-tool-registry/`.
+- [x] `pnpm -r typecheck`, `pnpm -r test:run`, and the workbench build
+      all pass.

--- a/openspec/changes/add-evidence-backed-answer-schema/acceptance.md
+++ b/openspec/changes/add-evidence-backed-answer-schema/acceptance.md
@@ -1,0 +1,43 @@
+# Acceptance — `add-evidence-backed-answer-schema`
+
+This change is accepted when **all** of the following hold:
+
+- [ ] `parseAgentAnswer(SAMPLE_AGENT_ANSWER)` returns
+      `{ ok: true, answer }`.
+- [ ] `parseAgentAnswer(badAnswer)` returns `ok: false` with an
+      `issues` array for at least:
+      - `schemaVersion !== "1"`,
+      - a supported claim with `evidence: []`,
+      - a claim citing `Procedure/x` (out-of-allow-list),
+      - missing top-level `missingData` field,
+      - empty `prompt`.
+- [ ] `RESOURCE_REFERENCE_REGEX` accepts the six allow-listed types
+      with valid FHIR ids and rejects out-of-list types, missing ids,
+      and ids over 64 chars.
+- [ ] `parseResourceReference` returns
+      `{ resourceType, id }` on valid input and `null` otherwise.
+- [ ] Visiting `/answer-preview` with the loaded sample renders a full
+      `AgentAnswer`: prompt, summary, three claims, one missing-data
+      entry, one cannot-determine entry, six tool-call rows.
+- [ ] Tweaking the JSON to drop `evidence` from a claim shows a
+      structured validation error in the left panel and the right panel
+      reverts to the empty placeholder.
+- [ ] Every evidence chip is a `<Link>` whose `href` is
+      `/connections/:cid/patients/:pid/<Type>/<id>`.
+- [ ] Missing-data and cannot-determine sections each render their own
+      `data-testid` block with their own entries — they are not
+      collapsed into the claims list.
+- [ ] An answer with all four sections empty renders four
+      `*-empty` hint blocks; the renderer does not collapse the
+      sections.
+- [ ] The renderer emits no Markdown markers in its output.
+- [ ] `pnpm -r typecheck` exits 0.
+- [ ] `pnpm -r test:run` exits 0; the suite includes at least 17
+      schema tests, 10 extractor tests, and 7 renderer tests.
+- [ ] `pnpm --filter @fhir-place/workbench build` produces a Vite
+      bundle.
+- [ ] `docs/agent-answer.md` describes the shape, hard rules, file
+      layout, downstream PR impact, and Phase A icebox.
+- [ ] No Phase A icebox item is introduced. Specifically: no LLM, no
+      DB persistence, no streaming, no confidence weights, no cross-
+      patient claims, no free-text Markdown rendering of model output.

--- a/openspec/changes/add-evidence-backed-answer-schema/proposal.md
+++ b/openspec/changes/add-evidence-backed-answer-schema/proposal.md
@@ -1,0 +1,112 @@
+# Proposal — `add-evidence-backed-answer-schema`
+
+## Summary
+
+PR 5 of Phase A. Defines `AgentAnswer` (and its supporting types
+`EvidenceBackedClaim`, `ResourceReference`, `MissingDataEntry`,
+`CannotDetermineEntry`, `ToolCallSummary`) as the source of truth for
+every agent output. Adds a renderer, evidence helpers, a known-good
+fixture, and a preview page that validates pasted JSON against the
+schema before rendering. No LLM yet — that lands in PR 6 against this
+schema.
+
+## Motivation
+
+Phase A's safety story rests on three claims:
+
+1. The agent only uses typed, patient-scoped tools (PR 4 ✓).
+2. Supported claims must cite source FHIR resources.
+3. Missing-data and cannot-determine are explicit, not implicit.
+
+Claims (2) and (3) collapse if the agent's output is free Markdown —
+it's trivially possible to write "the patient has diabetes" with no
+citation, or to imply "no allergies" when really the data is absent.
+
+Forcing the output through a Zod-validated structure lifts both safety
+properties from prompt-engineering to schema enforcement. PR 6's
+orchestrator can validate the model's JSON before rendering and either
+retry or downgrade to a partial answer; the UI never sees an unvalidated
+shape.
+
+## Scope
+
+In:
+
+- `apps/workbench/src/agent/answer-schema.ts` with `AgentAnswer`,
+  `EvidenceBackedClaim`, `ResourceReference`, `MissingDataEntry`,
+  `CannotDetermineEntry`, `ToolCallSummary`, `parseAgentAnswer`, and
+  `parseResourceReference`.
+- Resource references restricted to the Phase A allow-list and validated
+  as `<AllowedType>/<fhir-id>`.
+- `EvidenceBackedClaim.evidence.min(1)` enforced by the schema —
+  supported claims without citations fail validation.
+- `apps/workbench/src/agent/answer-extractors.ts`:
+  `citedReferences`, `dedupeReferences`, `evidenceCountsByType`,
+  `unsupportedClaimCount`, `duplicateClaimIds`, `resourceViewerHref`,
+  `uniqueEvidence`.
+- `apps/workbench/src/agent/AgentAnswerRenderer.tsx`: top-level
+  prompt + summary, supported-claims list with type-coloured evidence
+  chips that link to the resource viewer, first-class missing-data and
+  cannot-determine sections, tool-call timeline.
+- `apps/workbench/src/agent/EvidenceChip.tsx` with per-type tones and
+  resource-viewer links.
+- `apps/workbench/src/agent/fixtures.ts` with `SAMPLE_AGENT_ANSWER`.
+- `apps/workbench/src/pages/AnswerPreviewPage.tsx`: paste JSON, live
+  validation with structured Zod issue list, render on success.
+- `docs/agent-answer.md`.
+
+Out:
+
+- The agent loop, prompt, model wiring (PR 6).
+- DB persistence of `AgentAnswer` (PR 7).
+- Eval metrics (PR 8).
+- Failure-gallery pages built from stored answers (PR 9).
+- Confidence weights, streaming partial answers, cross-patient claims.
+
+## Architecture decisions
+
+- **One source of truth, one renderer.** The same `AgentAnswerRenderer`
+  is used by the agent (PR 6), the failure gallery (PR 9), the audit
+  detail view (PR 7), and the answer-preview page. There is no second
+  rendering path.
+- **References are FHIR-native, not opaque ids.** A claim points at
+  `Condition/abc-123`; the renderer resolves that to
+  `/connections/:cid/patients/:pid/Condition/abc-123` and the resource
+  viewer (PR 3) opens immediately. PR 7 will persist references in the
+  same shape so write-back is a no-op flip later.
+- **Supported claims and "missing data" are different shapes.** Phase
+  A's no-allergy-data eval depends on this. A claim with empty evidence
+  is rejected by the schema, not silently rendered as "I don't know".
+- **Renderer never validates.** Validation happens once in
+  `parseAgentAnswer`. The renderer's input type is the validated shape,
+  enforced by TypeScript. Defence in depth comes from the schema, not
+  from defensive runtime checks in the view.
+- **`summary` is free text but never load-bearing.** Counts, sections,
+  and evidence chips come from structured fields. The summary is for
+  humans skimming.
+
+## Safety
+
+- The schema is the choke-point that prevents:
+  - claims without evidence,
+  - claims with non-allow-listed FHIR types,
+  - "missing data" being implicit absence,
+  - "cannot determine" being a free-text apology buried in prose.
+- The renderer trusts its parsed input; tests guarantee the renderer
+  cannot be invoked with an unvalidated shape (TypeScript type) and that
+  malformed JSON is caught by `parseAgentAnswer` first.
+- No HTML / Markdown is interpolated into the rendered output. The
+  renderer composes React elements; user input flows through React's
+  default escaping. Fuzzed JSON cannot inject markup.
+- `unsupportedClaimCount` is exported as a sanity metric for PR 8 evals;
+  for any schema-valid answer it is always 0.
+
+## Non-goals
+
+- Authoring an answer by hand in the UI (the agent emits these; the
+  preview page only validates / renders).
+- Editing or annotating claims after creation.
+- Persistence (PR 7).
+- Streaming or partial-answer rendering.
+- Confidence scores.
+- Multi-patient or cross-patient claims.

--- a/openspec/changes/add-evidence-backed-answer-schema/requirements.md
+++ b/openspec/changes/add-evidence-backed-answer-schema/requirements.md
@@ -1,0 +1,88 @@
+# Requirements — `add-evidence-backed-answer-schema`
+
+## Functional
+
+- F1. `AgentAnswer` is a Zod schema covering: `schemaVersion: "1"`,
+  `sessionId`, `connectionId`, `patientId`, `prompt`, optional
+  `promptVersion`, optional `model`, optional `provider`, optional
+  `summary`, `claims[]`, `missingData[]`, `cannotDetermine[]`,
+  `toolCalls[]`, `createdAt`.
+- F2. `EvidenceBackedClaim` is `{ id, text, evidence[] }` and the
+  `evidence` array MUST contain at least one entry.
+- F3. `ResourceReference.reference` is validated against the regex
+  `^(Patient|Condition|MedicationRequest|AllergyIntolerance|Encounter
+  |Observation)/[A-Za-z0-9\-\.]{1,64}$`. Anything else fails.
+- F4. `MissingDataEntry` is `{ description }`.
+  `CannotDetermineEntry` is `{ question, why }`.
+- F5. `ToolCallSummary` mirrors PR 4's envelope:
+  `{ tool, toolVersion, ok, reason?, count?, truncated?, durationMs,
+  resourceIds? }`.
+- F6. `parseAgentAnswer(input)` returns
+  `{ ok: true, answer } | { ok: false, error, issues }` and never
+  throws.
+- F7. `parseResourceReference(ref)` returns
+  `{ resourceType, id }` for valid references and `null` otherwise.
+- F8. The renderer produces:
+  - prompt + (optional) summary header,
+  - supported-claims list with one node per claim and per-evidence
+    chip,
+  - first-class missing-data and cannot-determine sections,
+  - tool-call timeline with status badges,
+  - explicit empty-state hints for sections with zero entries.
+- F9. Each evidence chip links to
+  `/connections/:cid/patients/:pid/<Type>/<id>` (the PR 3 resource
+  viewer URL).
+- F10. The answer-preview page validates the textarea contents on every
+  change and renders only when `parseAgentAnswer` succeeds.
+
+## Non-functional
+
+- N1. The renderer never invokes Zod or any validation logic; its
+  input type is the validated `AgentAnswer`.
+- N2. The renderer never interpolates HTML / Markdown — only React
+  elements with default-escaped string content.
+- N3. The schema is shared logic and lives at
+  `apps/workbench/src/agent/answer-schema.ts`. Server-side use (PR 6,
+  PR 7) imports the same module.
+- N4. Tests cover both schema validation and the renderer, including
+  the "no Markdown smuggled into output" property.
+
+## Tests
+
+- T1. `RESOURCE_REFERENCE_REGEX` accepts every Phase A resource type
+  and rejects: out-of-list types, lowercase types, missing id, empty
+  id, ids with `..`, and ids longer than 64 chars.
+- T2. `EvidenceBackedClaim` rejects an empty `evidence` array.
+- T3. `AgentAnswer` accepts the fixture, rejects:
+  - `schemaVersion !== "1"`,
+  - claims without evidence,
+  - claims citing a Procedure (out-of-list),
+  - missing top-level `missingData` field,
+  - empty `prompt`.
+- T4. `parseAgentAnswer` returns `ok: true` for the fixture and
+  `ok: false` with an `issues` array for invalid input.
+- T5. Extractors:
+  - `citedReferences` is in claim order;
+  - `dedupeReferences` collapses dupes preserving order;
+  - `evidenceCountsByType` matches the fixture and ignores duplicates
+    across claims;
+  - `unsupportedClaimCount` is 0 for any schema-valid answer; matches
+    the input for synthetic data;
+  - `duplicateClaimIds` returns ids that appear more than once;
+  - `resourceViewerHref` builds the right URL or returns null;
+  - `uniqueEvidence` dedupes within a claim.
+- T6. Renderer tests (SSR via `renderToStaticMarkup`):
+  - prompt, summary, and section testIds appear;
+  - one `[data-testid="claim"]` per supported claim;
+  - every evidence chip carries a resource-viewer `href`;
+  - missing-data and cannot-determine entries appear as text;
+  - empty sections show an empty-state hint with `*-empty` testId;
+  - tool-call badges render `ok` and error reasons + `durationMs`;
+  - no Markdown markers (`**`, `#### `) appear in the output.
+
+## Documentation
+
+- D1. `docs/agent-answer.md` documents the shape, hard rules, file
+  layout, downstream PR impact, and Phase A icebox.
+- D2. The PR description points reviewers to `docs/agent-answer.md`
+  and references the OpenSpec change.

--- a/openspec/changes/add-evidence-backed-answer-schema/tasks.md
+++ b/openspec/changes/add-evidence-backed-answer-schema/tasks.md
@@ -1,0 +1,33 @@
+# Tasks — `add-evidence-backed-answer-schema`
+
+- [x] Add Zod schemas to `src/agent/answer-schema.ts`:
+      `ResourceReference`, `EvidenceBackedClaim`, `MissingDataEntry`,
+      `CannotDetermineEntry`, `ToolCallSummary`, `AgentAnswer`.
+- [x] Add `RESOURCE_REFERENCE_REGEX`, `parseResourceReference`,
+      `parseAgentAnswer`.
+- [x] Add `src/agent/answer-extractors.ts`: `citedReferences`,
+      `dedupeReferences`, `evidenceCountsByType`,
+      `unsupportedClaimCount`, `duplicateClaimIds`,
+      `resourceViewerHref`, `uniqueEvidence`.
+- [x] Add `src/agent/fixtures.ts` with `SAMPLE_AGENT_ANSWER` covering
+      supported claims, missing data, cannot-determine, and the full
+      tool-call timeline.
+- [x] Add `src/agent/EvidenceChip.tsx` with per-type tones and
+      resource-viewer linking.
+- [x] Add `src/agent/AgentAnswerRenderer.tsx` (sections + empty-state
+      hints; no validation).
+- [x] Add `src/pages/AnswerPreviewPage.tsx`: paste JSON, live
+      validation, render on success, structured Zod issue list on
+      failure.
+- [x] Wire `/sessions/:sid/answer-preview` and `/answer-preview` into
+      `App.tsx`; add an `AgentAnswer preview` link from the session
+      page.
+- [x] Tests:
+      - `src/agent/answer-schema.test.ts` (~17 tests)
+      - `src/agent/answer-extractors.test.ts` (~10 tests)
+      - `src/agent/AgentAnswerRenderer.test.tsx` (7 tests)
+- [x] `docs/agent-answer.md`.
+- [x] `openspec/changes/add-evidence-backed-answer-schema/{proposal,
+      requirements,tasks,acceptance}.md`.
+- [x] `pnpm -r typecheck`, `pnpm -r test:run`, and the workbench build
+      all pass.

--- a/openspec/changes/add-fhir-data-connection/acceptance.md
+++ b/openspec/changes/add-fhir-data-connection/acceptance.md
@@ -1,0 +1,35 @@
+# Acceptance — `add-fhir-data-connection`
+
+This change is accepted when **all** of the following hold:
+
+- [ ] `pnpm --filter @fhir-place/workbench db:setup` applies migrations
+      `0000_initial.sql` and `0001_data_connection.sql` against a fresh
+      SQLite file.
+- [ ] `pnpm --filter @fhir-place/workbench server` starts a Hono server on
+      port 5175 (configurable via `WORKBENCH_PORT`) that serves
+      `/api/health` and `/api/connections`.
+- [ ] `pnpm --filter @fhir-place/workbench dev` starts the Vite frontend on
+      port 5174 with `/api` proxied to the Hono server.
+- [ ] In the UI, a user can:
+      - [ ] Open the "Connections" page from the top nav.
+      - [ ] Create a new `fhir_clinical` connection with `none` or
+            `bearer` auth.
+      - [ ] See an error in the form when validation fails (e.g. missing
+            bearer token).
+      - [ ] Click **Test connection** and see the parsed FHIR version,
+            software, and a status badge.
+      - [ ] Delete a connection.
+- [ ] The synthetic-only / not-for-clinical-use banner stays visible on
+      every connections page.
+- [ ] Unsupported `kind` (e.g. `omop`) or `authType` (e.g. `smart`) values
+      are rejected with a 400 by the API.
+- [ ] Auth tokens never appear in any HTTP response body — verified by a
+      route test (`never returns the auth token in any response`).
+- [ ] `pnpm -r typecheck` and `pnpm -r test:run` pass with the new tests
+      included.
+- [ ] `pnpm --filter @fhir-place/workbench build` produces a Vite bundle.
+- [ ] `docs/data-connections.md` lists the allow-list, API surface, file
+      layout, dev workflow, and Phase A icebox.
+- [ ] No Phase A icebox item is introduced by this change. Specifically:
+      no SMART, no PHI, no write-back, no arbitrary FHIR query generation,
+      no MCP/OMOP/claims/wearable connection types.

--- a/openspec/changes/add-fhir-data-connection/proposal.md
+++ b/openspec/changes/add-fhir-data-connection/proposal.md
@@ -1,0 +1,75 @@
+# Proposal — `add-fhir-data-connection`
+
+## Summary
+
+Introduce the FHIR `DataConnection` abstraction: a typed, persisted
+configuration for a FHIR server the workbench can read from, plus a
+`/metadata` probe that fetches and persists a CapabilityStatement summary.
+This is PR 2 of Phase A.
+
+## Motivation
+
+The workbench needs a stable way to reference a FHIR server before any of
+the typed patient-scoped tools (PR 4) or the agent loop (PR 6) can run. The
+allow-list — `kind: fhir_clinical` and `authType: none | bearer` only — has
+to be enforced at the server boundary so unsupported modes (SMART, OMOP,
+claims) cannot be persisted by accident or by a misconfigured client.
+
+CapabilityStatement support also lands here so the connection setup flow
+ends in "this server is alive, here's what it claims to support" rather
+than just storing a URL.
+
+## Scope of this change (PR 2)
+
+In:
+
+- A `data_connection` table with denormalised `last_capability_*` fields.
+- A small Hono API (`apps/workbench/server/`) on port 5175 with:
+  - `GET / POST /api/connections`
+  - `GET / DELETE /api/connections/:id`
+  - `POST /api/connections/:id/test`
+- A FHIR `/metadata` probe service that returns the FHIR version and
+  software identification, and stores the raw CapabilityStatement.
+- A frontend connection setup UI: list, create, detail, test, delete.
+- Vite dev proxy `/api` → API port.
+- Docs at `docs/data-connections.md`.
+
+Out:
+
+- Patient search and the resource viewer (PR 3).
+- Tools (PR 4).
+- LLM and agent (PR 6).
+- Audit logging (PR 7) — capability fetch is not yet persisted as an
+  `AuditEvent`-shaped record.
+
+## Architecture decision: separate Hono process
+
+The Vite frontend cannot open SQLite directly (and shouldn't), so PR 2
+introduces a small Hono server alongside the Vite dev server. Two processes
+in dev (`pnpm --filter @fhir-place/workbench server` + `dev`); one in
+production (Vite emits a static bundle, Hono serves the API). This is the
+shape we'll need anyway for PR 4's server-enforced patient scope.
+
+## Safety
+
+- The auth allow-list is enforced in `server/schemas.ts` (Zod). Unknown
+  `kind` or `authType` values get a 400 before any DB write.
+- `bearer` auth requires a token; `none` rejects a token. Both rules are
+  unit-tested.
+- Stored auth tokens never leave the server. The API surface returns
+  `hasAuthToken: boolean` only.
+- The `/metadata` probe verifies the response is a `CapabilityStatement`
+  before persisting it; otherwise the connection is marked
+  `lastCapabilityStatus: "error"` with the reason.
+
+## Non-goals
+
+This change does **not**:
+
+- Add SMART on FHIR auth, OAuth client_credentials, mTLS, or any other
+  authentication mode.
+- Encrypt bearer tokens at rest. Phase A is synthetic-only; the README and
+  `docs/data-connections.md` say so explicitly.
+- Add connection-level scoping by patient compartment — that's the tool
+  registry's job (PR 4).
+- Add capability history; only the latest probe is stored.

--- a/openspec/changes/add-fhir-data-connection/requirements.md
+++ b/openspec/changes/add-fhir-data-connection/requirements.md
@@ -1,0 +1,65 @@
+# Requirements — `add-fhir-data-connection`
+
+## Functional
+
+- F1. A `data_connection` row is uniquely identified by an opaque `id` and
+  carries: `name`, `kind`, `baseUrl`, `authType`, optional `authToken`,
+  timestamps, and the latest CapabilityStatement summary fields.
+- F2. The API exposes the following endpoints under `/api/connections`:
+  `GET /`, `POST /`, `GET /:id`, `POST /:id/test`, `DELETE /:id`.
+- F3. `POST /` validates the input against a typed schema and returns 400
+  with a structured `{ error: "invalid_input", issues: [...] }` body on
+  failure.
+- F4. `POST /:id/test` calls `${baseUrl}/metadata` with `Accept:
+  application/fhir+json` and (when configured) a `Bearer` auth header,
+  verifies the response is a `CapabilityStatement`, and persists either the
+  parsed summary or a structured error.
+- F5. The frontend renders a list of connections with status, a create
+  form, a detail page with a test button, and a delete affordance.
+- F6. The Vite dev server proxies `/api` to the Hono server.
+- F7. The synthetic-only banner remains visible on every page introduced
+  by this change.
+
+## Non-functional
+
+- N1. The `kind` allow-list is `["fhir_clinical"]`. Other values are
+  rejected at the API boundary, regardless of HTTP path.
+- N2. The `authType` allow-list is `["none", "bearer"]`. Other values are
+  rejected at the API boundary.
+- N3. `authType: "bearer"` requires a non-empty `authToken`; `authType:
+  "none"` rejects a token.
+- N4. Auth tokens never appear in any HTTP response body. The redacted row
+  type is `Omit<DataConnection, "authToken"> & { hasAuthToken: boolean }`.
+- N5. The frontend never opens SQLite directly.
+- N6. The store is injectable: `createConnectionStore(db, { fetchFn,
+  generateId, now })`. Tests substitute `fetchFn` instead of relying on
+  global `vi.mock`.
+
+## Tests
+
+- T1. Unit tests cover `authHeadersFor` for all four meaningful inputs
+  (none, bearer w/ token, bearer w/o token, unknown auth type).
+- T2. Unit tests cover `probeCapabilityStatement` for: success, non-2xx,
+  wrong `resourceType`, network failure, and trailing-slash baseUrl.
+- T3. Route integration tests cover: list-empty, create-happy-path,
+  unsupported-kind, unsupported-auth-type, bearer-without-token,
+  none-with-token, 404-on-unknown-id, test-success, test-error, delete,
+  and token-redaction (no response body contains the stored token).
+
+## Safety
+
+- S1. Unsupported connection types and auth types cannot be persisted by
+  any path the API exposes.
+- S2. A malformed `/metadata` response (wrong shape or non-JSON) does not
+  panic the server; the connection is marked `lastCapabilityStatus:
+  "error"` with the reason.
+- S3. The probe `Accept` header is `application/fhir+json`. The probe sends
+  `Authorization: Bearer …` only when `authType === "bearer"` *and* a token
+  is configured.
+
+## Documentation
+
+- D1. `docs/data-connections.md` describes the allow-list, the API surface,
+  the file layout, the local dev workflow, and the Phase A icebox.
+- D2. `apps/workbench/README.md` references `docs/data-connections.md` and
+  the two-process dev setup.

--- a/openspec/changes/add-fhir-data-connection/tasks.md
+++ b/openspec/changes/add-fhir-data-connection/tasks.md
@@ -1,0 +1,31 @@
+# Tasks — `add-fhir-data-connection`
+
+- [x] Add `data_connection` table to `db/schema.ts` with denormalised
+      `last_capability_*` fields.
+- [x] Add migration `db/migrations/0001_data_connection.sql`.
+- [x] Add `server/schemas.ts` with the Phase A `kind` and `authType`
+      allow-lists and a Zod input schema.
+- [x] Add `server/services/fhir-connection.ts` with `authHeadersFor` and
+      `probeCapabilityStatement`.
+- [x] Add `server/services/connection-store.ts` with CRUD and capability
+      persistence; the store accepts injected `fetchFn`, `generateId`, and
+      `now` so tests don't reach for globals.
+- [x] Add `server/routes/connections.ts` (Hono router) and `server/app.ts`
+      (root app with `/api/health` + `/api/connections`).
+- [x] Add `server/index.ts` entry that boots the Hono app on
+      `WORKBENCH_PORT` (default 5175).
+- [x] Add `server/test-utils.ts` to spin up an in-memory test app with a
+      tmp SQLite file and a redactable connection store.
+- [x] Vitest tests for service and routes (token redaction included).
+- [x] Frontend API client at `src/api/connections.ts`.
+- [x] Frontend UI: `ConnectionsListPage`, `NewConnectionPage`,
+      `ConnectionDetailPage`, plus `ConnectionStatusBadge`.
+- [x] Wire the new routes into `App.tsx` and add a top-level nav link.
+- [x] Vite dev proxy `/api` → `WORKBENCH_PORT` (default 5175).
+- [x] Add `pnpm server` + `pnpm server:start` scripts.
+- [x] Update `apps/workbench/README.md` to mention the two-process dev
+      flow and link to `docs/data-connections.md`.
+- [x] Add `docs/data-connections.md`.
+- [x] Add `openspec/changes/add-fhir-data-connection/{proposal,requirements,tasks,acceptance}.md`.
+- [x] `pnpm -r typecheck`, `pnpm -r test:run`, and the workbench build all
+      pass.

--- a/openspec/changes/add-patient-search-and-viewer/acceptance.md
+++ b/openspec/changes/add-patient-search-and-viewer/acceptance.md
@@ -1,0 +1,41 @@
+# Acceptance — `add-patient-search-and-viewer`
+
+This change is accepted when **all** of the following hold:
+
+- [ ] `pnpm --filter @fhir-place/workbench server` and `dev` run
+      together; the user can navigate from the home page → Connections →
+      a connection → "Browse patients".
+- [ ] On the patients page, a user can submit a search by name,
+      identifier, birthdate, or gender, and see matching patients listed.
+- [ ] The patients page URL reflects the search; reloading and sharing
+      the URL re-applies the filter.
+- [ ] On the patient page, the demographics panel shows id, gender,
+      birthdate, and identifier(s).
+- [ ] The patient page renders five compartment cards (Condition,
+      MedicationRequest, AllergyIntolerance, Encounter, Observation),
+      each with a count and up to 8 entries; "+ N more" overflow.
+- [ ] Clicking any compartment entry opens the raw JSON viewer for that
+      resource.
+- [ ] The raw JSON viewer fetches the resource through the proxy and
+      shows pretty-printed JSON.
+- [ ] The synthetic-only banner is visible on every new page.
+- [ ] `GET /api/connections/:cid/fhir/Procedure` returns 400
+      `resource_type_not_allowed`.
+- [ ] `_include`, `_revinclude`, `_has`, `_filter`, `_elements`,
+      `_summary`, and `_format` are stripped before the proxy forwards
+      upstream.
+- [ ] `_count` larger than `MAX_COUNT = 100` is clamped.
+- [ ] FHIR `id` path segments containing `..`, `/`, or other unsafe
+      characters return 400.
+- [ ] Auth tokens never appear in any HTTP response from the proxy
+      routes — verified by a route test.
+- [ ] `pnpm -r typecheck` exits 0.
+- [ ] `pnpm -r test:run` exits 0; the suite includes the new
+      proxy/routes/PatientName tests.
+- [ ] `pnpm --filter @fhir-place/workbench build` produces a Vite
+      bundle.
+- [ ] `docs/patient-viewer.md` describes the URL shape, read path,
+      allow-lists, search-param policy, and Phase A icebox.
+- [ ] No Phase A icebox item is introduced. Specifically: no SMART, no
+      PHI path, no write-back, no DocumentReference text extraction, no
+      `$everything`, no arbitrary FHIR query generation.

--- a/openspec/changes/add-patient-search-and-viewer/proposal.md
+++ b/openspec/changes/add-patient-search-and-viewer/proposal.md
@@ -1,0 +1,90 @@
+# Proposal — `add-patient-search-and-viewer`
+
+## Summary
+
+PR 3 of Phase A. Lets a user search a configured FHIR server for a
+synthetic patient, select one, view demographics + a compartment summary,
+and inspect any allow-listed resource as raw JSON. All reads go through
+the existing Hono proxy so the auth token stays server-side and the
+resource-type / search-param allow-lists remain a single chokepoint.
+
+## Motivation
+
+PRs 1–2 set up the app shell and a configured FHIR connection. PR 3 is
+the first feature that actually reads patient data, and it sets the
+patterns the agent will reuse in PRs 4–6:
+
+- **One read path.** The user-facing "browse patients" flow uses the same
+  `/api/connections/:cid/fhir/*` proxy the typed-tool registry will use
+  in PR 4. The allow-lists land here, exercised by humans first, before
+  the agent ever sees them.
+- **No FHIR client in the browser.** The frontend never speaks to the
+  upstream FHIR server directly. The auth token never crosses the network
+  to the browser.
+- **URL is the selected-patient context.** No React context for "current
+  patient" — the URL holds it. Refresh-safe, shareable, audit-friendly.
+
+## Scope
+
+In:
+
+- A read-only FHIR proxy at `/api/connections/:cid/fhir/*` with two
+  routes: `GET /:resourceType` and `GET /:resourceType/:id`.
+- Phase A resource-type allow-list: Patient, Condition,
+  MedicationRequest, AllergyIntolerance, Encounter, Observation.
+- Per-resource search-parameter allow-list. Disallowed params (including
+  `_include`, `_revinclude`, `_has`, `_filter`, `_elements`, `_summary`,
+  `_format`) are silently dropped before forwarding.
+- `_count` clamped to `MAX_COUNT = 100`, default `20`.
+- FHIR `id` validated against the R4 spec regex before being placed in a
+  URL path segment.
+- Frontend pages: PatientsPage, PatientPage, ResourcePage; "Browse
+  patients" link from the connection detail page.
+- Docs at `docs/patient-viewer.md`.
+
+Out:
+
+- The typed FHIR tool registry (PR 4). The proxy here is user-facing, not
+  agent-callable. The agent in PR 6 only ever sees the typed tools that
+  PR 4 builds on top of this proxy.
+- Audit logging (PR 7) — the proxy doesn't yet emit `AuditEvent`-shaped
+  records.
+- Encrypted-at-rest tokens, SMART, OAuth client_credentials — same Phase
+  A icebox as PR 2.
+
+## Architecture decisions
+
+- **One proxy route, used by humans now and the agent later.** The
+  alternative — separate user-facing and agent-facing endpoints — would
+  duplicate the allow-list. Putting both behind the same chokepoint
+  means PR 4 narrows the surface (typed inputs, deny-by-default patient
+  scope) without re-implementing it.
+- **Search-param drop, not 400.** Disallowed params are silently dropped
+  rather than returning a 400. This matches FHIR's "ignore unknown
+  params" guidance and keeps the proxy lenient for browsers that send
+  legacy query strings, while still preventing `_include` and friends
+  from expanding the response shape.
+- **No `$everything`.** A single `Patient/:id/$everything` is tempting
+  but pulls back resource types we haven't allow-listed. We use plain
+  `?patient=Patient/:id` searches per resource type instead.
+
+## Safety
+
+- Resource-type allow-list is enforced at the proxy boundary. Anything
+  outside the six allow-listed types → 400.
+- Search-param allow-list is per-resource. `Condition`'s allow-list
+  rejects `birthdate`, etc.
+- FHIR `id` regex enforced before path-segment insertion (no
+  `../OperationDefinition` traversal).
+- Token redaction tests carried over from PR 2 are extended with a new
+  case asserting the proxy never returns the configured bearer token.
+- The proxy is GET-only. Hono returns 404 for `POST`/`PUT`/`PATCH`/
+  `DELETE` on this prefix.
+
+## Non-goals
+
+- Free-text search across resource bodies.
+- DocumentReference content extraction.
+- Anything that mutates the upstream FHIR server.
+- A patient-record completeness assessment — Phase A surfaces what the
+  server returned, no more.

--- a/openspec/changes/add-patient-search-and-viewer/requirements.md
+++ b/openspec/changes/add-patient-search-and-viewer/requirements.md
@@ -1,0 +1,72 @@
+# Requirements — `add-patient-search-and-viewer`
+
+## Functional
+
+- F1. The proxy exposes `GET /api/connections/:cid/fhir/:resourceType`
+  and `GET /api/connections/:cid/fhir/:resourceType/:id`.
+- F2. The Phase A resource-type allow-list is exactly:
+  `Patient`, `Condition`, `MedicationRequest`, `AllergyIntolerance`,
+  `Encounter`, `Observation`.
+- F3. The Phase A search-parameter allow-list is per-resource and lives
+  in `apps/workbench/server/schemas.ts`.
+- F4. The proxy filters search params before forwarding upstream.
+  Disallowed params (incl. `_include`, `_revinclude`, `_has`, `_filter`,
+  `_elements`, `_summary`, `_format`) are dropped silently.
+- F5. `_count` is clamped to `MAX_COUNT = 100`. Missing or non-positive
+  `_count` falls back to `20`.
+- F6. Repeated values for the same allow-listed key are preserved (FHIR
+  uses comma- and repeat-style multi-values).
+- F7. FHIR `id` path segments are validated against the R4 regex
+  `[A-Za-z0-9\-\.]{1,64}` before insertion. Anything else → 400.
+- F8. The frontend exposes:
+  - `/connections/:cid/patients` — search & list.
+  - `/connections/:cid/patients/:pid` — demographics + compartment.
+  - `/connections/:cid/patients/:pid/:resourceType/:resourceId` — raw
+    JSON viewer.
+- F9. The selected-patient context is URL-driven; there is no separate
+  React context or store.
+- F10. The patient search form supports `name`, `identifier`,
+  `birthdate`, and `gender`. The form's state is mirrored into URL search
+  params on submit.
+
+## Non-functional
+
+- N1. The auth token never reaches the browser. The proxy reads the raw
+  row via `ConnectionStore.getInternal`, attaches `Authorization` for
+  the upstream request, and never echoes the token back.
+- N2. The proxy is GET-only. `POST`/`PUT`/`PATCH`/`DELETE` on the
+  `/api/connections/:cid/fhir` prefix get a 404 by routing-table
+  omission.
+- N3. The synthetic-only banner stays visible on every new page.
+- N4. The frontend never opens the upstream FHIR server directly.
+
+## Tests
+
+- T1. `filterSearchParams`:
+  - keeps allow-listed params per resource;
+  - drops `_include`, `_revinclude`, `_has`, `_format`, etc.;
+  - clamps `_count` to `MAX_COUNT`;
+  - falls back to `_count=20` for invalid values;
+  - preserves repeated values;
+  - rejects Patient-only params (`birthdate`) on Condition.
+- T2. `proxySearch` / `proxyRead`:
+  - forward URL + auth headers correctly;
+  - propagate non-2xx upstream as `ok: false` with the body;
+  - return 502 on network failure;
+  - reject path-traversal ids before any fetch.
+- T3. Routes:
+  - 404 when connection not found;
+  - 400 when resource type outside allow-list;
+  - drop disallowed params before forwarding;
+  - never return the configured auth token in any response;
+  - 404 for non-GET on the prefix;
+  - propagate upstream non-2xx with status + body.
+- T4. `patientDisplayName` covers `official > usual > first`, text
+  fallback, empty array, and undefined input.
+
+## Documentation
+
+- D1. `docs/patient-viewer.md` documents the URL shape, read path,
+  allow-lists, search-param policy, and Phase A icebox.
+- D2. The PR description points reviewers to `docs/patient-viewer.md`
+  and references the OpenSpec change.

--- a/openspec/changes/add-patient-search-and-viewer/tasks.md
+++ b/openspec/changes/add-patient-search-and-viewer/tasks.md
@@ -1,0 +1,34 @@
+# Tasks — `add-patient-search-and-viewer`
+
+- [x] Add `ResourceType` enum, `SEARCH_PARAM_ALLOWLIST`, and `MAX_COUNT`
+      to `server/schemas.ts`.
+- [x] Add `server/services/fhir-proxy.ts` with `filterSearchParams`,
+      `proxySearch`, and `proxyRead` (FHIR id regex enforced).
+- [x] Add `server/routes/fhir.ts` mounted at
+      `/api/connections/:cid/fhir`. GET-only.
+- [x] Add `ConnectionStore.getInternal` for server-only access to the
+      raw row including `authToken`.
+- [x] Wire `fhirRoutes` into `server/app.ts` and propagate the injected
+      `fetchFn` through `createApp`.
+- [x] Tests:
+      - `services/fhir-proxy.test.ts` (12 tests)
+      - `routes/fhir.test.ts` (8 tests)
+      - `components/PatientName.test.tsx` (6 tests)
+- [x] Frontend client at `src/api/fhir.ts`:
+      `searchPatients`, `getPatient`, `searchByPatient`, `readResource`,
+      `bundleEntries`.
+- [x] Pages:
+      - `src/pages/PatientsPage.tsx` (search by name / identifier /
+        birthdate / gender; URL-synced)
+      - `src/pages/PatientPage.tsx` (demographics + 5 compartment cards)
+      - `src/pages/ResourcePage.tsx` (raw JSON viewer; allow-list
+        guard)
+- [x] `src/components/PatientName.tsx` with `patientDisplayName` and
+      `formatHumanName` helpers.
+- [x] Wire new routes into `App.tsx`.
+- [x] Add "Browse patients" affordance on the connection detail page.
+- [x] Add `docs/patient-viewer.md`.
+- [x] Add `openspec/changes/add-patient-search-and-viewer/{proposal,
+      requirements,tasks,acceptance}.md`.
+- [x] `pnpm -r typecheck`, `pnpm -r test:run`, and the workbench build
+      all pass.

--- a/openspec/changes/add-workbench-app/acceptance.md
+++ b/openspec/changes/add-workbench-app/acceptance.md
@@ -1,0 +1,24 @@
+# Acceptance — `add-workbench-app`
+
+This change is accepted when **all** of the following are true:
+
+- [ ] `pnpm install` succeeds at the repo root from a clean checkout.
+- [ ] `pnpm --filter @fhir-place/workbench dev` starts a Vite server on
+      `http://127.0.0.1:5174` and the page renders the synthetic-only banner
+      and the "FHIR Agent Workbench" home page.
+- [ ] `pnpm --filter @fhir-place/workbench db:setup` creates a SQLite file
+      at the configured path and applies the `0000_initial.sql` migration.
+- [ ] `pnpm -r typecheck` exits 0 with the new package included.
+- [ ] `pnpm -r test:run` exits 0 with the new package's tests included,
+      including:
+      - the synthetic-only banner test, and
+      - the Drizzle round-trip test.
+- [ ] `pnpm --filter @fhir-place/workbench build` produces a Vite bundle.
+- [ ] The CI workflow (`.github/workflows/ci.yml`) exercises the workbench
+      build.
+- [ ] `apps/workbench/README.md` opens with the synthetic-only / not-for-
+      clinical-use disclaimer.
+- [ ] `AGENTS.md` exists at the repo root and lists the Phase A icebox.
+- [ ] `docs/architecture.md`, `docs/safety.md`, and `docs/limitations.md`
+      exist as placeholders linked from the workbench README.
+- [ ] None of the Phase A icebox items are introduced by this change.

--- a/openspec/changes/add-workbench-app/proposal.md
+++ b/openspec/changes/add-workbench-app/proposal.md
@@ -1,0 +1,71 @@
+# Proposal — `add-workbench-app`
+
+## Summary
+
+Add a new package, `@fhir-place/workbench`, as the home of the FHIR Agent
+Workbench Phase A. This change introduces the repository foundation only:
+the app skeleton, a local-first SQLite database, the synthetic-only UI
+banner, and the supporting docs and CI hooks. Subsequent OpenSpec changes
+build features on top.
+
+## Motivation
+
+The existing repo ships a generic spec-driven FHIR component library
+(`@fhir-place/react-fhir`) and a demo app. The workbench is a separate
+research project with a different threat model and a different definition of
+done — synthetic-only, read-only, evidence-backed agent answers over typed
+patient-scoped tools.
+
+Carving it out as its own workspace package means:
+
+- The library and demo retain their general-purpose framing.
+- Workbench-specific safety constraints (no write-back, no SMART, no PHI)
+  are encoded in one place and don't bleed into the library.
+- The Phase A scope is reviewable PR-by-PR without entangling library work.
+
+## Scope of this change (PR 1 only)
+
+In:
+
+- New workspace package `apps/workbench/` with Vite + React + Tailwind
+  matching `apps/demo/` conventions.
+- A SQLite + Drizzle local-first DB scaffold with a placeholder
+  `schema_version` table and a `pnpm db:setup` script. Real models land in
+  later changes.
+- A synthetic-only / not-for-clinical-use banner rendered on every page.
+- Top-level docs placeholders (`docs/architecture.md`, `docs/safety.md`,
+  `docs/limitations.md`) and `AGENTS.md`.
+- CI hook so the new package is typechecked, tested, and built.
+
+Out:
+
+- Patient search (PR 3, change `add-patient-search-and-viewer`).
+- Tool registry (PR 4, change `add-agent-tool-registry`).
+- Agent loop, audit logging, evals — all later changes.
+- Any feature listed in the Phase A icebox.
+
+## Stack decisions
+
+- **pnpm workspace** — already in use by the repo.
+- **Vite + React 18 + Tailwind 3** — mirrors `apps/demo/` so reviewers and
+  contributors don't context-switch between two stacks.
+- **TanStack Query + react-router** — same as the demo.
+- **`@fhir-place/react-fhir`'s `FetchFhirClient`** — reuse rather than
+  reinvent the FHIR client.
+- **SQLite via `better-sqlite3` + Drizzle ORM** — local-first, single-file,
+  no external services. The `db/` directory is node-only and segregated
+  from the Vite frontend by a separate `tsconfig.node.json`.
+- **Zod** — installed now; load-bearing in PR 5 (`AgentAnswer` schema) but
+  declared here so later PRs don't have to add a fundamental dep.
+
+## Non-goals
+
+This change does **not**:
+
+- Add SMART on FHIR auth.
+- Open a path for PHI.
+- Add any write-back path against the FHIR server.
+- Add real `data_connection`, `agent_session`, `tool_call`, or
+  `evidence_claim` models — those land in their own OpenSpec changes.
+- Wire up an LLM provider — that lands in PR 6
+  (`add-patient-summary-agent`).

--- a/openspec/changes/add-workbench-app/requirements.md
+++ b/openspec/changes/add-workbench-app/requirements.md
@@ -1,0 +1,48 @@
+# Requirements — `add-workbench-app`
+
+## Functional
+
+- F1. The repository contains a workspace package named
+  `@fhir-place/workbench` at `apps/workbench/`.
+- F2. The package exposes the following pnpm scripts: `dev`, `build`,
+  `test`, `test:run`, `typecheck`, `db:setup`, `db:generate`.
+- F3. Running `pnpm --filter @fhir-place/workbench dev` starts a Vite dev
+  server that serves the workbench UI on `http://127.0.0.1:5174`.
+- F4. The UI shell renders a synthetic-only / not-for-clinical-use banner on
+  every page (in PR 1 there is one page; the banner stays as the app grows).
+- F5. The package contains a local-first SQLite database wired through
+  Drizzle ORM. Running `pnpm --filter @fhir-place/workbench db:setup`
+  creates `workbench.sqlite` and applies all migrations under
+  `db/migrations/`.
+- F6. Drizzle's schema lives at `db/schema.ts`. PR 1 ships a
+  `schema_version` placeholder table; subsequent OpenSpec changes replace or
+  extend it.
+
+## Non-functional
+
+- N1. The frontend (`src/`) and the node-only code (`db/`, `scripts/`) are
+  enforced as separate TypeScript projects via `tsconfig.json` and
+  `tsconfig.node.json`.
+- N2. `src/` does not import anything from `db/` or `scripts/`.
+- N3. The package mirrors the demo's stack: Vite, React 18, Tailwind 3,
+  TanStack Query, React Router. No new state-management library.
+- N4. The package reuses `@fhir-place/react-fhir`'s `FetchFhirClient`; it
+  does not reimplement a FHIR HTTP client.
+
+## Safety
+
+- S1. The synthetic-only banner uses `role="alert"` and copy that names both
+  "synthetic data only" and "not for clinical use".
+- S2. The README states upfront that the app is synthetic-only and not
+  clinical. The disclaimer also appears in `docs/safety.md` and
+  `docs/limitations.md`.
+- S3. No SMART on FHIR auth, PHI handling, write-back, CQL, MCP server,
+  prior auth, care-gap detection, DocumentReference extraction, or
+  arbitrary FHIR query generation is introduced by this change. The icebox
+  in `TASKS.md` and `docs/limitations.md` is the source of truth.
+
+## CI
+
+- C1. The repo's existing `pnpm -r typecheck` and `pnpm -r test:run`
+  commands cover the new package.
+- C2. `pnpm --filter @fhir-place/workbench build` is exercised in CI.

--- a/openspec/changes/add-workbench-app/tasks.md
+++ b/openspec/changes/add-workbench-app/tasks.md
@@ -1,0 +1,25 @@
+# Tasks — `add-workbench-app`
+
+- [x] Create `apps/workbench/` workspace package.
+- [x] Add `package.json`, `tsconfig.json`, `tsconfig.node.json`,
+      `vite.config.ts`, `vitest.config.ts`, `tailwind.config.js`,
+      `postcss.config.js`, `index.html`.
+- [x] Add UI shell: `src/main.tsx`, `src/App.tsx`, `src/index.css`,
+      `src/config.ts`, `src/pages/HomePage.tsx`,
+      `src/components/SyntheticOnlyBanner.tsx`.
+- [x] Vitest test asserting the synthetic-only banner renders the required
+      copy and `role="alert"`.
+- [x] Add Drizzle config and SQLite scaffold: `drizzle.config.ts`,
+      `db/schema.ts`, `db/client.ts`, `db/migrations/0000_initial.sql`,
+      `scripts/db-setup.ts`.
+- [x] Vitest test that opens the SQLite DB, applies migrations, and
+      round-trips a row through Drizzle.
+- [x] Add `apps/workbench/README.md` with synthetic-only positioning, local
+      setup, scripts table, and Phase A non-goals.
+- [x] Add `AGENTS.md` at the repo root.
+- [x] Add `docs/architecture.md`, `docs/safety.md`, `docs/limitations.md`
+      placeholders.
+- [x] Add `openspec/changes/add-workbench-app/{proposal,requirements,tasks,acceptance}.md`.
+- [x] Update `.github/workflows/ci.yml` to also build the workbench.
+- [x] Verify `pnpm -r typecheck`, `pnpm -r test:run`, and
+      `pnpm --filter @fhir-place/workbench build` succeed locally.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@fhir-place/react-fhir':
         specifier: workspace:*
         version: link:../../packages/react-fhir
+      '@hono/node-server':
+        specifier: ^2.0.1
+        version: 2.0.1(hono@4.12.16)
       '@tanstack/react-query':
         specifier: ^5.62.0
         version: 5.99.2(react@18.3.1)
@@ -88,6 +91,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)
+      hono:
+        specifier: ^4.12.16
+        version: 4.12.16
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -967,6 +973,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@hono/node-server@2.0.1':
+    resolution: {integrity: sha512-jI9yMDyFpqBeSighf/zlXnQG/nl9AyBc6aAgy4XtxJMyt/CNyJpvPfzDD+bCc2zAOmhhqtF6TnmIaY+xV4mIrw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
 
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
@@ -1886,6 +1898,10 @@ packages:
 
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
+
+  hono@4.12.16:
+    resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
+    engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -3395,6 +3411,10 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@hono/node-server@2.0.1(hono@4.12.16)':
+    dependencies:
+      hono: 4.12.16
+
   '@inquirer/ansi@2.0.5': {}
 
   '@inquirer/confirm@6.0.12(@types/node@22.19.17)':
@@ -4252,6 +4272,8 @@ snapshots:
     dependencies:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.0
+
+  hono@4.12.16: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7))
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(tsx@4.21.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.5.0(postcss@8.5.10)
@@ -59,13 +59,13 @@ importers:
         version: 8.5.10
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19
+        version: 3.4.19(tsx@4.21.0)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)
+        version: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)(tsx@4.21.0)
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))
@@ -73,6 +73,76 @@ importers:
       msw:
         specifier: ^2.7.0
         version: 2.13.4(@types/node@22.19.17)(typescript@5.9.3)
+
+  apps/workbench:
+    dependencies:
+      '@fhir-place/react-fhir':
+        specifier: workspace:*
+        version: link:../../packages/react-fhir
+      '@tanstack/react-query':
+        specifier: ^5.62.0
+        version: 5.99.2(react@18.3.1)
+      better-sqlite3:
+        specifier: ^12.9.0
+        version: 12.9.0
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: ^7.0.0
+        version: 7.14.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      zod:
+        specifier: ^4.4.1
+        version: 4.4.1
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/fhir':
+        specifier: ^0.0.41
+        version: 0.0.41
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
+      '@types/react':
+        specifier: ^18.3.0
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(tsx@4.21.0))
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.5.0(postcss@8.5.10)
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.10
+      tailwindcss:
+        specifier: ^3.4.17
+        version: 3.4.19(tsx@4.21.0)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)(tsx@4.21.0)
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))
 
   packages/react-fhir:
     dependencies:
@@ -305,6 +375,17 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
@@ -317,6 +398,18 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -327,6 +420,18 @@ packages:
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.21.5':
@@ -341,6 +446,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -353,6 +470,18 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.21.5':
     resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
@@ -363,6 +492,18 @@ packages:
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.21.5':
@@ -377,6 +518,18 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.21.5':
     resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
@@ -387,6 +540,18 @@ packages:
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.21.5':
@@ -401,6 +566,18 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.21.5':
     resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
@@ -411,6 +588,18 @@ packages:
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.21.5':
@@ -425,6 +614,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.21.5':
     resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
@@ -435,6 +636,18 @@ packages:
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.21.5':
@@ -449,6 +662,18 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.21.5':
     resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
@@ -459,6 +684,18 @@ packages:
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.21.5':
@@ -473,6 +710,18 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.21.5':
     resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
@@ -483,6 +732,18 @@ packages:
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.21.5':
@@ -497,6 +758,18 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.21.5':
     resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
@@ -509,10 +782,28 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -527,10 +818,28 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -545,11 +854,29 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
@@ -563,6 +890,18 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
@@ -573,6 +912,18 @@ packages:
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.21.5':
@@ -587,6 +938,18 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
@@ -595,6 +958,12 @@ packages:
 
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -891,6 +1260,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/dompurify@3.2.0':
     resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
     deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
@@ -1023,6 +1395,9 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.20:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
     engines: {node: '>=6.0.0'}
@@ -1032,9 +1407,19 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-sqlite3@12.9.0:
+    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1044,6 +1429,12 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1074,6 +1465,9 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -1140,9 +1534,17 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1154,6 +1556,10 @@ packages:
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   didyoumean@1.2.2:
@@ -1175,6 +1581,102 @@ packages:
   dompurify@3.4.1:
     resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
 
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
+    hasBin: true
+
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1184,6 +1686,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -1212,6 +1717,11 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
@@ -1219,6 +1729,11 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1233,6 +1748,10 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1266,6 +1785,9 @@ packages:
       picomatch:
         optional: true
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -1280,6 +1802,9 @@ packages:
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -1317,6 +1842,12 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1380,6 +1911,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1387,6 +1921,12 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -1520,9 +2060,19 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -1553,6 +2103,13 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
+
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
@@ -1570,6 +2127,9 @@ packages:
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -1708,6 +2268,12 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -1716,6 +2282,9 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1726,6 +2295,10 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -1767,6 +2340,10 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -1782,6 +2359,9 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -1808,6 +2388,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -1849,12 +2432,25 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   spawndamnit@3.0.1:
@@ -1880,6 +2476,9 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -1891,6 +2490,10 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -1912,6 +2515,13 @@ packages:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -1978,6 +2588,14 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
@@ -2143,6 +2761,9 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -2176,6 +2797,9 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  zod@4.4.1:
+    resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
 
 snapshots:
 
@@ -2468,10 +3092,28 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
+  '@drizzle-team/brocli@0.10.2': {}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.14.0
+
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
   '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
     optional: true
 
   '@esbuild/android-arm64@0.21.5':
@@ -2480,10 +3122,22 @@ snapshots:
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
   '@esbuild/android-arm@0.21.5':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
     optional: true
 
   '@esbuild/android-x64@0.21.5':
@@ -2492,10 +3146,22 @@ snapshots:
   '@esbuild/android-x64@0.25.12':
     optional: true
 
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
     optional: true
 
   '@esbuild/darwin-x64@0.21.5':
@@ -2504,10 +3170,22 @@ snapshots:
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-x64@0.21.5':
@@ -2516,10 +3194,22 @@ snapshots:
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
     optional: true
 
   '@esbuild/linux-arm@0.21.5':
@@ -2528,10 +3218,22 @@ snapshots:
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
     optional: true
 
   '@esbuild/linux-loong64@0.21.5':
@@ -2540,10 +3242,22 @@ snapshots:
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
   '@esbuild/linux-ppc64@0.21.5':
@@ -2552,10 +3266,22 @@ snapshots:
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.18.20':
     optional: true
 
   '@esbuild/linux-s390x@0.21.5':
@@ -2564,13 +3290,28 @@ snapshots:
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
+    optional: true
+
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -2579,7 +3320,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -2588,7 +3338,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.18.20':
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
@@ -2597,10 +3356,22 @@ snapshots:
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.18.20':
     optional: true
 
   '@esbuild/win32-ia32@0.21.5':
@@ -2609,10 +3380,19 @@ snapshots:
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@inquirer/ansi@2.0.5': {}
@@ -2861,6 +3641,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/dompurify@3.2.0':
     dependencies:
       dompurify: 3.4.1
@@ -2895,7 +3679,7 @@ snapshots:
   '@types/trusted-types@2.0.7':
     optional: true
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -2903,7 +3687,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2996,13 +3780,30 @@ snapshots:
       postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.20: {}
 
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
 
+  better-sqlite3@12.9.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   binary-extensions@2.3.0: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   braces@3.0.3:
     dependencies:
@@ -3015,6 +3816,13 @@ snapshots:
       electron-to-chromium: 1.5.342
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   cac@6.7.14: {}
 
@@ -3050,6 +3858,8 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  chownr@1.1.4: {}
 
   cli-width@4.1.0: {}
 
@@ -3103,13 +3913,21 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
+
+  deep-extend@0.6.0: {}
 
   delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
+
+  detect-libc@2.1.2: {}
 
   didyoumean@1.2.2: {}
 
@@ -3127,6 +3945,18 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
+  drizzle-kit@0.31.10:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      tsx: 4.21.0
+
+  drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0):
+    optionalDependencies:
+      '@types/better-sqlite3': 7.6.13
+      better-sqlite3: 12.9.0
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -3136,6 +3966,10 @@ snapshots:
   electron-to-chromium@1.5.342: {}
 
   emoji-regex@8.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enquirer@2.4.1:
     dependencies:
@@ -3160,6 +3994,31 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.3
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -3216,6 +4075,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
 
   esprima@4.0.1: {}
@@ -3223,6 +4111,8 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
 
@@ -3254,6 +4144,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -3272,6 +4164,8 @@ snapshots:
       mime-types: 2.1.35
 
   fraction.js@5.3.4: {}
+
+  fs-constants@1.0.0: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -3314,6 +4208,12 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -3381,9 +4281,15 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   indent-string@4.0.0: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -3507,7 +4413,13 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mri@1.2.0: {}
 
@@ -3548,6 +4460,12 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
+
   node-releases@2.0.37: {}
 
   normalize-path@3.0.0: {}
@@ -3557,6 +4475,10 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   outdent@0.5.0: {}
 
@@ -3632,12 +4554,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.10
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.10):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.10)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.10
+      tsx: 4.21.0
 
   postcss-nested@6.2.0(postcss@8.5.10):
     dependencies:
@@ -3657,6 +4580,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prettier@2.8.8: {}
 
   pretty-format@27.5.1:
@@ -3665,11 +4603,23 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -3710,6 +4660,12 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
@@ -3722,6 +4678,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   resolve@1.22.12:
     dependencies:
@@ -3773,6 +4731,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -3801,9 +4761,24 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   slash@3.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
 
   spawndamnit@3.0.1:
     dependencies:
@@ -3826,6 +4801,10 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -3835,6 +4814,8 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-json-comments@2.0.1: {}
 
   sucrase@3.35.1:
     dependencies:
@@ -3852,7 +4833,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(tsx@4.21.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -3871,7 +4852,7 @@ snapshots:
       postcss: 8.5.10
       postcss-import: 15.1.0(postcss@8.5.10)
       postcss-js: 4.1.0(postcss@8.5.10)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.10)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.10)(tsx@4.21.0)
       postcss-nested: 6.2.0(postcss@8.5.10)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -3879,6 +4860,21 @@ snapshots:
     transitivePeerDependencies:
       - tsx
       - yaml
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   term-size@2.2.1: {}
 
@@ -3935,6 +4931,17 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-fest@5.6.0:
     dependencies:
       tagged-tag: 1.0.0
@@ -3982,7 +4989,7 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
 
-  vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7):
+  vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3994,6 +5001,7 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
       jiti: 1.21.7
+      tsx: 4.21.0
 
   vitest@2.1.9(@types/node@22.19.17)(jsdom@25.0.1)(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3)):
     dependencies:
@@ -4063,6 +5071,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrappy@1.0.2: {}
+
   ws@8.20.0: {}
 
   xml-name-validator@5.0.0: {}
@@ -4084,3 +5094,5 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  zod@4.4.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,5 +3,6 @@ packages:
   - apps/*
 
 onlyBuiltDependencies:
+  - better-sqlite3
   - esbuild
   - msw


### PR DESCRIPTION
Closes #74. Stacks on #83 (PR 4). Part of #69 (Phase A).

> ⚠️ Stacked on #83 → review #80 → #81 → #82 → #83 first.

## Summary

Defines `AgentAnswer` (and its supporting types `EvidenceBackedClaim`,
`ResourceReference`, `MissingDataEntry`, `CannotDetermineEntry`,
`ToolCallSummary`) as the source of truth for every agent output. Adds
the renderer, evidence helpers, a known-good fixture, and a preview
page that validates pasted JSON against the schema before rendering.

**No LLM yet.** PR 6 will be constrained to emit JSON that parses
against this schema; PR 7 will persist instances; PR 8 will measure
them.

## Hard rules (enforced by Zod, not prompt-engineering)

1. **Supported claims must cite ≥ 1 resource.**
   `EvidenceBackedClaim.evidence.min(1)`. A claim without evidence
   fails validation **before render**.
2. **Resource references restricted to the Phase A allow-list.**
   Pattern `^(Patient|Condition|MedicationRequest|AllergyIntolerance|
   Encounter|Observation)/[A-Za-z0-9\-\.]{1,64}$`. Procedure /
   DocumentReference / arbitrary types → rejected.
3. **`schemaVersion` is `"1"` exactly.** Bumping is a breaking change.
4. **`missingData` and `cannotDetermine` are required top-level
   arrays.** "I don't know" cannot be smuggled in as a free-text claim.

## What landed

### Schema + helpers (`src/agent/`)

| File | What it is |
| --- | --- |
| `answer-schema.ts` | Zod schemas + `parseAgentAnswer` + `parseResourceReference` |
| `answer-extractors.ts` | `citedReferences`, `dedupeReferences`, `evidenceCountsByType`, `unsupportedClaimCount`, `duplicateClaimIds`, `resourceViewerHref`, `uniqueEvidence` |
| `fixtures.ts` | `SAMPLE_AGENT_ANSWER` |
| `EvidenceChip.tsx` | Type-coloured chip linking to the PR 3 resource viewer |
| `AgentAnswerRenderer.tsx` | The renderer (no validation; trusts its input type) |

### Renderer

- Prompt + optional summary header.
- Supported-claims list — one node per claim, evidence chips that link
  to `/connections/:cid/patients/:pid/<Type>/<id>` (PR 3's resource
  viewer URL — no rewriting).
- Missing-data and cannot-determine **as their own sections**, not as
  bullets in claims.
- Tool-call timeline with status badges + `durationMs`.
- Empty-state hints when a section has zero entries (so a blank
  missing-data is meaningfully different from "the agent didn't think
  about it").

### Preview page

`/answer-preview` and `/sessions/:sid/answer-preview` let a human paste
or edit JSON, see structured Zod errors on failure, and the rendered
answer on success. Demonstrates *"UI renders from structured answer,
not raw Markdown"*.

## Test plan

- [x] `pnpm -r typecheck`
- [x] `pnpm -r test:run` — **256 + 15 + 129 tests pass** (45 new)
  - `answer-schema.test.ts` (~17): regex matrix, evidence-min(1),
    schemaVersion mismatch, Procedure rejection, missing top-level
    `missingData`, empty prompt.
  - `answer-extractors.test.ts` (~10): order, dedupe,
    evidenceCountsByType, unsupportedClaimCount, duplicateClaimIds,
    resourceViewerHref + null path, uniqueEvidence.
  - `AgentAnswerRenderer.test.tsx` (7): SSR via
    `renderToStaticMarkup` + `MemoryRouter`, sections, claim count,
    evidence-chip hrefs, first-class missing/cannot-determine,
    empty-state hints, tool-call badges, **no Markdown markers in
    output**.
- [x] `pnpm --filter @fhir-place/workbench build` — Vite bundle.

## Architecture notes

- **One renderer for everything.** PR 6 (live agent), PR 7 (audit
  detail), PR 9 (failure gallery), and the preview page all use the
  same `AgentAnswerRenderer`. There is no second rendering path.
- **Refs are FHIR-native.** `Condition/abc-123` round-trips into the
  resource viewer with no URL rewriting; PR 7 will persist references
  in the same shape so write-back is a no-op flip later if the icebox
  ever opens.
- **Validation happens once, at the boundary.** The renderer's input
  type is the validated `AgentAnswer`; defence in depth comes from the
  schema, not from defensive runtime checks in the view.
- **`summary` is allowed but never load-bearing.** The evaluator never
  reads it; the renderer doesn't branch on it. Counts and sections
  come from structured fields.

## Phase A icebox (still excluded)

No LLM, no DB persistence, no streaming, no confidence weights, no
cross-patient claims, no free-text Markdown rendering of model output,
no editing/annotating claims after creation.

https://claude.ai/code/session_0171aCQPjQQMteJhAvwc1DtQ


---
_Generated by [Claude Code](https://claude.ai/code/session_0171aCQPjQQMteJhAvwc1DtQ)_