### PR TITLE
ci: allow repository-relative screenshot evidence in manual QA guard

### DIFF
--- a/.github/workflows/manual-qa-guard.yml
+++ b/.github/workflows/manual-qa-guard.yml
@@ -1,0 +1,43 @@
+name: Manual QA guard
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  manual-qa-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect acceptance changes
+        id: changes
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          files=$(git diff --name-only "$base" "$head" -- 'openspec/changes/**/acceptance.md')
+          if [ -n "$files" ]; then
+            echo "acceptance_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "acceptance_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enforce manual QA label and screenshot link
+        if: steps.changes.outputs.acceptance_changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map((l) => l.name)
+            const body = context.payload.pull_request.body || ''
+            const hasManualQa = labels.includes('manual-qa')
+            const screenshotSection = /##\s*Screenshots\s*\/\s*recordings[\s\S]*(https?:\/\/|apps\/workbench\/docs\/screenshots\/|\[[^\]]+\]\([^\)]+\))/i.test(body)
+
+            const errors = []
+            if (!hasManualQa) errors.push('Add the `manual-qa` label when acceptance criteria are changed.')
+            if (!screenshotSection) errors.push('Add at least one screenshot/recording link under `## Screenshots / recordings`.')
+
+            if (errors.length) {
+              core.setFailed(errors.join('\n'))
+            }


### PR DESCRIPTION
### Motivation
- PRs that change `openspec/changes/**/acceptance.md` previously required `http(s)` screenshot links which rejected valid repository-relative evidence, so the guard was updated to accept repo-relative paths and still enforce the `manual-qa` label.

### Description
- Add ` .github/workflows/manual-qa-guard.yml` which detects changes to `openspec/changes/**/acceptance.md` and, when present, runs an `actions/github-script` check that requires the `manual-qa` label and a `## Screenshots / recordings` section containing either an `http(s)` URL, a repository-relative path under `apps/workbench/docs/screenshots/`, or a generic markdown link.

### Testing
- No automated tests were run for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d006c7888333b7bf55d8092f3bc8)