### PR TITLE
docs(workbench): require manual-QA checklist and screenshots evidence path

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,17 @@ Closes #
 ## Test results
 -
 
+## Acceptance / manual QA
+- [ ] Acceptance criteria updated (if applicable)
+- [ ] `manual-qa` label added when any acceptance item is not fully automated
+- [ ] Linked/created manual QA issue(s):
+
+## TASKS.md update
+- [ ] Updated `apps/workbench/TASKS.md` for backlog/done status
+
 ## Screenshots / recordings
-Optional
+Required for UI/UX changes. Add links to assets committed in `apps/workbench/docs/screenshots/` or externally hosted recordings.
+-
 
 ## Risks
 -

--- a/apps/workbench/docs/screenshots/README.md
+++ b/apps/workbench/docs/screenshots/README.md
@@ -1,0 +1,11 @@
+# Screenshots for Acceptance
+
+Store PR screenshots or short recordings for workbench acceptance/manual QA in this folder.
+
+Suggested naming:
+- `pr-<number>-<feature>-<step>.png`
+- `pr-<number>-<feature>-<step>.gif`
+
+When used, link these files in:
+- PR body `## Screenshots / recordings`
+- `apps/workbench/TASKS.md` task notes when manual QA evidence is relevant.


### PR DESCRIPTION
Adds acceptance/manual-QA and TASKS.md checklist sections to the PR
template, makes the screenshots/recordings section required for UI/UX
changes, and creates apps/workbench/docs/screenshots/ with a README
documenting naming and where to link the artifacts. No CI or workflow
changes.

https://claude.ai/code/session_01PhBmYo7Le6R6XNy6PJQceA