### PR TITLE
feat(search): typed search builder v0.2 — chained search and `_has` (#129)

### DIFF
--- a/packages/react-fhir/src/client/searchBuilder.test.ts
+++ b/packages/react-fhir/src/client/searchBuilder.test.ts
@@ -95,6 +95,59 @@ describe("searchBuilder runtime", () => {
     }).toString();
     expect(built).toBe(reference);
   });
+
+  it("emits chained search with the :Type modifier", () => {
+    const url = searchBuilder("Observation")
+      .whereChained("subject", "Patient", "name", "Smith")
+      .build();
+    expect(url).toBe("Observation?subject%3APatient.name=Smith");
+  });
+
+  it("types chained values against the target param", () => {
+    const url = searchBuilder("Observation")
+      .whereChained("subject", "Patient", "birthdate", { ge: "1990-01-01" })
+      .build();
+    expect(url).toBe(
+      "Observation?subject%3APatient.birthdate=ge1990-01-01",
+    );
+  });
+
+  it("emits reverse chained _has", () => {
+    const url = searchBuilder("Patient")
+      .whereHas("Observation", "subject", "code", "85354-9")
+      .build();
+    expect(url).toBe(
+      "Patient?_has%3AObservation%3Asubject%3Acode=85354-9",
+    );
+  });
+
+  it("matches buildSearchParams byte-for-byte for chained and _has keys", () => {
+    const chained = searchBuilder("Observation")
+      .whereChained("subject", "Patient", "name", "Smith")
+      .toQueryString();
+    expect(chained).toBe(
+      buildSearchParams({ "subject:Patient.name": "Smith" }).toString(),
+    );
+
+    const has = searchBuilder("Patient")
+      .whereHas("Observation", "subject", "code", "85354-9")
+      .toQueryString();
+    expect(has).toBe(
+      buildSearchParams({
+        "_has:Observation:subject:code": "85354-9",
+      }).toString(),
+    );
+  });
+
+  it("composes chained + _has + plain wheres in declaration order", () => {
+    const url = searchBuilder("Patient")
+      .where("name", "Smith")
+      .whereHas("Observation", "subject", "code", "85354-9")
+      .build();
+    expect(url).toBe(
+      "Patient?name=Smith&_has%3AObservation%3Asubject%3Acode=85354-9",
+    );
+  });
 });
 
 describe("searchBuilder types", () => {
@@ -118,6 +171,37 @@ describe("searchBuilder types", () => {
     b.include("Observation:bogus");
     // @ts-expect-error wrong shape for date range.
     b.where("birthdate", { foo: "bar" });
+
+    expect(true).toBe(true);
+  });
+
+  it("rejects bogus chained / _has args at compile time", () => {
+    const obs = searchBuilder("Observation");
+    const pt = searchBuilder("Patient");
+
+    // Well-typed calls compile cleanly.
+    obs.whereChained("subject", "Patient", "name", "Smith");
+    obs.whereChained("subject", "Patient", "birthdate", { ge: "1990-01-01" });
+    pt.whereHas("Observation", "subject", "code", "85354-9");
+    pt.whereHas("Observation", "patient", "status", "final");
+
+    // @ts-expect-error 'Bogus' is not a SearchableResource.
+    obs.whereChained("subject", "Bogus", "name", "x");
+    // @ts-expect-error 'name' is not a reference param on Observation.
+    obs.whereChained("name", "Patient", "name", "x");
+    // @ts-expect-error target-param value type is enforced (birthdate is a date).
+    obs.whereChained("subject", "Patient", "birthdate", 1);
+    // @ts-expect-error 'bogus' is not a registered Patient search param.
+    obs.whereChained("subject", "Patient", "bogus", "x");
+
+    // @ts-expect-error 'Bogus' is not a SearchableResource.
+    pt.whereHas("Bogus", "subject", "code", "x");
+    // @ts-expect-error Observation.encounter does not target Patient.
+    pt.whereHas("Observation", "encounter", "code", "x");
+    // @ts-expect-error 'name' is not a reference param on Observation.
+    pt.whereHas("Observation", "name", "code", "x");
+    // @ts-expect-error 'value-quantity' on Observation is a number; string not assignable.
+    pt.whereHas("Observation", "subject", "value-quantity", "x");
 
     expect(true).toBe(true);
   });

--- a/packages/react-fhir/src/client/searchBuilder.ts
+++ b/packages/react-fhir/src/client/searchBuilder.ts
@@ -1,11 +1,13 @@
 /**
- * Typed search builder (v0). See issue #121 / ADR 0004.
+ * Typed search builder. See issues #121 (v0 — operators + `_include`) and
+ * #129 (v0.2 — chained search and `_has`) and ADR 0004.
  *
  * Models the FHIR search parameter types we cover initially:
  * `string`, `token`, `date`, `reference`, `number`. Composite, quantity, uri,
  * and special types are deferred. Resources and `_include`/`_revinclude`
- * targets are seeded minimally; both registries are extensible via TypeScript
- * declaration merging on `SearchParamTypes` and `IncludePaths`.
+ * targets are seeded minimally; the `SearchParamTypes`, `IncludePaths`, and
+ * `ReferenceTargets` registries are all extensible via TypeScript declaration
+ * merging.
  *
  * Output is byte-identical to `buildSearchParams` for any case both can express.
  */
@@ -86,6 +88,59 @@ export interface IncludePaths {
 
 export type IncludeSpec = keyof IncludePaths;
 
+/**
+ * Optional declaration-merged map: for each `(sourceResource, refParam)` reference
+ * search parameter, list the resource types the reference can target. Seeded for
+ * Patient and Observation; extend via declaration merging to cover more resources.
+ *
+ * Used to type the `:Type` modifier in chained search and to constrain the
+ * back-pointer in `_has`. Targets that are not in `SearchableResource` are
+ * filtered out, since chained / `_has` queries require the target resource to
+ * have registered search params.
+ */
+export interface ReferenceTargets {
+  Patient: {
+    "general-practitioner":
+      | "Practitioner"
+      | "Organization"
+      | "PractitionerRole";
+    organization: "Organization";
+  };
+  Observation: {
+    subject: "Patient" | "Group" | "Device" | "Location";
+    patient: "Patient";
+    encounter: "Encounter";
+  };
+}
+
+type ReferenceParamsOf<R extends SearchableResource> = {
+  [K in keyof SearchParamTypes[R]]: SearchParamTypes[R][K] extends "reference"
+    ? K & string
+    : never;
+}[keyof SearchParamTypes[R]];
+
+type ChainedTargetsOf<
+  R extends SearchableResource,
+  P extends ReferenceParamsOf<R>,
+> = R extends keyof ReferenceTargets
+  ? P extends keyof ReferenceTargets[R]
+    ? Extract<ReferenceTargets[R][P], SearchableResource>
+    : SearchableResource
+  : SearchableResource;
+
+type RefParamsTargeting<
+  S extends SearchableResource,
+  R extends SearchableResource,
+> = S extends keyof ReferenceTargets
+  ? {
+      [K in ReferenceParamsOf<S>]: K extends keyof ReferenceTargets[S]
+        ? R extends Extract<ReferenceTargets[S][K], SearchableResource>
+          ? K
+          : never
+        : K;
+    }[ReferenceParamsOf<S>]
+  : ReferenceParamsOf<S>;
+
 const isPlainOperatorObject = (
   value: unknown,
 ): value is Record<string, unknown> =>
@@ -105,15 +160,63 @@ export class SearchBuilder<R extends SearchableResource> {
     name: P,
     value: SearchValue<Extract<SearchParamTypes[R][P], ParamType>>,
   ): this {
+    this.appendValue(name, value);
+    return this;
+  }
+
+  /**
+   * Chained search: `subject:Patient.name=Smith`.
+   *
+   * `refParam` must be a `reference` parameter on `R`. When `ReferenceTargets`
+   * has an entry for `(R, refParam)`, `targetType` is constrained to its
+   * intersection with `SearchableResource`; otherwise any `SearchableResource`
+   * is accepted. `value` is typed against `(targetType, targetParam)`.
+   */
+  whereChained<
+    P extends ReferenceParamsOf<R>,
+    T extends ChainedTargetsOf<R, P>,
+    TP extends keyof SearchParamTypes[T] & string,
+  >(
+    refParam: P,
+    targetType: T,
+    targetParam: TP,
+    value: SearchValue<Extract<SearchParamTypes[T][TP], ParamType>>,
+  ): this {
+    this.appendValue(`${refParam}:${targetType}.${targetParam}`, value);
+    return this;
+  }
+
+  /**
+   * Reverse chained search: `_has:Observation:subject:code=85354-9`.
+   *
+   * `(sourceType, refParam)` must be a `reference` parameter that points back
+   * at `R` (when `ReferenceTargets` records the relationship). `targetParam`
+   * must be a registered search param on `sourceType`; `value` is typed
+   * against it.
+   */
+  whereHas<
+    S extends SearchableResource,
+    RP extends RefParamsTargeting<S, R>,
+    TP extends keyof SearchParamTypes[S] & string,
+  >(
+    sourceType: S,
+    refParam: RP,
+    targetParam: TP,
+    value: SearchValue<Extract<SearchParamTypes[S][TP], ParamType>>,
+  ): this {
+    this.appendValue(`_has:${sourceType}:${refParam}:${targetParam}`, value);
+    return this;
+  }
+
+  private appendValue(key: string, value: unknown): void {
     if (isPlainOperatorObject(value)) {
       for (const [prefix, raw] of Object.entries(value)) {
         if (raw === undefined || raw === null) continue;
-        this.entries.push([name, `${prefix}${formatScalar(raw)}`]);
+        this.entries.push([key, `${prefix}${formatScalar(raw)}`]);
       }
     } else {
-      this.entries.push([name, formatScalar(value)]);
+      this.entries.push([key, formatScalar(value)]);
     }
-    return this;
   }
 
   include(spec: IncludeSpec): this {


### PR DESCRIPTION
Extends `searchBuilder` with `whereChained` for `subject:Patient.name=…` style
chained search and `whereHas` for `_has:Observation:subject:code=…` reverse
chained queries. Output is byte-identical to `buildSearchParams` for the keys
both can express.

Adds an optional `ReferenceTargets` declaration-merging map so `:Type`
modifiers and `_has` back-pointers are typed against the resources a
reference can target.