### PR TITLE
feat(search): typed search builder v0 (#121)

### DIFF
--- a/packages/react-fhir/src/client/index.ts
+++ b/packages/react-fhir/src/client/index.ts
@@ -1,3 +1,4 @@
 export * from "./types.js";
 export * from "./searchParams.js";
+export * from "./searchBuilder.js";
 export * from "./FetchFhirClient.js";

--- a/packages/react-fhir/src/client/searchBuilder.test.ts
+++ b/packages/react-fhir/src/client/searchBuilder.test.ts
@@ -121,4 +121,27 @@ describe("searchBuilder types", () => {
 
     expect(true).toBe(true);
   });
+
+  it("scopes include/revInclude allow-lists to the searched resource", () => {
+    const obs = searchBuilder("Observation");
+
+    // include must match the searched resource as the path SOURCE.
+    obs.include("Observation:subject");
+    // @ts-expect-error 'Patient:general-practitioner' source is Patient, not Observation.
+    obs.include("Patient:general-practitioner");
+
+    // revInclude must match the searched resource as the path TARGET.
+    // Observation has no v0 revInclude entries, so any spec is rejected.
+    // @ts-expect-error Observation has no revInclude allow-list entries.
+    obs.revInclude("Observation:subject");
+    // @ts-expect-error same: cross-resource revInclude is rejected.
+    obs.revInclude("Patient:general-practitioner");
+
+    const pat = searchBuilder("Patient");
+    pat.revInclude("Observation:subject");
+    // @ts-expect-error Patient.general-practitioner targets Practitioner, not Patient.
+    pat.revInclude("Patient:general-practitioner");
+
+    expect(true).toBe(true);
+  });
 });

--- a/packages/react-fhir/src/client/searchBuilder.test.ts
+++ b/packages/react-fhir/src/client/searchBuilder.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { searchBuilder } from "./searchBuilder.js";
+import { buildSearchParams } from "./searchParams.js";
+
+describe("searchBuilder runtime", () => {
+  it("builds a path with no params", () => {
+    expect(searchBuilder("Patient").build()).toBe("Patient");
+  });
+
+  it("emits string operators", () => {
+    const url = searchBuilder("Patient").where("name", "Smith").build();
+    expect(url).toBe("Patient?name=Smith");
+  });
+
+  it("emits token operators", () => {
+    const url = searchBuilder("Patient")
+      .where("identifier", "http://hospital.example|abc")
+      .build();
+    expect(url).toBe(
+      "Patient?identifier=http%3A%2F%2Fhospital.example%7Cabc",
+    );
+  });
+
+  it("emits reference operators", () => {
+    const url = searchBuilder("Observation")
+      .where("subject", "Patient/123")
+      .build();
+    expect(url).toBe("Observation?subject=Patient%2F123");
+  });
+
+  it("emits date prefix operators in given order", () => {
+    const url = searchBuilder("Patient")
+      .where("birthdate", { ge: "1990-01-01", lt: "2000-01-01" })
+      .build();
+    expect(url).toBe(
+      "Patient?birthdate=ge1990-01-01&birthdate=lt2000-01-01",
+    );
+  });
+
+  it("ISO-formats Date values for date params", () => {
+    const url = searchBuilder("Observation")
+      .where("date", new Date("2024-01-02T03:04:05.000Z"))
+      .build();
+    expect(url).toBe("Observation?date=2024-01-02T03%3A04%3A05.000Z");
+  });
+
+  it("emits number operators", () => {
+    const url = searchBuilder("Observation")
+      .where("value-quantity", { gt: 5, le: 10 })
+      .build();
+    expect(url).toBe(
+      "Observation?value-quantity=gt5&value-quantity=le10",
+    );
+  });
+
+  it("emits _include", () => {
+    const url = searchBuilder("Patient")
+      .include("Patient:general-practitioner")
+      .build();
+    expect(url).toBe(
+      "Patient?_include=Patient%3Ageneral-practitioner",
+    );
+  });
+
+  it("emits _revinclude", () => {
+    const url = searchBuilder("Patient")
+      .revInclude("Observation:subject")
+      .build();
+    expect(url).toBe(
+      "Patient?_revinclude=Observation%3Asubject",
+    );
+  });
+
+  it("chains multiple wheres and include", () => {
+    const url = searchBuilder("Patient")
+      .where("name", "Smith")
+      .where("birthdate", { ge: "1990-01-01" })
+      .include("Patient:general-practitioner")
+      .build();
+    expect(url).toBe(
+      "Patient?name=Smith&birthdate=ge1990-01-01&_include=Patient%3Ageneral-practitioner",
+    );
+  });
+
+  it("matches the existing search serializer byte-for-byte for shared cases", () => {
+    const built = searchBuilder("Patient")
+      .where("name", "Smith")
+      .where("birthdate", "ge1990-01-01")
+      .include("Patient:general-practitioner")
+      .toQueryString();
+    const reference = buildSearchParams({
+      name: "Smith",
+      birthdate: "ge1990-01-01",
+      _include: "Patient:general-practitioner",
+    }).toString();
+    expect(built).toBe(reference);
+  });
+});
+
+describe("searchBuilder types", () => {
+  it("rejects mistyped values and unknown include specs at compile time", () => {
+    const b = searchBuilder("Patient");
+
+    // Well-typed calls compile cleanly.
+    b.where("name", "Smith");
+    b.where("birthdate", { ge: "1990-01-01" });
+    b.where("birthdate", new Date("1990-01-01"));
+    b.include("Patient:general-practitioner");
+    b.revInclude("Observation:subject");
+
+    // @ts-expect-error name is a string param; number is not assignable.
+    b.where("name", 1);
+    // @ts-expect-error 'bogus' is not a registered Patient search param.
+    b.where("bogus", "x");
+    // @ts-expect-error 'value-quantity' is not on Patient.
+    b.where("value-quantity", 5);
+    // @ts-expect-error 'Observation:bogus' is not in the include allow-list.
+    b.include("Observation:bogus");
+    // @ts-expect-error wrong shape for date range.
+    b.where("birthdate", { foo: "bar" });
+
+    expect(true).toBe(true);
+  });
+});

--- a/packages/react-fhir/src/client/searchBuilder.ts
+++ b/packages/react-fhir/src/client/searchBuilder.ts
@@ -1,0 +1,149 @@
+/**
+ * Typed search builder (v0). See issue #121 / ADR 0004.
+ *
+ * Models the FHIR search parameter types we cover initially:
+ * `string`, `token`, `date`, `reference`, `number`. Composite, quantity, uri,
+ * and special types are deferred. Resources and `_include`/`_revinclude`
+ * targets are seeded minimally; both registries are extensible via TypeScript
+ * declaration merging on `SearchParamTypes` and `IncludePaths`.
+ *
+ * Output is byte-identical to `buildSearchParams` for any case both can express.
+ */
+
+export type ParamType = "string" | "token" | "date" | "reference" | "number";
+
+export type DatePrefix =
+  | "eq"
+  | "ne"
+  | "gt"
+  | "ge"
+  | "lt"
+  | "le"
+  | "sa"
+  | "eb"
+  | "ap";
+
+export type NumberPrefix = "eq" | "ne" | "gt" | "ge" | "lt" | "le" | "ap";
+
+type DateValue = string | Date;
+type DateRange = { [P in DatePrefix]?: DateValue };
+type NumberRange = { [P in NumberPrefix]?: number };
+
+export type SearchValue<T extends ParamType> = T extends "string"
+  ? string
+  : T extends "token"
+    ? string
+    : T extends "reference"
+      ? string
+      : T extends "date"
+        ? DateValue | DateRange
+        : T extends "number"
+          ? number | NumberRange
+          : never;
+
+/**
+ * Per-resource search parameter typing. Augment via module declaration to
+ * cover additional resources or parameters without forking this file.
+ */
+export interface SearchParamTypes {
+  Patient: {
+    _id: "token";
+    _lastUpdated: "date";
+    name: "string";
+    family: "string";
+    given: "string";
+    identifier: "token";
+    gender: "token";
+    birthdate: "date";
+    active: "token";
+    "general-practitioner": "reference";
+    organization: "reference";
+  };
+  Observation: {
+    _id: "token";
+    _lastUpdated: "date";
+    code: "token";
+    date: "date";
+    subject: "reference";
+    patient: "reference";
+    encounter: "reference";
+    status: "token";
+    "value-quantity": "number";
+    "value-string": "string";
+  };
+}
+
+export type SearchableResource = keyof SearchParamTypes;
+
+/**
+ * Allow-list of `_include` / `_revinclude` paths. Seeded for v0 with the two
+ * paths called out in the issue; extend via declaration merging.
+ */
+export interface IncludePaths {
+  "Observation:subject": true;
+  "Patient:general-practitioner": true;
+}
+
+export type IncludeSpec = keyof IncludePaths;
+
+const isPlainOperatorObject = (
+  value: unknown,
+): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !(value instanceof Date);
+
+const formatScalar = (value: unknown): string => {
+  if (value instanceof Date) return value.toISOString();
+  return String(value);
+};
+
+export class SearchBuilder<R extends SearchableResource> {
+  private readonly entries: Array<[string, string]> = [];
+
+  constructor(private readonly resourceType: R) {}
+
+  where<P extends keyof SearchParamTypes[R] & string>(
+    name: P,
+    value: SearchValue<Extract<SearchParamTypes[R][P], ParamType>>,
+  ): this {
+    if (isPlainOperatorObject(value)) {
+      for (const [prefix, raw] of Object.entries(value)) {
+        if (raw === undefined || raw === null) continue;
+        this.entries.push([name, `${prefix}${formatScalar(raw)}`]);
+      }
+    } else {
+      this.entries.push([name, formatScalar(value)]);
+    }
+    return this;
+  }
+
+  include(spec: IncludeSpec): this {
+    this.entries.push(["_include", spec]);
+    return this;
+  }
+
+  revInclude(spec: IncludeSpec): this {
+    this.entries.push(["_revinclude", spec]);
+    return this;
+  }
+
+  toSearchParams(): URLSearchParams {
+    const qs = new URLSearchParams();
+    for (const [k, v] of this.entries) qs.append(k, v);
+    return qs;
+  }
+
+  toQueryString(): string {
+    return this.toSearchParams().toString();
+  }
+
+  build(): string {
+    const qs = this.toQueryString();
+    return qs ? `${this.resourceType}?${qs}` : this.resourceType;
+  }
+}
+
+export function searchBuilder<R extends SearchableResource>(
+  resourceType: R,
+): SearchBuilder<R> {
+  return new SearchBuilder(resourceType);
+}

--- a/packages/react-fhir/src/client/searchBuilder.ts
+++ b/packages/react-fhir/src/client/searchBuilder.ts
@@ -76,15 +76,40 @@ export interface SearchParamTypes {
 export type SearchableResource = keyof SearchParamTypes;
 
 /**
- * Allow-list of `_include` / `_revinclude` paths. Seeded for v0 with the two
- * paths called out in the issue; extend via declaration merging.
+ * `_include` allow-list, keyed by the resource being SEARCHED. Each value is
+ * the union of include paths whose source type is that resource.
+ *
+ * v0 seed:
+ *   Patient → "Patient:general-practitioner"
+ *   Observation → "Observation:subject"
+ *
+ * Extend via declaration merging.
  */
-export interface IncludePaths {
-  "Observation:subject": true;
-  "Patient:general-practitioner": true;
+export interface IncludePathsByResource {
+  Patient: "Patient:general-practitioner";
+  Observation: "Observation:subject";
 }
 
-export type IncludeSpec = keyof IncludePaths;
+/**
+ * `_revinclude` allow-list, keyed by the resource being SEARCHED. Each value
+ * is the union of include paths whose reference TARGET is that resource.
+ *
+ * v0 seed:
+ *   Patient → "Observation:subject"  (Observation.subject targets Patient)
+ *
+ * Extend via declaration merging.
+ */
+export interface RevIncludePathsByResource {
+  Patient: "Observation:subject";
+}
+
+export type IncludeSpec<R extends SearchableResource> =
+  R extends keyof IncludePathsByResource ? IncludePathsByResource[R] : never;
+
+export type RevIncludeSpec<R extends SearchableResource> =
+  R extends keyof RevIncludePathsByResource
+    ? RevIncludePathsByResource[R]
+    : never;
 
 const isPlainOperatorObject = (
   value: unknown,
@@ -116,12 +141,12 @@ export class SearchBuilder<R extends SearchableResource> {
     return this;
   }
 
-  include(spec: IncludeSpec): this {
+  include(spec: IncludeSpec<R>): this {
     this.entries.push(["_include", spec]);
     return this;
   }
 
-  revInclude(spec: IncludeSpec): this {
+  revInclude(spec: RevIncludeSpec<R>): this {
     this.entries.push(["_revinclude", spec]);
     return this;
   }


### PR DESCRIPTION
Adds `searchBuilder(resourceType)` in `packages/react-fhir/src/client/`
with a fluent typed API for FHIR search. v0 covers `string`, `token`,
`date`, `reference`, `number` operators (including prefix-object form
for date/number) and a typed `_include`/`_revinclude` allow-list seeded
with `Observation:subject` and `Patient:general-practitioner`.

Output is byte-identical to `buildSearchParams` for shared cases
(URLSearchParams under the hood). The resource and include registries
are extensible via TypeScript declaration merging on
`SearchParamTypes` and `IncludePaths`.