### PR TITLE
fix(demo): unstall Patient detail page on missing/erroring resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,30 @@ jobs:
       - run: pnpm -r test:run
       - run: pnpm --filter @fhir-place/demo build
       - run: pnpm --filter @fhir-place/workbench build
+
+  e2e:
+    runs-on: ubuntu-latest
+    # PR-time end-to-end coverage against the demo (MSW-backed). Catches UI
+    # regressions like the patient-detail page stalling on Loading… that
+    # the unit suites can't see. Live HAPI is monitored separately by
+    # `live-site-monitor.yml` once a deploy is out.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @fhir-place/react-fhir build
+      - name: Install Playwright browsers
+        run: pnpm --filter @fhir-place/demo exec playwright install --with-deps chromium
+      - name: Run Playwright (chromium project)
+        run: pnpm --filter @fhir-place/demo exec playwright test --project=chromium
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/demo/playwright-report
+          if-no-files-found: ignore

--- a/apps/demo/e2e/missing-resource.spec.ts
+++ b/apps/demo/e2e/missing-resource.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Regression for the deployed Patient detail page hanging on "Loading…"
+ * when the requested ID had been deleted upstream (or never existed).
+ * The page must surface a not-found state — not stall behind a spinner —
+ * and a `retry: 1` policy on 4xx errors must not delay the resolution.
+ */
+test.describe("Missing resource detail page", () => {
+  test("Patient/<unknown id> shows a Not Found state, not a stuck spinner", async ({
+    page,
+  }) => {
+    await page.goto("/Patient/this-id-does-not-exist");
+
+    await expect(page.getByTestId("resource-not-found")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId("resource-loading")).toHaveCount(0);
+    await expect(
+      page.getByTestId("resource-not-found").getByRole("link", { name: /all patients/i }),
+    ).toBeVisible();
+  });
+
+  test("transient 5xx surfaces an error with a Retry button", async ({ page }) => {
+    let attempts = 0;
+    await page.route(/\/Patient\/p-flaky$/, async (route) => {
+      if (route.request().method() !== "GET") return route.continue();
+      attempts += 1;
+      await route.fulfill({
+        status: 503,
+        contentType: "application/fhir+json",
+        body: JSON.stringify({
+          resourceType: "OperationOutcome",
+          issue: [{ severity: "error", code: "transient", diagnostics: "upstream down" }],
+        }),
+      });
+    });
+
+    await page.goto("/Patient/p-flaky");
+    await expect(page.getByTestId("resource-error")).toBeVisible({ timeout: 10_000 });
+    // 503 is retryable, so we expect at least the initial + one retry.
+    expect(attempts).toBeGreaterThanOrEqual(2);
+    await expect(
+      page.getByTestId("resource-error").getByRole("button", { name: /retry/i }),
+    ).toBeVisible();
+  });
+});

--- a/apps/demo/src/main.tsx
+++ b/apps/demo/src/main.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { FetchFhirClient, FhirClientProvider } from "@fhir-place/react-fhir";
+import { FetchFhirClient, FhirClientProvider, FhirError } from "@fhir-place/react-fhir";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, HashRouter } from "react-router-dom";
@@ -7,9 +7,25 @@ import { App } from "./App.js";
 import { FHIR_BASE_URL, ROUTER_BASENAME, USE_HASH_ROUTER, USE_MOCK } from "./config.js";
 import "./index.css";
 
+// 4xx responses (404, 410, 422…) aren't transient — retrying them just pads
+// perceived load time before the user sees the real error. Keep a single
+// retry for 408 (timeout) and 5xx so flaky network/HAPI hiccups self-heal.
+const shouldRetry = (failureCount: number, error: unknown): boolean => {
+  if (failureCount >= 1) return false;
+  if (
+    error instanceof FhirError &&
+    error.status >= 400 &&
+    error.status < 500 &&
+    error.status !== 408
+  ) {
+    return false;
+  }
+  return true;
+};
+
 const queryClient = new QueryClient({
   defaultOptions: {
-    queries: { staleTime: 30_000, retry: 1 },
+    queries: { staleTime: 30_000, retry: shouldRetry },
   },
 });
 

--- a/apps/demo/src/pages/ResourceDetailPage.tsx
+++ b/apps/demo/src/pages/ResourceDetailPage.tsx
@@ -1,4 +1,5 @@
 import {
+  FhirError,
   ResourceView,
   useDeleteResource,
   useResource,
@@ -13,7 +14,9 @@ import { PATIENT_COMPARTMENT } from "../compartment.js";
 export function ResourceDetailPage() {
   const { resourceType = "", id = "" } = useParams();
   const navigate = useNavigate();
-  const { data, isLoading, isError, error } = useResource<Resource>(resourceType, id);
+  const { data, isLoading, isError, error, refetch } = useResource<Resource>(resourceType, id);
+  const notFound =
+    error instanceof FhirError && (error.status === 404 || error.status === 410);
   const del = useDeleteResource();
   const [confirmingDelete, setConfirmingDelete] = useState(false);
 
@@ -101,11 +104,43 @@ export function ResourceDetailPage() {
         </div>
       )}
 
-      {isLoading && <p className="text-sm text-slate-500">Loading…</p>}
-      {isError && (
-        <p className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
-          {(error as Error)?.message}
+      {isLoading && (
+        <p className="text-sm text-slate-500" data-testid="resource-loading">
+          Loading {resourceType}/{id}…
         </p>
+      )}
+      {isError && notFound && (
+        <div
+          data-testid="resource-not-found"
+          className="rounded border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900"
+        >
+          <p className="font-medium">{resourceType} not found</p>
+          <p className="mt-1 text-amber-800">
+            {resourceType}/{id} doesn't exist on this server, or it was deleted. It
+            may also be cached in a stale link.
+          </p>
+          <Link
+            to={`/${resourceType}`}
+            className="mt-2 inline-block text-amber-900 underline"
+          >
+            ← Back to all {resourceType.toLowerCase()}s
+          </Link>
+        </div>
+      )}
+      {isError && !notFound && (
+        <div
+          data-testid="resource-error"
+          className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+        >
+          <p>{(error as Error)?.message ?? `Failed to load ${resourceType}/${id}.`}</p>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="mt-2 rounded border border-red-300 bg-white px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-100"
+          >
+            Retry
+          </button>
+        </div>
       )}
       {data && (
         <ResourceView

--- a/apps/demo/src/pages/ResourceIndexPage.tsx
+++ b/apps/demo/src/pages/ResourceIndexPage.tsx
@@ -80,10 +80,16 @@ export function ResourceIndexPage() {
     isFetchingNextPage,
   } = useInfiniteSearch<Resource>(resourceType, params);
 
-  const resources =
-    data?.pages.flatMap(
-      (b) => b.entry?.flatMap((e) => (e.resource ? [e.resource] : [])) ?? [],
-    ) ?? [];
+  // Memoised so it has a stable reference between renders — downstream
+  // useMemos/useEffects key off `resources` and a fresh array each render
+  // would feed a re-render loop through the column-picker effect.
+  const resources = useMemo(
+    () =>
+      data?.pages.flatMap(
+        (b) => b.entry?.flatMap((e) => (e.resource ? [e.resource] : [])) ?? [],
+      ) ?? [],
+    [data?.pages],
+  );
   const totalAdvertised = data?.pages[0]?.total;
 
   const columnConfig = PATIENT_COMPARTMENT.find(
@@ -120,8 +126,19 @@ export function ResourceIndexPage() {
     setColumns((current) => {
       const available = new Set(allColumnOptions.map((option) => option.path));
       const kept = current.filter((path) => available.has(path));
-      if (kept.length > 0) return kept;
-      return defaultColumns.filter((path) => available.has(path));
+      const next = kept.length > 0
+        ? kept
+        : defaultColumns.filter((path) => available.has(path));
+      // Bail out when nothing changed — otherwise React schedules a re-render
+      // every effect tick and we feed the next allColumnOptions memo into the
+      // same effect again.
+      if (
+        next.length === current.length &&
+        next.every((path, i) => path === current[i])
+      ) {
+        return current;
+      }
+      return next;
     });
   }, [allColumnOptions, defaultColumns]);
 


### PR DESCRIPTION
The deployed `#/Patient/<id>` route stalled on a forever "Loading…" when
the upstream read failed: React Query's blanket `retry: 1` re-issued
404s, the page had no error UI tuned for missing resources, and a
re-render loop in `ResourceIndexPage` (added with the SD-derived default
columns) compounded the problem.

- Skip retry for non-408 4xx FhirErrors so 404/410 surface immediately.
- Render a Not Found panel for 404/410 and a Retry button for other errors.
- Memoise `resources` and short-circuit the column-picker effect so a
  stable result no longer schedules a fresh setState every render.
- Pin a Playwright spec covering the unknown-id and 503-with-retry flows
  and run the chromium e2e project on every PR (the live-site monitor
  only catches regressions post-deploy).

https://claude.ai/code/session_01B4VAB1qnVpaSBxTdWN2gJ2