### PR TITLE
Add full JSON viewer to ResourceDetail and a customizable ColumnPicker for ResourceIndex

### DIFF
--- a/apps/demo/src/pages/ResourceDetailPage.tsx
+++ b/apps/demo/src/pages/ResourceDetailPage.tsx
@@ -115,6 +115,17 @@ export function ResourceDetailPage() {
         />
       )}
 
+      {data && (
+        <details className="rounded border border-slate-200 bg-white" data-testid="resource-json">
+          <summary className="cursor-pointer px-4 py-2 text-sm font-medium text-slate-700">
+            View full JSON
+          </summary>
+          <pre className="max-h-[32rem] overflow-auto border-t border-slate-200 bg-slate-50 p-4 text-xs text-slate-800">
+            {JSON.stringify(data, null, 2)}
+          </pre>
+        </details>
+      )}
+
       {data && resourceType === "Patient" && (
         <section
           className="space-y-6 pt-2"

--- a/apps/demo/src/pages/ResourceIndexPage.tsx
+++ b/apps/demo/src/pages/ResourceIndexPage.tsx
@@ -1,13 +1,55 @@
 import {
+  ColumnPicker,
   ResourceSearch,
   ResourceTable,
   useInfiniteSearch,
+  useStructureDefinition,
 } from "@fhir-place/react-fhir";
 import type { Resource } from "fhir/r4";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import type { SearchParams } from "@fhir-place/react-fhir";
 import { PATIENT_COMPARTMENT } from "../compartment.js";
+
+const columnLabelFromPath = (path: string): string => {
+  const last = path.split(".").pop() ?? path;
+  return last
+    .replace(/\[\d+\]/g, "")
+    .replace(/\[x\]$/, "")
+    .replace(/([A-Z])/g, " $1")
+    .replace(/^./, (c) => c.toUpperCase())
+    .trim();
+};
+
+
+const summaryPathsFromStructure = (resourceType: string, paths: string[]): string[] => {
+  const prefix = `${resourceType}.`;
+  return paths
+    .filter((path) => path.startsWith(prefix) && path.split(".").length > 2)
+    .map((path) => path.slice(prefix.length))
+    .filter((path) => !path.includes(".extension") && !path.includes(".modifierExtension"));
+};
+
+const collectPaths = (value: unknown, prefix = "", out = new Set<string>()): Set<string> => {
+  if (value === null || value === undefined) return out;
+  if (Array.isArray(value)) {
+    if (value.length > 0) collectPaths(value[0], prefix, out);
+    return out;
+  }
+  if (typeof value !== "object") {
+    if (prefix) out.add(prefix);
+    return out;
+  }
+
+  const record = value as Record<string, unknown>;
+  for (const [key, next] of Object.entries(record)) {
+    if (key === "resourceType") continue;
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (next !== null && typeof next === "object") collectPaths(next, path, out);
+    else out.add(path);
+  }
+  return out;
+};
 
 /**
  * Generic index page for a resource type (non-Patient). Reads `?patient=<id>`
@@ -47,8 +89,43 @@ export function ResourceIndexPage() {
   const columnConfig = PATIENT_COMPARTMENT.find(
     (c) => c.resourceType === resourceType,
   );
-  const columns = columnConfig?.columns ?? ["status", "code.text"];
-  const columnLabels = columnConfig?.columnLabels;
+  const { data: structureDefinition } = useStructureDefinition(resourceType, {
+    enabled: Boolean(resourceType),
+  });
+  const defaultColumns = useMemo(() => {
+    if (columnConfig?.columns?.length) return columnConfig.columns;
+    const summary = summaryPathsFromStructure(
+      resourceType,
+      structureDefinition?.snapshot?.element
+        ?.filter((element) => element.isSummary)
+        .map((element) => element.path ?? "") ?? [],
+    );
+    if (summary.length > 0) return summary.slice(0, 8);
+    return ["status", "code.text", "subject.reference", "id"];
+  }, [columnConfig?.columns, resourceType, structureDefinition?.snapshot?.element]);
+
+  const allColumnOptions = useMemo(() => {
+    const fromRows = resources.flatMap((resource) => Array.from(collectPaths(resource)));
+    const unique = new Set<string>([...defaultColumns, ...fromRows]);
+    return Array.from(unique).map((path) => ({
+      path,
+      label: columnConfig?.columnLabels?.[path] ?? columnLabelFromPath(path),
+    }));
+  }, [columnConfig?.columnLabels, defaultColumns, resources]);
+
+  const columnStorageKey = `fhir-place-demo-${resourceType.toLowerCase()}-columns`;
+  const [columns, setColumns] = useState<string[]>(defaultColumns);
+
+  useEffect(() => {
+    setColumns((current) => {
+      const available = new Set(allColumnOptions.map((option) => option.path));
+      const kept = current.filter((path) => available.has(path));
+      if (kept.length > 0) return kept;
+      return defaultColumns.filter((path) => available.has(path));
+    });
+  }, [allColumnOptions, defaultColumns]);
+
+  const columnLabels = Object.fromEntries(allColumnOptions.map((c) => [c.path, c.label]));
 
   return (
     <div className="space-y-4">
@@ -89,6 +166,14 @@ export function ResourceIndexPage() {
           setParams({ _count: 20, ...(patientId ? { patient: patientId } : {}), ...p })
         }
       />
+
+      <div className="flex justify-end">
+        <ColumnPicker
+          options={allColumnOptions}
+          onChange={setColumns}
+          storageKey={columnStorageKey}
+        />
+      </div>
 
       {isError && (
         <p className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">


### PR DESCRIPTION
### Motivation

- Provide a quick way to inspect the raw FHIR resource JSON on the detail page for debugging and transparency.
- Allow users to customize which columns appear in the resource index and surface sensible defaults derived from StructureDefinition summaries.
- Ensure column choices adapt to available fields in loaded resources and persist per-resource-type for a better browsing experience.

### Description

- Added a collapsible JSON viewer to `ResourceDetailPage` that shows the full resource via `JSON.stringify(data, null, 2)` in a `<details>` block with `data-testid="resource-json"`.
- Enhanced `ResourceIndexPage` to include a `ColumnPicker` and dynamic column handling, including new helpers `columnLabelFromPath`, `summaryPathsFromStructure`, and `collectPaths` to derive column options from `StructureDefinition` and from actual resource rows.
- Integrated `useStructureDefinition` to read element summaries and compute sensible default columns, falling back to a conservative list `[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3bb6ac5188333a8bbbc44c009896b)