### PR TITLE
Support WORKBENCH_AGENT_* env vars and gateway usage; update docs and hints

### DIFF
--- a/apps/workbench/README.md
+++ b/apps/workbench/README.md
@@ -72,6 +72,67 @@ WORKBENCH_PORT=6000 pnpm --filter @fhir-place/workbench dev
 The SQLite file defaults to `apps/workbench/workbench.sqlite`; override with
 `WORKBENCH_DB_URL=/some/path.sqlite`.
 
+### Agent provider configuration
+
+By default, the patient-summary agent reads `ANTHROPIC_API_KEY`.
+
+- `WORKBENCH_AGENT_API_KEY` overrides `ANTHROPIC_API_KEY`.
+- `WORKBENCH_AGENT_MODEL` overrides the default `claude-sonnet-4-6`.
+- `WORKBENCH_AGENT_BASE_URL` lets you point the Anthropic SDK at a compatible
+  gateway endpoint.
+
+If you want to run via AWS Bedrock, run the workbench against a Bedrock-aware
+gateway that exposes the Anthropic Messages API shape, then set
+`WORKBENCH_AGENT_BASE_URL` + `WORKBENCH_AGENT_API_KEY` for that gateway.
+
+#### Does Bedrock make sense for this workbench?
+
+It can, depending on your deployment constraints.
+
+Use Bedrock when you need one or more of:
+
+- AWS-native networking and identity boundaries (for example, private VPC
+  routing and IAM-based access to your gateway).
+- Centralized model routing/governance shared with other internal AWS workloads.
+- A single provider control plane for demos that must stay inside an AWS
+  account boundary.
+
+Keep Anthropic direct when you want the simplest local setup with the fewest
+moving parts.
+
+#### How this works in practice
+
+The workbench server still calls the Anthropic Messages API contract expected
+by the current Phase A orchestrator. In a Bedrock deployment, you place a small
+gateway in front of Bedrock that:
+
+1. Accepts Anthropic-compatible requests from the workbench.
+2. Authenticates and signs outbound Bedrock calls with AWS credentials.
+3. Maps Bedrock responses back into Anthropic-compatible response shapes.
+
+Because this translation happens at the gateway edge, the workbench app and
+agent loop do not need Bedrock-specific code paths.
+
+#### Example use case
+
+Your team runs internal synthetic-data demos in an AWS sandbox account and
+already has a platform gateway that standardizes model access. The workbench
+uses that gateway endpoint so demo traffic follows existing AWS guardrails and
+logging pipelines.
+
+#### Example `.env` values (gateway pattern)
+
+```bash
+# Anthropic-compatible gateway endpoint (backed by Bedrock internally)
+WORKBENCH_AGENT_BASE_URL=https://llm-gateway.internal.example.com/anthropic
+
+# Gateway-issued key/token (not an Anthropic key in this pattern)
+WORKBENCH_AGENT_API_KEY=demo_gateway_token
+
+# Optional model override used by the workbench agent
+WORKBENCH_AGENT_MODEL=claude-sonnet-4-6
+```
+
 ## Scripts
 
 | Script | What it does |

--- a/apps/workbench/server/agent/model-config.ts
+++ b/apps/workbench/server/agent/model-config.ts
@@ -36,10 +36,12 @@ export interface ModelConfig {
  * stays usable without an API key (patient search, FHIR proxy, etc.).
  */
 export function modelConfigFromEnv(): ModelConfig | null {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const apiKey =
+    process.env.WORKBENCH_AGENT_API_KEY ?? process.env.ANTHROPIC_API_KEY;
   if (!apiKey) return null;
   const model = process.env.WORKBENCH_AGENT_MODEL ?? DEFAULT_MODEL;
-  const client = new Anthropic({ apiKey });
+  const baseURL = process.env.WORKBENCH_AGENT_BASE_URL;
+  const client = new Anthropic({ apiKey, baseURL });
   return {
     provider: PHASE_A_PROVIDER,
     model,

--- a/apps/workbench/server/routes/answers.test.ts
+++ b/apps/workbench/server/routes/answers.test.ts
@@ -130,7 +130,7 @@ const HAPPY_PATH_SCRIPT: ReadonlyArray<Anthropic.Message> = [
   ),
 ];
 
-describe("POST /api/sessions/:sid/answer — without ANTHROPIC_API_KEY", () => {
+describe("POST /api/sessions/:sid/answer — without agent api key", () => {
   it("returns 503 with hint when no model is configured", async () => {
     const { app } = newApp({ modelConfig: null });
     const cid = await createConn(app);
@@ -144,7 +144,7 @@ describe("POST /api/sessions/:sid/answer — without ANTHROPIC_API_KEY", () => {
     expect(res.status).toBe(503);
     const body = await res.json();
     expect(body.error).toBe("agent_unavailable");
-    expect(body.hint).toMatch(/ANTHROPIC_API_KEY/);
+    expect(body.hint).toMatch(/ANTHROPIC_API_KEY|WORKBENCH_AGENT_API_KEY/);
   });
 });
 

--- a/apps/workbench/server/routes/answers.ts
+++ b/apps/workbench/server/routes/answers.ts
@@ -54,10 +54,10 @@ export function answersRoutes(deps: Deps) {
       return jsonBody(503, {
         error: "agent_unavailable",
         hint:
-          "ANTHROPIC_API_KEY is not configured. Set it in the workbench " +
-          "server's environment to enable the patient-summary agent. The " +
-          "rest of the workbench (patient search, FHIR proxy, tool runner) " +
-          "remains usable without it.",
+          "Set ANTHROPIC_API_KEY (or WORKBENCH_AGENT_API_KEY) in the " +
+          "workbench server environment to enable the patient-summary " +
+          "agent. The rest of the workbench (patient search, FHIR proxy, " +
+          "tool runner) remains usable without it.",
       });
     }
 
@@ -215,7 +215,7 @@ export function agentInfoRoutes(deps: Pick<Deps, "modelConfig">) {
       suggestedPrompts: SUGGESTED_PROMPTS,
       hint:
         deps.modelConfig === null
-          ? "Set ANTHROPIC_API_KEY in the server's environment to enable the agent."
+          ? "Set ANTHROPIC_API_KEY (or WORKBENCH_AGENT_API_KEY) in the server environment to enable the agent."
           : null,
     }),
   );


### PR DESCRIPTION
### Motivation

- Make the patient-summary agent configurable so the workbench can run against an Anthropic-compatible gateway (for example, an AWS Bedrock gateway) or use an alternate API key/model without changing code. 
- Improve error/status messaging and tests so they reflect the additional `WORKBENCH_AGENT_API_KEY` option and the new runtime knobs.

### Description

- Added an "Agent provider configuration" section to `apps/workbench/README.md` documenting `WORKBENCH_AGENT_API_KEY`, `WORKBENCH_AGENT_MODEL`, and `WORKBENCH_AGENT_BASE_URL`, and describing a Bedrock gateway deployment pattern and example `.env` values. 
- Updated `apps/workbench/server/agent/model-config.ts` to read `WORKBENCH_AGENT_API_KEY ?? ANTHROPIC_API_KEY`, `WORKBENCH_AGENT_MODEL ?? DEFAULT_MODEL`, and to pass `baseURL` from `WORKBENCH_AGENT_BASE_URL` to the Anthropic client. 
- Updated the agent availability error and status hint text in `apps/workbench/server/routes/answers.ts` to mention `WORKBENCH_AGENT_API_KEY` alongside `ANTHROPIC_API_KEY`. 
- Adjusted `apps/workbench/server/routes/answers.test.ts` to reflect the new wording and to assert the hint may mention either `ANTHROPIC_API_KEY` or `WORKBENCH_AGENT_API_KEY`.

### Testing

- Ran the workbench test suite with `pnpm --filter @fhir-place/workbench test` (Vitest) which includes `apps/workbench/server/routes/answers.test.ts`, and the tests passed. 
- Verified the agent status endpoint returns `ready: false` with the updated hint string when no model API key is configured (covered by the updated unit test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ae0ea088833382bcb65dcd9a7197)