### PR TITLE
fix(react-fhir): forward profile to token search and infer base type from core canonical

### DIFF
--- a/packages/react-fhir/src/components/ResourceSearch.tsx
+++ b/packages/react-fhir/src/components/ResourceSearch.tsx
@@ -218,10 +218,10 @@ const fieldWrapper = (
   );
 };
 
-function SearchField({ base, param, value, onChange }: SearchFieldProps): ReactNode {
+function SearchField({ base, param, value, onChange, profile }: SearchFieldProps): ReactNode {
   if (param.type === "token") {
     return (
-      <TokenSearchField base={base} param={param} value={value} onChange={onChange} />
+      <TokenSearchField base={base} param={param} value={value} onChange={onChange} profile={profile} />
     );
   }
   if (param.type === "date") {

--- a/packages/react-fhir/src/hooks/queries.test.tsx
+++ b/packages/react-fhir/src/hooks/queries.test.tsx
@@ -125,6 +125,26 @@ describe("query hooks", () => {
 
 
 
+  it("useStructureDefinition treats a core canonical the same as a bare type (bundled fallback applies)", async () => {
+    // Both server endpoints miss; success here means the bundled core Patient SD
+    // was returned, which only happens when the resolver recognises the canonical
+    // as the base Patient type.
+    server.use(
+      http.get(`${BASE}/StructureDefinition/Patient`, () => new HttpResponse(null, { status: 404 })),
+      http.get(`${BASE}/StructureDefinition`, () =>
+        HttpResponse.json({ resourceType: "Bundle", type: "searchset", entry: [] }),
+      ),
+    );
+    const { wrapper } = mkWrapper();
+    const { result } = renderHook(
+      () => useStructureDefinition("http://hl7.org/fhir/StructureDefinition/Patient"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.type).toBe("Patient");
+    expect(result.current.data?.snapshot?.element.some((e) => e.path === "Patient.name")).toBe(true);
+  });
+
   it("useStructureDefinition accepts canonical profile URLs", async () => {
     const profile = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient";
     server.use(

--- a/packages/react-fhir/src/hooks/queries.ts
+++ b/packages/react-fhir/src/hooks/queries.ts
@@ -116,17 +116,37 @@ export function useInfiniteSearch<T extends Resource = Resource>(
 
 export type StructureDefinitionInput = string | { type: string; profile?: string | null };
 
+const FHIR_CORE_SD_BASE = "http://hl7.org/fhir/StructureDefinition/";
+
+function parseStructureDefinitionInput(
+  input: StructureDefinitionInput,
+): { type: string; profile: string | null | undefined } {
+  if (typeof input !== "string") {
+    return { type: input.type || "Resource", profile: input.profile };
+  }
+  if (!input.includes("://")) {
+    return { type: input, profile: undefined };
+  }
+  // Canonical URL. If it points at a core R4 StructureDefinition, treat it as
+  // a base type so the resolver's bundled-core fallback stays reachable.
+  if (input.startsWith(FHIR_CORE_SD_BASE)) {
+    const tail = input.slice(FHIR_CORE_SD_BASE.length);
+    if (tail && !tail.includes("/")) {
+      return { type: tail, profile: undefined };
+    }
+  }
+  return { type: "Resource", profile: input };
+}
+
 export function useStructureDefinition(
   input: StructureDefinitionInput,
   options?: ReadQueryOpts<StructureDefinition>,
 ) {
   const client = useFhirClient();
-  const type = typeof input === "string" && input.includes("http") ? "" : (typeof input === "string" ? input : input.type);
-  const profile = typeof input === "string" && input.includes("http") ? input : (typeof input === "string" ? undefined : input.profile);
-  const normalizedType = type || "Resource";
+  const { type, profile } = parseStructureDefinitionInput(input);
   return useQuery({
-    queryKey: fhirQueryKeys.structure(client.baseUrl, normalizedType, profile),
-    queryFn: ({ signal }) => resolveStructureDefinition(client, normalizedType, { signal, profile }),
+    queryKey: fhirQueryKeys.structure(client.baseUrl, type, profile),
+    queryFn: ({ signal }) => resolveStructureDefinition(client, type, { signal, profile }),
     staleTime: 60 * 60_000,
     ...options,
   });


### PR DESCRIPTION
## Summary

Address Codex review comments from PR #94 (which was merged before the fixes landed):

- **P1 — `ResourceSearch.tsx`**: `SearchField` was dropping the `profile` prop. Destructure and forward it to `TokenSearchField` so token-field StructureDefinition lookups actually receive the caller-supplied profile.
- **P2 — `queries.ts` (`useStructureDefinition`)**: Replace the brittle `input.includes("http")` heuristic with `parseStructureDefinitionInput`. A canonical pointing at `http://hl7.org/fhir/StructureDefinition/{Type}` now resolves with `type={Type}` (no profile), restoring parity with the bare-type form so the bundled-core fallback still applies. Non-core canonicals continue to resolve as profiled lookups.

Adds a regression test in `queries.test.tsx` that locks in core-canonical → bundled-fallback equivalence.

## Test plan

- [x] `pnpm test:run src/structure/resolve.test.ts src/hooks/queries.test.tsx src/components/ResourceEditor.test.tsx src/components/ResourceSearch.test.tsx` — 58/58 passing
- [x] `pnpm typecheck` — clean

https://claude.ai/code/session_01XoWVSgvedy9JJZJkRHx5yd

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoWVSgvedy9JJZJkRHx5yd)_