### PR TITLE
Fail stalled FHIR reads with explicit timeout (FhirError 408)

### DIFF
--- a/packages/react-fhir/src/client/FetchFhirClient.test.ts
+++ b/packages/react-fhir/src/client/FetchFhirClient.test.ts
@@ -261,6 +261,21 @@ describe("FetchFhirClient", () => {
     expect(cap.fhirVersion).toBe("4.0.1");
   });
 
+
+
+  it("fails stalled requests with a timeout FhirError", async () => {
+    server.use(
+      http.get(`${BASE}/Patient/slow-timeout`, async () => {
+        await new Promise((r) => setTimeout(r, 50));
+        return HttpResponse.json(mkPatient({ id: "slow-timeout" }));
+      }),
+    );
+    const client = new FetchFhirClient({ baseUrl: BASE, requestTimeoutMs: 5 });
+    await expect(client.read("Patient", "slow-timeout")).rejects.toMatchObject({
+      name: "FhirError",
+      status: 408,
+    });
+  });
   it("uses a custom fetch implementation when supplied", async () => {
     const customFetch = vi.fn(async () =>
       new Response(JSON.stringify(mkPatient({ id: "fake" })), {

--- a/packages/react-fhir/src/client/FetchFhirClient.ts
+++ b/packages/react-fhir/src/client/FetchFhirClient.ts
@@ -26,6 +26,8 @@ export interface FetchFhirClientOptions {
   headers?: Record<string, string>;
   /** Async header producer, called per request. Overrides `headers` on collision. */
   getHeaders?: () => Promise<Record<string, string>> | Record<string, string>;
+  /** Fails requests that stall beyond this duration (ms). Defaults to 15s. */
+  requestTimeoutMs?: number;
 }
 
 const trimSlash = (s: string): string => s.replace(/\/+$/, "");
@@ -37,6 +39,7 @@ export class FetchFhirClient implements FhirClient {
   private readonly fetchImpl: typeof fetch;
   private readonly staticHeaders: Record<string, string>;
   private readonly getHeaders: FetchFhirClientOptions["getHeaders"];
+  private readonly requestTimeoutMs: number;
 
   constructor(opts: FetchFhirClientOptions) {
     this.baseUrl = trimSlash(opts.baseUrl);
@@ -44,6 +47,7 @@ export class FetchFhirClient implements FhirClient {
     this.fetchImpl = opts.fetch ?? globalThis.fetch.bind(globalThis);
     this.staticHeaders = opts.headers ?? {};
     this.getHeaders = opts.getHeaders;
+    this.requestTimeoutMs = Math.max(1, opts.requestTimeoutMs ?? 15_000);
   }
 
   capabilities(options?: RequestOptions): Promise<CapabilityStatement> {
@@ -207,13 +211,33 @@ export class FetchFhirClient implements FhirClient {
       body = JSON.stringify(init.body);
     }
 
-    const response = await this.fetchImpl(url, {
-      method: init.method ?? "GET",
-      headers,
-      body,
-      signal: init.signal,
-      cache: init.cache,
-    });
+    const timeoutController = new AbortController();
+    const timeoutId = setTimeout(() => timeoutController.abort(), this.requestTimeoutMs);
+    const signal = init.signal
+      ? AbortSignal.any([init.signal, timeoutController.signal])
+      : timeoutController.signal;
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        method: init.method ?? "GET",
+        headers,
+        body,
+        signal,
+        cache: init.cache,
+      });
+    } catch (err) {
+      const timedOut = timeoutController.signal.aborted && !init.signal?.aborted;
+      if (timedOut) {
+        throw new FhirError(
+          `FHIR ${init.method ?? "GET"} ${url} timed out after ${this.requestTimeoutMs}ms`,
+          { status: 408, url },
+        );
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     if (!response.ok) {
       let outcome: OperationOutcome | undefined;


### PR DESCRIPTION
### Motivation
- Upstream FHIR reads could stall indefinitely and leave the Patient detail route stuck in a perpetual loading state instead of surfacing an error.

### Description
- Add an optional `requestTimeoutMs` option to `FetchFhirClient` with a default of `15000ms` and use it to abort stalled requests inside `request`.
- Merge any caller-provided `AbortSignal` with an internal timeout signal via `AbortSignal.any` so explicit cancellation still works.
- Convert timeout-aborted requests into a `FhirError` with `status: 408` and a clear diagnostics message so the UI can render an error instead of an infinite spinner.
- Add a unit test in `packages/react-fhir/src/client/FetchFhirClient.test.ts` that verifies stalled reads fail fast with a deterministic timeout `FhirError`.

### Testing
- Ran `pnpm test:run src/client/FetchFhirClient.test.ts` from `packages/react-fhir` and the targeted suite passed (17 tests).
- Ran `pnpm vitest run` in `apps/demo` and the demo tests passed (15 tests).
- An earlier workspace-wide test invocation produced unrelated failures when run from the repo root, so package-local test commands were used to validate this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d02d1fac8333b8cc026e6f27f642)