### PR TITLE
docs(react-fhir): add implementation PR plan and strategy-to-issue templates

### DIFF
--- a/packages/react-fhir/docs/implementation-prs-2026-05.md
+++ b/packages/react-fhir/docs/implementation-prs-2026-05.md
@@ -1,0 +1,169 @@
+# `@fhir-place/react-fhir` — Implementation PR Plan (Fresh Pass)
+
+_Date: May 1, 2026_
+
+This plan is a fresh, implementation-first pass for **`packages/react-fhir` + `apps/demo` only**.
+
+It incorporates prior review direction:
+
+- no workbench roadmap coupling,
+- no vague strategy-only text,
+- concrete PR slices with acceptance criteria and test expectations.
+
+## Working positioning (for README + demo)
+
+`@fhir-place/react-fhir` is an **easy React library for building product experiences on top of any FHIR backend**.
+
+Primary wedge:
+
+1. Headless/backend-agnostic React-FHIR primitives.
+2. Strong developer ergonomics for typed FHIR reads/search/rendering.
+3. Clear escape hatches (raw client + raw resource access).
+
+---
+
+## PR 1 — Package identity + docs tightening
+
+### Why
+Current value is real, but package narrative is underspecified for first-time evaluators.
+
+### Scope
+- Update `packages/react-fhir/README.md` intro and section order:
+  - explicit positioning sentence,
+  - “who this is for / not for”,
+  - backend-agnostic statement,
+  - pre-1.0 expectations.
+- Add `packages/react-fhir/docs/positioning.md` with:
+  - competitive scope boundaries,
+  - non-goals (not a hosted backend; not an EHR replacement).
+- Update `apps/demo/src/App.tsx` header subtitle to mirror the wedge language.
+
+### Acceptance criteria
+- A new developer can answer in <60s: “What is this library and when should I use it?”
+- README and demo headline are aligned.
+
+### Test/check plan
+- `pnpm --filter @fhir-place/react-fhir typecheck`
+- `pnpm --filter @fhir-place/demo typecheck`
+
+---
+
+## PR 2 — Competitive matrix with evidence links
+
+### Why
+Claims need credibility artifacts tied to real code/examples.
+
+### Scope
+- Add `packages/react-fhir/docs/competitive-matrix.md` with columns:
+  - Client transport,
+  - React hooks,
+  - component strategy,
+  - backend lock-in profile,
+  - typed search ergonomics,
+  - escape hatches.
+- Include “Where we are currently weaker” section.
+- For each “supported” claim, link to package source/test/demo page.
+
+### Acceptance criteria
+- Every non-trivial claim has a repo link.
+- Matrix is neutral (includes tradeoffs, not only wins).
+
+### Test/check plan
+- docs-only + link spot-check using local preview/read.
+
+---
+
+## PR 3 — Typed search DX slice (technical hook)
+
+### Why
+Typed search ergonomics is the most defensible implementation wedge.
+
+### Scope
+- Add a constrained typed search builder on top of existing search params:
+  - initial support: token/string/date basics,
+  - include/revinclude typed options for selected resource types,
+  - no breaking API changes to existing `search` path.
+- Add dedicated tests for:
+  - serialization correctness,
+  - include/revinclude behavior,
+  - type-level usage examples.
+- Add demo usage section/page showing practical autocomplete benefit.
+
+### Acceptance criteria
+- Existing search tests keep passing.
+- New typed builder can produce identical URLs for supported cases.
+- Demo includes at least one concrete before/after DX snippet.
+
+### Test/check plan
+- `pnpm --filter @fhir-place/react-fhir test:run`
+- `pnpm --filter @fhir-place/react-fhir typecheck`
+- `pnpm --filter @fhir-place/demo test:run`
+
+---
+
+## PR 4 — Interop demo matrix (backend-agnostic proof)
+
+### Why
+“Backend-agnostic” must be demonstrable, not asserted.
+
+### Scope
+- Add `apps/demo/docs/interop-matrix.md`:
+  - backend targets (at least 2),
+  - setup steps,
+  - expected behavior per page/feature,
+  - known caveats.
+- Add scripts or env presets to reduce setup friction.
+- Add one smoke e2e profile per target where feasible.
+
+### Acceptance criteria
+- Another engineer can run at least two backends from docs.
+- Caveats are explicit and reproducible.
+
+### Test/check plan
+- `pnpm --filter @fhir-place/demo test:run`
+- `pnpm --filter @fhir-place/demo e2e -- --grep smoke` (or equivalent targeted smoke run)
+
+---
+
+## PR 5 — Release readiness for external adoption
+
+### Why
+Pre-1.0 projects need explicit upgrade and stability expectations.
+
+### Scope
+- Add `packages/react-fhir/CHANGELOG.md` discipline section (or initialize changelog if absent).
+- Add `packages/react-fhir/docs/recipes.md` for common flows:
+  - patient list/search,
+  - resource detail,
+  - update flow with invalidation,
+  - custom renderer override.
+- Add “Support policy” note (pre-1.0 compatibility expectations).
+
+### Acceptance criteria
+- Users can map common use-case -> recipe -> API entry point quickly.
+- Upgrade risk is clearly documented.
+
+### Test/check plan
+- `pnpm --filter @fhir-place/react-fhir build`
+- `pnpm --filter @fhir-place/react-fhir test:ci`
+
+---
+
+## Implementation order
+
+1. PR 1 (positioning clarity)
+2. PR 2 (credibility matrix)
+3. PR 3 (typed search DX)
+4. PR 4 (interop proof)
+5. PR 5 (adoption/readiness)
+
+This order prioritizes **clarity -> trust -> differentiation -> proof -> adoption**.
+
+---
+
+## Explicit non-goals in this plan
+
+- Building a hosted backend product.
+- Re-platforming to a different UI framework.
+- Adding clinical/compliance claims.
+- Coupling this roadmap to workbench Phase A constraints.

--- a/packages/react-fhir/docs/issue-templates-strategy-execution.md
+++ b/packages/react-fhir/docs/issue-templates-strategy-execution.md
@@ -1,0 +1,186 @@
+# Issue Templates: Strategy -> Implementation (`@fhir-place/react-fhir`)
+
+Use these six issues to convert strategy into implementation PRs.
+
+---
+
+## Issue 1 — Typed Search Builder v0 (core API)
+
+**Title**
+`feat(search): add typed search builder v0 for Patient/Observation`
+
+**Problem**
+Current search support works, but typed search ergonomics are not a standout differentiator.
+
+**Scope**
+- Add `createSearchBuilder` (or equivalent) in `packages/react-fhir/src/client/`.
+- Support initial operators for `string`, `token`, `date`.
+- Support `_include` and `_revinclude` for an initial allowlist:
+  - `Observation:subject`
+  - `Patient:general-practitioner`
+- Keep existing `search(resourceType, params)` API intact.
+
+**Out of scope**
+- Full coverage for all resource types/search params.
+- Breaking changes to existing search API.
+
+**Acceptance criteria**
+- Builder emits identical query strings for supported cases vs existing serializer.
+- Existing search tests pass unchanged.
+- New tests cover operator serialization + include/revinclude.
+
+**Test plan**
+- `pnpm --filter @fhir-place/react-fhir test:run`
+- `pnpm --filter @fhir-place/react-fhir typecheck`
+
+---
+
+## Issue 2 — Typed Search Builder v0.1 (hook + demo usage)
+
+**Title**
+`feat(hooks/demo): expose typed search builder via hooks and demo example`
+
+**Problem**
+The builder must be visible in real React usage to prove DX value.
+
+**Scope**
+- Add hook integration path in `packages/react-fhir/src/hooks/queries.ts`.
+- Add demo usage example in `apps/demo` (new page or section in Patient index).
+- Show at least one chained include example.
+
+**Out of scope**
+- Advanced query planner and auto-optimization.
+
+**Acceptance criteria**
+- Demo compiles and runs with typed builder example.
+- Example shows autocomplete/narrowing in code sample.
+- Query output remains backward compatible.
+
+**Test plan**
+- `pnpm --filter @fhir-place/react-fhir test:run`
+- `pnpm --filter @fhir-place/demo test:run`
+- `pnpm --filter @fhir-place/demo typecheck`
+
+---
+
+## Issue 3 — Profile-aware codegen spike (US Core seed)
+
+**Title**
+`spike(codegen): profile-aware type narrowing from StructureDefinition (US Core seed)`
+
+**Problem**
+Generic FHIR typings are broad; profile-aware narrowing is needed for stronger DX.
+
+**Scope**
+- Add a spike in `packages/react-fhir/src/structure/` utilities for profile-derived narrowing.
+- Start with one profile family (US Core Patient/Observation seed).
+- Produce generated artifacts in a clearly marked experimental location.
+
+**Out of scope**
+- Full IG pipeline and full profile coverage.
+- API stability guarantees for generated artifacts.
+
+**Acceptance criteria**
+- Spike can generate at least one profile-specific type artifact.
+- Include docs that explain limitations and next expansion step.
+
+**Test plan**
+- `pnpm --filter @fhir-place/react-fhir typecheck`
+- `pnpm --filter @fhir-place/react-fhir test:run`
+
+---
+
+## Issue 4 — Zod schema generation from StructureDefinition (experimental)
+
+**Title**
+`feat(validation): experimental zod schema generation from StructureDefinition`
+
+**Problem**
+Structured-output and validation ergonomics are strategic, but need concrete package primitives.
+
+**Scope**
+- Add optional generator/util to create Zod schemas from a limited subset of `StructureDefinition`.
+- Start with a small target set (e.g., Patient + Observation core fields).
+- Expose as experimental API (clearly documented).
+
+**Out of scope**
+- Complete parity with all FHIR constraints/invariants.
+- Runtime validator replacement for server-side conformance tools.
+
+**Acceptance criteria**
+- Generated schema validates happy-path fixtures for target resources.
+- Known unsupported constraints are documented.
+
+**Test plan**
+- `pnpm --filter @fhir-place/react-fhir test:run`
+- `pnpm --filter @fhir-place/react-fhir typecheck`
+
+---
+
+## Issue 5 — Interop demo matrix (2+ backends)
+
+**Title**
+`docs/demo: add reproducible interop matrix for 2+ FHIR backends`
+
+**Problem**
+“Backend-agnostic” needs reproducible proof.
+
+**Scope**
+- Add `apps/demo/docs/interop-matrix.md`.
+- Cover at least two targets (for example: HAPI + Medplum/Aidbox sandbox).
+- Document setup, env vars, expected behavior by page, known differences.
+- Add/update one smoke e2e path per target where feasible.
+
+**Out of scope**
+- Full certification/conformance claims.
+
+**Acceptance criteria**
+- Another engineer can reproduce both targets using only docs.
+- Matrix explicitly calls out caveats, unsupported behaviors, and fallbacks.
+
+**Test plan**
+- `pnpm --filter @fhir-place/demo test:run`
+- `pnpm --filter @fhir-place/demo e2e -- --grep smoke`
+
+---
+
+## Issue 6 — README positioning + honest comparison + roadmap links
+
+**Title**
+`docs(readme): tighten positioning, add honest comparison table, link roadmap issues`
+
+**Problem**
+Implementation work needs a single external-facing narrative and trust surface.
+
+**Scope**
+- Update `packages/react-fhir/README.md` with:
+  - one-line wedge statement,
+  - “who this is for / not for”,
+  - comparison table vs alternatives,
+  - “where we are weaker today”,
+  - links to the five implementation issues above.
+- Update demo header copy in `apps/demo/src/App.tsx` for consistency.
+
+**Out of scope**
+- Marketing claims unsupported by code/tests.
+
+**Acceptance criteria**
+- README claims are backed by links to code, tests, or demo pages.
+- No contradictory positioning language between README and demo.
+
+**Test plan**
+- `pnpm --filter @fhir-place/react-fhir typecheck`
+- `pnpm --filter @fhir-place/demo typecheck`
+
+---
+
+## Recommended execution order
+
+1. Issue 6 (positioning + comparison anchor)
+2. Issue 1 (typed builder core)
+3. Issue 2 (typed builder in hooks/demo)
+4. Issue 5 (interop matrix proof)
+5. Issue 3 (profile-aware codegen spike)
+6. Issue 4 (zod generation experimental)
+
+This sequencing drives fast external clarity, then tangible technical differentiation.


### PR DESCRIPTION
### Motivation
- Provide an implementation-first PR plan for `packages/react-fhir` and `apps/demo` to convert strategy into concrete, reviewable PRs.
- Improve external clarity and credibility by tightening positioning, documenting a competitive matrix, and prioritizing a typed-search DX wedge plus interop proofs.
- Enable contributors to execute work quickly by supplying ready issue templates with scope, acceptance criteria, and test plans.

### Description
- Add `packages/react-fhir/docs/implementation-prs-2026-05.md` which defines five concrete PRs (positioning, competitive matrix, typed search DX, interop demo matrix, and release readiness) with scope, acceptance criteria, and test/check commands.
- Add `packages/react-fhir/docs/issue-templates-strategy-execution.md` which supplies six executable issue templates mapping strategy to implementation (typed search builder, hooks/demo integration, codegen spike, zod schema generation, interop matrix, and README positioning) with test plans.
- Include recommended execution order, explicit non-goals, and `pnpm`-based verification commands throughout the documents to guide CI and local checks.

### Testing
- No automated tests were executed for this docs-only change.
- CI or reviewers are expected to run the suggested checks such as `pnpm --filter @fhir-place/react-fhir typecheck`, `pnpm --filter @fhir-place/react-fhir test:run`, and `pnpm --filter @fhir-place/demo test:run` as part of validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49c0ba5c48333ba0aa7094c18b626)