### PR TITLE
test(react-fhir): expand integration coverage and codify stop-the-bleed policy

### DIFF
--- a/packages/react-fhir/integration/FhirClient.integration.test.ts
+++ b/packages/react-fhir/integration/FhirClient.integration.test.ts
@@ -191,11 +191,10 @@ describe.skipIf(!reachable)(`integration: FhirClient @ ${FHIR_BASE_URL}`, () => 
 
   test(
     "readReference() throws on malformed reference",
-    async () => {
-      const err = await client
-        .readReference<Patient>({ reference: "not-a-fhir-reference" })
-        .catch((e) => e);
-      expect(err).toBeInstanceOf(Error);
+    () => {
+      expect(() =>
+        client.readReference<Patient>({ reference: "not-a-fhir-reference" }),
+      ).toThrow(/Unsupported reference form/);
     },
     30_000,
   );

--- a/packages/react-fhir/integration/FhirClient.integration.test.ts
+++ b/packages/react-fhir/integration/FhirClient.integration.test.ts
@@ -170,6 +170,37 @@ describe.skipIf(!reachable)(`integration: FhirClient @ ${FHIR_BASE_URL}`, () => 
   );
 
   test(
+    "readReference() resolves an absolute reference URL",
+    async () => {
+      const unique = (globalThis.crypto ?? require("crypto")).randomUUID();
+      const patient = await client.create<Patient>({
+        resourceType: "Patient",
+        identifier: [{ system: TEST_IDENTIFIER_SYSTEM, value: unique }],
+        name: [{ given: ["Absolute"], family: "Reference" }],
+      });
+      cleanup.push({ type: "Patient", id: patient.id! });
+
+      const resolved = await client.readReference<Patient>({
+        reference: `${FHIR_BASE_URL}/Patient/${patient.id}`,
+      });
+      expect(resolved.resourceType).toBe("Patient");
+      expect(resolved.id).toBe(patient.id);
+    },
+    60_000,
+  );
+
+  test(
+    "readReference() throws on malformed reference",
+    async () => {
+      const err = await client
+        .readReference<Patient>({ reference: "not-a-fhir-reference" })
+        .catch((e) => e);
+      expect(err).toBeInstanceOf(Error);
+    },
+    30_000,
+  );
+
+  test(
     "walkResource() produces sensible output for a real fetched Patient",
     async () => {
       const unique = (globalThis.crypto ?? require("crypto")).randomUUID();
@@ -208,6 +239,21 @@ describe.skipIf(!reachable)(`integration: FhirClient @ ${FHIR_BASE_URL}`, () => 
         .catch((e) => e);
       expect(isFhirError(err)).toBe(true);
       expect([404, 410, 400]).toContain(err.status);
+    },
+    30_000,
+  );
+
+  test(
+    "search on a guaranteed-missing identifier returns an empty searchset",
+    async () => {
+      const unique = (globalThis.crypto ?? require("crypto")).randomUUID();
+      const bundle: Bundle<Patient> = await client.search<Patient>("Patient", {
+        identifier: `${TEST_IDENTIFIER_SYSTEM}|missing-${unique}`,
+      });
+      expect(bundle.resourceType).toBe("Bundle");
+      expect(bundle.type).toBe("searchset");
+      expect(bundle.total ?? 0).toBe(0);
+      expect((bundle.entry ?? []).length).toBe(0);
     },
     30_000,
   );

--- a/packages/react-fhir/integration/README.md
+++ b/packages/react-fhir/integration/README.md
@@ -37,3 +37,6 @@ post-merge via the nightly run, not block unrelated PRs on HAPI downtime.
 - Default per-test timeout is 30 s; give CRUD roundtrips 60 s.
 - Never assert on pre-existing data — HAPI's public instance is reset
   periodically.
+- Stop-the-bleed policy: when fixing a production bug or server-contract
+  regression, add or extend an integration test in the same PR so the failure
+  mode is pinned and cannot silently reappear.


### PR DESCRIPTION
### Motivation

- Harden the FHIR client integration contract by covering edge cases around `readReference` and search behavior so server-regression or contract changes are caught by CI. 
- Ensure future fixes include a matching integration test to prevent regressions from silently reappearing (stop-the-bleed).

### Description

- Add integration tests in `packages/react-fhir/integration/FhirClient.integration.test.ts` to cover: absolute-reference resolution via `readReference`, failure on malformed references, and guaranteed-empty identifier searches returning an empty `searchset`.
- Document a `Stop-the-bleed` policy in `packages/react-fhir/integration/README.md` instructing that production bug fixes or server-contract regressions must include integration test coverage in the same PR.
- No library or API surface changes; testing-only additions meant to exercise existing `FetchFhirClient` behaviors against a live FHIR server.

### Testing

- Ran the integration suite with `pnpm --filter @fhir-place/react-fhir test:integration`, which was auto-skipped because the configured public HAPI endpoint at `https://hapi.fhir.org/baseR4` was unreachable (suite skipped; 14 tests skipped).
- Ran unit/test-run subset with `pnpm --filter @fhir-place/react-fhir test:run -- src/client`, and the test run completed successfully with the repository unit tests: 22 files / 260 tests passed.
- The integration tests added are written to use `crypto.randomUUID()` for unique resources and perform best-effort cleanup in `afterAll` per the existing integration guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3bc11217083339e17faabad4aa374)