### PR TITLE
fix(demo): use router navigate from compartment row clicks

### DIFF
--- a/apps/demo/src/components/CompartmentSection.tsx
+++ b/apps/demo/src/components/CompartmentSection.tsx
@@ -1,6 +1,6 @@
 import { ResourceTable, useSearch } from "@fhir-place/react-fhir";
 import type { Resource } from "fhir/r4";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 export interface CompartmentSectionProps {
   /** Patient id scoping the search. */
@@ -34,6 +34,7 @@ export function CompartmentSection({
   patientSearchParam = "patient",
   limit = 5,
 }: CompartmentSectionProps) {
+  const navigate = useNavigate();
   const { data, isLoading } = useSearch<Resource>(resourceType, {
     [patientSearchParam]: patientId,
     _count: limit,
@@ -71,7 +72,7 @@ export function CompartmentSection({
             columns={columns}
             columnLabels={columnLabels}
             onRowClick={(r) => {
-              if (r.id) window.location.assign(`/${r.resourceType}/${r.id}`);
+              if (r.id) navigate(`/${r.resourceType}/${r.id}`);
             }}
           />
           {total > resources.length && (


### PR DESCRIPTION
## Summary
- Clicking an Observation/Condition/etc. row in a Patient's compartment view called `window.location.assign("/Type/id")`, doing a full-page navigation that bypassed react-router.
- On GitHub Pages the app is served from `/fhir-place/` behind `HashRouter` (see `apps/demo/src/config.ts:20-22`, `apps/demo/src/main.tsx:30`), so `/Observation/<id>` landed outside any Pages site and rendered GitHub's "There isn't a GitHub Pages site here" 404 instead of opening the existing `ResourceDetailPage` route.
- Swap the row-click handler in `apps/demo/src/components/CompartmentSection.tsx` to `useNavigate()` so the basename and hash router are honored, matching how `ResourceDetailPage` already handles reference clicks.

## Test plan
- [x] `pnpm --filter @fhir-place/demo typecheck`
- [x] `pnpm --filter @fhir-place/demo test:run`
- [ ] Manually verify on the deployed Pages build: open a Patient with observations, click an Observation row, confirm it navigates to `/fhir-place/#/Observation/<id>` and renders the detail page (no GitHub 404).

https://claude.ai/code/session_0114T4cXXLszukYSdYprBWbL

---
_Generated by [Claude Code](https://claude.ai/code/session_0114T4cXXLszukYSdYprBWbL)_