### PR TITLE
Add patient resource count indicator to patient list table

### DIFF
--- a/apps/demo/e2e/patient-table.screenshot.spec.ts
+++ b/apps/demo/e2e/patient-table.screenshot.spec.ts
@@ -20,6 +20,8 @@ test.describe("patient list — table view + column picker", () => {
     await expect(table).toBeVisible();
     await expect(page.getByRole("columnheader", { name: /^name$/i })).toBeVisible();
     await expect(page.getByRole("columnheader", { name: /gender/i })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: /resources/i })).toBeVisible();
+    await expect(page.getByTestId("patient-row-counts").first()).toBeVisible();
 
     await page.screenshot({
       path: "../../screenshots/12-patient-table.png",

--- a/apps/demo/src/pages/PatientListPage.tsx
+++ b/apps/demo/src/pages/PatientListPage.tsx
@@ -28,6 +28,7 @@ const TABLE_COLUMNS: Array<{ path: string; label: string }> = [
   { path: "birthDate", label: "Birth date" },
   { path: "address.city", label: "City" },
   { path: "id", label: "ID" },
+  { path: "__counts", label: "Resources" },
 ];
 
 const readLayout = (): Layout => {
@@ -208,6 +209,10 @@ export function PatientListPage() {
           resources={patients}
           columns={TABLE_COLUMNS.map((c) => c.path).filter((p) => columns.includes(p))}
           columnLabels={Object.fromEntries(TABLE_COLUMNS.map((c) => [c.path, c.label]))}
+          cellRenderers={{
+            __counts: (patient) =>
+              patient.id ? <PatientRowCounts patientId={patient.id} /> : <span className="text-slate-400">—</span>,
+          }}
           onRowClick={(p) => navigate(`/Patient/${p.id}`)}
           emptyState={
             <p className="px-4 py-6 text-center text-sm text-slate-500">


### PR DESCRIPTION
### Motivation
- Make it easy to see how many supported resources exist per patient from the search page so users can triage patients with or without data.

### Description
- Add a `Resources` column (`{ path: "__counts", label: "Resources" }`) to `TABLE_COLUMNS` in `apps/demo/src/pages/PatientListPage.tsx` so the column is included by default via existing column state initialization.
- Render per-patient counts in the table by supplying a `cellRenderers` entry that reuses `PatientRowCounts` (with a graceful fallback) so counts appear in both list and table layouts.
- Update the Playwright screenshot test `apps/demo/e2e/patient-table.screenshot.spec.ts` to assert the new `Resources` column header and visibility of the count widget in table mode.

### Testing
- Ran `pnpm -C apps/demo typecheck`, which completed successfully.
- Updated the Playwright e2e screenshot test assertions to expect the new column and count widget (test file modified but E2E run was not executed in this rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ad50513c83338f06f0b9ba0a93cc)