### PR TITLE
Add agent workflow docs, issue/PR templates, and ADRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-work-item.yml
+++ b/.github/ISSUE_TEMPLATE/agent-work-item.yml
@@ -1,0 +1,65 @@
+name: Agent work item
+description: Scoped implementation packet for Codex/Claude
+title: "[work] "
+labels:
+  - fhir-workbench-phase-a
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is broken or missing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: user_impact
+    attributes:
+      label: User impact
+      description: Why this matters to users/reviewers.
+    validations:
+      required: true
+
+  - type: textarea
+    id: desired_behavior
+    attributes:
+      label: Desired behavior
+      description: What should happen after this change?
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Use checkboxes.
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+
+  - type: textarea
+    id: relevant_files
+    attributes:
+      label: Relevant files
+      description: List likely files/areas.
+      value: |
+        - `apps/workbench/...`
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Explicit non-goals and boundaries.
+
+  - type: textarea
+    id: test_plan
+    attributes:
+      label: Test plan
+      value: |
+        - [ ] Run:
+        - [ ] Manual verification:
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+-
+
+## Issue
+Closes #
+
+## Changes
+-
+
+## Test results
+-
+
+## Screenshots / recordings
+Optional
+
+## Risks
+-
+
+## Follow-ups
+-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code Notes
+
+- Keep context small; read only files relevant to the active issue.
+- Before implementation, summarize a short plan.
+- Prefer existing patterns over new abstractions.
+- Treat GitHub issue acceptance criteria as the source of truth.
+- After changes, report files changed, tests run, risks, and follow-ups.

--- a/docs/decisions/0001-use-github-issues-as-source-of-truth.md
+++ b/docs/decisions/0001-use-github-issues-as-source-of-truth.md
@@ -1,0 +1,21 @@
+# 0001 Use GitHub Issues as Source of Truth
+
+## Status
+Accepted
+
+## Context
+Work tracking spans coding-agent chat, local markdown notes, and repository docs.
+Without a single canonical tracker, task state drifts and implementation context
+gets stale.
+
+## Decision
+GitHub Issues are the canonical source for scoped implementation work and status.
+GitHub PRs are the canonical code-change/audit record.
+
+`tasks.md` is temporary execution context for one active branch, not backlog
+storage.
+
+## Consequences
+- Each implementation task must link to a GitHub issue.
+- PRs should close linked issues when merged.
+- Long-lived backlog and prioritization happen in GitHub, not chat logs.

--- a/docs/decisions/0002-use-linear-only-if-github-projects-break-down.md
+++ b/docs/decisions/0002-use-linear-only-if-github-projects-break-down.md
@@ -1,0 +1,19 @@
+# 0002 Use Linear Only if GitHub Projects Break Down
+
+## Status
+Accepted
+
+## Context
+Maintaining both GitHub Issues and Linear too early can create duplicate state
+and conflicting workflows.
+
+## Decision
+Default to GitHub Issues + GitHub Projects first.
+Introduce Linear only if roadmap/prioritization needs exceed GitHub workflows.
+If adopted, Linear is product-planning layer while GitHub Issues/PRs remain tied
+to technical execution.
+
+## Consequences
+- Lower tooling overhead while project scope is still evolving.
+- Fewer synchronization mistakes between trackers.
+- A future migration path remains open if collaboration load increases.

--- a/docs/decisions/0003-agent-safety-rules.md
+++ b/docs/decisions/0003-agent-safety-rules.md
@@ -1,0 +1,26 @@
+# 0003 Agent Safety Rules
+
+## Status
+Accepted
+
+## Context
+Coding agents can execute commands and edit many files quickly.
+Prompt-only constraints are insufficient without explicit repository rules.
+
+## Decision
+Agent workflows in this repository must enforce:
+- small, issue-scoped changes,
+- no destructive or out-of-scope operations,
+- PR-based review before merge.
+
+Agents must not:
+- delete production data,
+- modify secrets/credentials,
+- rewrite migration history,
+- force-push `main`,
+- perform destructive commands without explicit human direction.
+
+## Consequences
+- Lower operational risk when delegating implementation.
+- Clear boundaries for Codex/Claude behavior.
+- Better auditability from issue -> branch -> PR chain.

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,28 @@
+# Current Agent Task
+
+> Temporary execution checklist for one active issue.
+> Source of truth for backlog/priorities stays in GitHub Issues.
+
+## Goal
+
+<!-- One-sentence outcome. -->
+
+## Source issue
+
+<!-- GitHub issue URL or #number. -->
+
+## Scope
+
+- [ ]
+
+## Non-goals
+
+- [ ]
+
+## Acceptance criteria
+
+- [ ]
+
+## Notes
+
+<!-- Optional implementation notes for the current branch only. -->


### PR DESCRIPTION
### Motivation
- Provide a single, durable workflow for agent-driven work so backlog and implementation stay in GitHub Issues and PRs. 
- Give coding agents concise repo rules and a disposable per-branch checklist to avoid competing task systems. 
- Capture lightweight, auditable decisions about tracker choice and agent safety to reduce operational risk when using automated coding agents.

### Description
- Add an agent-sized GitHub issue template at `.github/ISSUE_TEMPLATE/agent-work-item.yml` to structure problem, impact, desired behavior, acceptance criteria, relevant files, constraints, and test plan. 
- Add a pull request template at `.github/pull_request_template.md` to standardize PR summaries, issue linkage, changes, test results, risks, and follow-ups. 
- Add `CLAUDE.md` with concise Claude-specific operating notes and `tasks.md` as a disposable per-task execution checklist. 
- Add three ADRs under `docs/decisions/` formalizing: GitHub Issues as source-of-truth, deferring Linear until needed, and agent safety/guardrails (`0001-use-github-issues-as-source-of-truth.md`, `0002-use-linear-only-if-github-projects-break-down.md`, `0003-agent-safety-rules.md`).

### Testing
- No automated tests were necessary for these documentation and template-only changes; CI will run repository checks on the eventual PR as usual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ab0590848333ac951f81d148455f)