### PR TITLE
Add @fhir-place/mcp package for patient-scoped FHIR tools

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,21 @@
+# @fhir-place/mcp
+
+`@fhir-place/mcp` wraps a FHIR R4 base URL as two typed, patient-scoped, deny-by-default tools:
+
+- `patient_summary`
+- `read_resource`
+
+The package intentionally allows only a small resource allowlist and always requires `patientId`.
+
+## Quick start
+
+```ts
+import { FhirMcpClient } from "@fhir-place/mcp";
+
+const client = new FhirMcpClient("https://fhir.example.com/fhir");
+const tools = client.listTools();
+
+const summary = await client.callTool("patient_summary", {
+  patientId: "example-patient"
+});
+```

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@fhir-place/mcp",
+  "version": "0.0.0",
+  "description": "Typed MCP-style tools around a patient-scoped FHIR R4 base URL.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { FhirMcpClient } from "./index";
+
+describe("FhirMcpClient", () => {
+  it("lists the two typed tools", () => {
+    const client = new FhirMcpClient("https://example.test/fhir");
+    expect(client.listTools().map((tool) => tool.name)).toEqual(["patient_summary", "read_resource"]);
+  });
+
+  it("enforces allowlisted resources", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    const client = new FhirMcpClient("https://example.test/fhir", fetchMock);
+
+    await expect(
+      client.callTool("read_resource", {
+        patientId: "p-1",
+        resourceType: "DocumentReference"
+      })
+    ).rejects.toThrow("not allowlisted");
+  });
+
+  it("calls patient-scoped search endpoints", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({ resourceType: "Bundle", total: 1 })
+    } as Response);
+
+    const client = new FhirMcpClient("https://example.test/fhir/", fetchMock);
+    await client.callTool("read_resource", {
+      patientId: "p-1",
+      resourceType: "Observation",
+      count: 10
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.test/fhir/Observation?patient=p-1&_count=10",
+      expect.objectContaining({ headers: expect.anything() })
+    );
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,154 @@
+export type FhirToolName = "patient_summary" | "read_resource";
+
+const ALLOWED_RESOURCES = new Set([
+  "AllergyIntolerance",
+  "Condition",
+  "Encounter",
+  "Immunization",
+  "MedicationRequest",
+  "Observation",
+  "Patient",
+  "Procedure"
+]);
+
+export type FhirToolDefinition = {
+  name: FhirToolName;
+  description: string;
+  inputSchema: Record<string, unknown>;
+};
+
+export type PatientSummaryInput = {
+  patientId: string;
+  resourceTypes?: string[];
+  count?: number;
+};
+
+export type ReadResourceInput = {
+  patientId: string;
+  resourceType: string;
+  resourceId?: string;
+  count?: number;
+};
+
+const normalizeBase = (url: string): string => url.replace(/\/+$/, "");
+
+const ensureAllowedResource = (resourceType: string): void => {
+  if (!ALLOWED_RESOURCES.has(resourceType)) {
+    throw new Error(`Resource type ${resourceType} is not allowlisted.`);
+  }
+};
+
+const ensurePatientId = (patientId: string): void => {
+  if (!patientId.trim()) {
+    throw new Error("patientId is required.");
+  }
+};
+
+export class FhirMcpClient {
+  readonly baseUrl: string;
+
+  constructor(baseUrl: string, private readonly fetchImpl: typeof fetch = fetch) {
+    this.baseUrl = normalizeBase(baseUrl);
+  }
+
+  listTools(): FhirToolDefinition[] {
+    return [
+      {
+        name: "patient_summary",
+        description: "Return a patient-scoped bundle for core read-only summary resources.",
+        inputSchema: {
+          type: "object",
+          required: ["patientId"],
+          properties: {
+            patientId: { type: "string", minLength: 1 },
+            resourceTypes: { type: "array", items: { type: "string" } },
+            count: { type: "number", minimum: 1, maximum: 100 }
+          }
+        }
+      },
+      {
+        name: "read_resource",
+        description: "Return a patient-scoped allowlisted resource read/search result.",
+        inputSchema: {
+          type: "object",
+          required: ["patientId", "resourceType"],
+          properties: {
+            patientId: { type: "string", minLength: 1 },
+            resourceType: { type: "string" },
+            resourceId: { type: "string" },
+            count: { type: "number", minimum: 1, maximum: 100 }
+          }
+        }
+      }
+    ];
+  }
+
+  async callTool(name: FhirToolName, input: PatientSummaryInput | ReadResourceInput): Promise<unknown> {
+    if (name === "patient_summary") {
+      return this.patientSummary(input as PatientSummaryInput);
+    }
+
+    return this.readResource(input as ReadResourceInput);
+  }
+
+  private async patientSummary(input: PatientSummaryInput): Promise<unknown> {
+    ensurePatientId(input.patientId);
+    const limit = input.count ?? 20;
+    const resourceTypes = input.resourceTypes ?? [
+      "Patient",
+      "Condition",
+      "AllergyIntolerance",
+      "MedicationRequest",
+      "Observation"
+    ];
+
+    for (const resourceType of resourceTypes) {
+      ensureAllowedResource(resourceType);
+    }
+
+    const entries = await Promise.all(
+      resourceTypes.map(async (resourceType) => ({
+        resourceType,
+        bundle: await this.fetchJson(
+          `${this.baseUrl}/${resourceType}?patient=${encodeURIComponent(input.patientId)}&_count=${limit}`
+        )
+      }))
+    );
+
+    return {
+      patientId: input.patientId,
+      entries
+    };
+  }
+
+  private async readResource(input: ReadResourceInput): Promise<unknown> {
+    ensurePatientId(input.patientId);
+    ensureAllowedResource(input.resourceType);
+
+    if (input.resourceId) {
+      const resource = await this.fetchJson(`${this.baseUrl}/${input.resourceType}/${encodeURIComponent(input.resourceId)}`);
+      return { patientId: input.patientId, resource };
+    }
+
+    const limit = input.count ?? 20;
+    const bundle = await this.fetchJson(
+      `${this.baseUrl}/${input.resourceType}?patient=${encodeURIComponent(input.patientId)}&_count=${limit}`
+    );
+
+    return { patientId: input.patientId, bundle };
+  }
+
+  private async fetchJson(url: string): Promise<unknown> {
+    const response = await this.fetchImpl(url, {
+      headers: {
+        Accept: "application/fhir+json, application/json"
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`FHIR request failed (${response.status}): ${url}`);
+    }
+
+    return response.json();
+  }
+}

--- a/packages/mcp/tsconfig.build.json
+++ b/packages/mcp/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
### Motivation
- Provide a small, typed MCP-style workspace package that wraps a FHIR R4 base URL as patient-scoped, deny-by-default tools to support Phase A agent tooling and demos.
- Enforce patient-scoped access and a conservative resource allowlist so the client can be used safely by the workbench agent and eval harness without exposing arbitrary queries.

### Description
- Add new workspace package `@fhir-place/mcp` with `package.json`, `tsconfig.json`, and `tsconfig.build.json` to integrate with the monorepo build scripts.
- Implement `FhirMcpClient` in `packages/mcp/src/index.ts` providing two typed tools: `patient_summary` and `read_resource`, validating `patientId` and checking an allowlist of resource types before issuing fetches.
- Add unit tests in `packages/mcp/src/index.test.ts` that assert tool listing, allowlist enforcement, and correct patient-scoped request URL construction.
- Include `packages/mcp/README.md` with a quick-start example and notes about the deny-by-default policy.

### Testing
- Unit tests were added in `packages/mcp/src/index.test.ts` but were not executed in this environment because workspace dependency installation failed when running `pnpm install` due to an npm registry authorization error (`ERR_PNPM_FETCH_403`).
- Running `pnpm --filter @fhir-place/mcp test:run` failed for the same reason and `pnpm exec vitest run packages/mcp/src/index.test.ts` failed because `vitest` was not available without installing dev dependencies.
- No automated tests passed or failed against the new package in CI here; the tests should run locally or in CI after `pnpm install` completes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4c3988b308333ac3df4d8af081491)