### PR TITLE
Add manual-QA checklist to PR template and screenshots evidence path

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,17 @@ Closes #
 ## Test results
 -
 
+## Acceptance / manual QA
+- [ ] Acceptance criteria updated (if applicable)
+- [ ] `manual-qa` label added when any acceptance item is not fully automated
+- [ ] Linked/created manual QA issue(s):
+
+## TASKS.md update
+- [ ] Updated `apps/workbench/TASKS.md` for backlog/done status
+
 ## Screenshots / recordings
-Optional
+Required for UI/UX changes. Add links to assets committed in `apps/workbench/docs/screenshots/` or externally hosted recordings.
+-
 
 ## Risks
 -

--- a/apps/workbench/docs/screenshots/README.md
+++ b/apps/workbench/docs/screenshots/README.md
@@ -1,0 +1,11 @@
+# Screenshots for Acceptance
+
+Store PR screenshots or short recordings for workbench acceptance/manual QA in this folder.
+
+Suggested naming:
+- `pr-<number>-<feature>-<step>.png`
+- `pr-<number>-<feature>-<step>.gif`
+
+When used, link these files in:
+- PR body `## Screenshots / recordings`
+- `apps/workbench/TASKS.md` task notes when manual QA evidence is relevant.


### PR DESCRIPTION
### Motivation
- Make acceptance/manual-QA expectations visible to contributors at PR time.
- Give UI/UX work a documented home for screenshot/recording evidence.

### Description
- Updated `.github/pull_request_template.md` to add an Acceptance / manual QA checklist (including a `manual-qa` label reminder), a TASKS.md update checkbox, and to make the Screenshots / recordings section required for UI/UX changes.
- Added `apps/workbench/docs/screenshots/README.md` documenting the naming convention and where to link the artifacts.

### Out of scope (intentionally not included)
The earlier revision of this PR also proposed a `manual-qa-guard` workflow, a `workbench-acceptance` CI job, and a `post-merge-task-sync` workflow + script. Those were dropped:
- `manual-qa-guard` had a merge-base diff bug (P1) and a path/regex mismatch with the PR template (P2 ×2).
- `workbench-acceptance` duplicated work already covered by the existing `test` job (`pnpm -r typecheck`, `pnpm -r test:run`, `pnpm --filter @fhir-place/workbench build`).
- `post-merge-task-sync` pushed bot commits directly to `main`, ran on any base branch, and would fail on fork PRs due to the read-only `GITHUB_TOKEN`.

If we want guard/automation later, it should land as a separate PR with those issues addressed.

### Testing
- Documentation/template-only change; no automated tests run. Existing CI (`test`, `e2e`, `build`) covers the repo as before.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3babade588333aa2f133471b2f287)