### PR TITLE
ci(workbench): build SPA bundle and upload as artifact

### DIFF
--- a/.github/workflows/workbench-preview.yml
+++ b/.github/workflows/workbench-preview.yml
@@ -1,0 +1,31 @@
+name: Build workbench preview
+
+on:
+  pull_request:
+    paths:
+      - "apps/workbench/**"
+      - "packages/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/workbench-preview.yml"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @fhir-place/react-fhir build
+      - run: pnpm --filter @fhir-place/workbench build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: workbench-dist
+          path: apps/workbench/dist
+          retention-days: 7
+          if-no-files-found: error

--- a/apps/workbench/README.md
+++ b/apps/workbench/README.md
@@ -76,6 +76,38 @@ The SQLite file defaults to `apps/workbench/workbench.sqlite`; override with
 | `db:setup` | Open `workbench.sqlite` and apply migrations under `db/migrations/` |
 | `db:generate` | Re-generate Drizzle migrations from `db/schema.ts` |
 
+## Iterating quickly
+
+Most iteration should stay off CI. The local loop is already fast:
+
+- **Two terminals.** `server` (tsx watches and restarts on save) plus `dev`
+  (Vite HMR). Vite proxies `/api` so edits on either side land sub-second.
+- **Vitest in watch mode.** `pnpm --filter @fhir-place/workbench test` (no
+  `:run`) re-runs on save.
+- **Throwaway DB per experiment.** Point `WORKBENCH_DB_URL` at a tmp file,
+  then `db:setup`, so you can blow away state without fighting migrations:
+  ```bash
+  WORKBENCH_DB_URL=/tmp/wb-$(date +%s).sqlite pnpm --filter @fhir-place/workbench db:setup
+  ```
+- **Don't burn Anthropic calls while iterating UI.** Drive
+  `AgentAnswerRenderer` from `src/agent/fixtures.ts` on
+  `AnswerPreviewPage`. Only hit the live agent when validating the loop
+  itself.
+- **For agent-loop tweaks**, write a vitest with the Anthropic SDK stubbed
+  to return canned `tool_use` blocks ending in `finalize`. Faster than
+  clicking through the UI.
+- **Iterating the preview workflow.** Don't push-and-wait. Trigger
+  `workbench-preview.yml` manually via `workflow_dispatch` (Actions tab →
+  "Run workflow" on the branch), or run it locally with
+  [`act`](https://github.com/nektos/act):
+  ```bash
+  act -W .github/workflows/workbench-preview.yml workflow_dispatch
+  ```
+- **Pre-push gate.** `pnpm --filter @fhir-place/workbench typecheck &&
+  pnpm --filter @fhir-place/workbench test:run && pnpm --filter
+  @fhir-place/workbench build` mirrors `ci.yml` and catches the 95% case
+  before the round-trip.
+
 ## Layout
 
 ```


### PR DESCRIPTION
Add a preview-only workflow that produces apps/workbench/dist on PRs
touching the workbench (or on manual dispatch) and uploads it as an
actions artifact. The workbench is a two-process app (Vite SPA + Hono
API + SQLite + Anthropic), so it can't ride pages.yml; this lets
reviewers download the built frontend without standing up a host.

https://claude.ai/code/session_01Mv8Asd4gvqqERn3QFiQiL9