### PR TITLE
demo: add FHIR server picker to homepage header

### DIFF
--- a/.changeset/demo-server-picker.md
+++ b/.changeset/demo-server-picker.md
@@ -1,0 +1,4 @@
+---
+---
+
+Demo: add a FHIR server picker to the app header so visitors can switch the live demo between known public FHIR R4 servers (HAPI Public Test Server, SMART Health IT R4) without rebuilding. Selection is persisted in `localStorage` and applied via a page reload so the `FetchFhirClient` rebuilds against the new base URL. Demonstrates that the `@fhir-place/react-fhir` UI is server-agnostic — it works against any spec-compliant FHIR REST API. HAPI remains the default; the picker is hidden in mock mode and when `VITE_FHIR_BASE_URL` overrides the base URL.

--- a/.changeset/demo-server-picker.md
+++ b/.changeset/demo-server-picker.md
@@ -1,4 +1,15 @@
 ---
 ---
 
-Demo: add a FHIR server picker to the app header so visitors can switch the live demo between known public FHIR R4 servers (HAPI Public Test Server, SMART Health IT R4) without rebuilding. Selection is persisted in `localStorage` and applied via a page reload so the `FetchFhirClient` rebuilds against the new base URL. Demonstrates that the `@fhir-place/react-fhir` UI is server-agnostic — it works against any spec-compliant FHIR REST API. HAPI remains the default; the picker is hidden in mock mode and when `VITE_FHIR_BASE_URL` overrides the base URL.
+Demo: add a FHIR server picker and `/settings` page so visitors can point the
+live demo at any FHIR R4 server. The picker lists built-in public servers
+(HAPI Public Test Server, SMART Health IT R4) plus user-added entries; the
+settings page lets users add/edit/delete servers, layer a static bearer token
+or custom request headers (e.g. `Epic-Client-ID`), and run a "Test connection"
+that hits `/metadata` and surfaces software name + `fhirVersion`. Configuration
+is stored in `localStorage`; selecting a server triggers a page reload so the
+singleton `FetchFhirClient` rebuilds with the new base URL and headers. HAPI
+remains the default; the picker/settings are hidden in mock mode and when
+`VITE_FHIR_BASE_URL` overrides the base URL. Demonstrates that
+`@fhir-place/react-fhir` is server-agnostic — it works against any FHIR R4
+REST API.

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -4,11 +4,9 @@ import { PatientListPage } from "./pages/PatientListPage.js";
 import { ResourceDetailPage } from "./pages/ResourceDetailPage.js";
 import { ResourceEditPage } from "./pages/ResourceEditPage.js";
 import { ResourceIndexPage } from "./pages/ResourceIndexPage.js";
+import { SettingsPage } from "./pages/SettingsPage.js";
 import { ServerPicker } from "./components/ServerPicker.js";
-import { FHIR_BASE_URL, FHIR_SERVERS, USE_MOCK } from "./config.js";
-
-const showServerPicker =
-  !USE_MOCK && FHIR_SERVERS.some((s) => s.url === FHIR_BASE_URL);
+import { FHIR_BASE_URL, SETTINGS_ENABLED, USE_MOCK } from "./config.js";
 
 export function App() {
   return (
@@ -23,7 +21,7 @@ export function App() {
               spec-driven FHIR viewer
             </span>
           </div>
-          {showServerPicker ? (
+          {SETTINGS_ENABLED ? (
             <ServerPicker />
           ) : (
             <div className="text-xs text-slate-500" data-testid="base-url">
@@ -37,6 +35,7 @@ export function App() {
           <Route path="/" element={<Navigate to="/Patient" replace />} />
           <Route path="/Patient" element={<PatientListPage />} />
           <Route path="/Patient/new" element={<PatientCreatePage />} />
+          <Route path="/settings" element={<SettingsPage />} />
           <Route path="/:resourceType/:id/edit" element={<ResourceEditPage />} />
           <Route path="/:resourceType/:id" element={<ResourceDetailPage />} />
           <Route path="/:resourceType" element={<ResourceIndexPage />} />

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -4,7 +4,11 @@ import { PatientListPage } from "./pages/PatientListPage.js";
 import { ResourceDetailPage } from "./pages/ResourceDetailPage.js";
 import { ResourceEditPage } from "./pages/ResourceEditPage.js";
 import { ResourceIndexPage } from "./pages/ResourceIndexPage.js";
-import { FHIR_BASE_URL, USE_MOCK } from "./config.js";
+import { ServerPicker } from "./components/ServerPicker.js";
+import { FHIR_BASE_URL, FHIR_SERVERS, USE_MOCK } from "./config.js";
+
+const showServerPicker =
+  !USE_MOCK && FHIR_SERVERS.some((s) => s.url === FHIR_BASE_URL);
 
 export function App() {
   return (
@@ -19,9 +23,13 @@ export function App() {
               spec-driven FHIR viewer
             </span>
           </div>
-          <div className="text-xs text-slate-500" data-testid="base-url">
-            {USE_MOCK ? "mock" : "live"} · {FHIR_BASE_URL}
-          </div>
+          {showServerPicker ? (
+            <ServerPicker />
+          ) : (
+            <div className="text-xs text-slate-500" data-testid="base-url">
+              {USE_MOCK ? "mock" : "live"} · {FHIR_BASE_URL}
+            </div>
+          )}
         </div>
       </header>
       <main className="mx-auto max-w-5xl p-6">

--- a/apps/demo/src/components/ServerPicker.tsx
+++ b/apps/demo/src/components/ServerPicker.tsx
@@ -1,0 +1,39 @@
+import type { ChangeEvent } from "react";
+import { FHIR_BASE_URL, FHIR_SERVERS, setStoredFhirBaseUrl } from "../config.js";
+
+/**
+ * Header dropdown that lets visitors point the demo at any FHIR R4 server in
+ * `FHIR_SERVERS`. Persisted to localStorage and applied via a full reload so
+ * the singleton `FetchFhirClient` in `main.tsx` rebuilds with the new base URL
+ * (and TanStack Query's cache is dropped along with it).
+ */
+export function ServerPicker() {
+  const onChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const next = event.target.value;
+    if (next === FHIR_BASE_URL) return;
+    setStoredFhirBaseUrl(next);
+    window.location.reload();
+  };
+
+  return (
+    <label
+      className="flex items-center gap-2 text-xs text-slate-500"
+      data-testid="base-url"
+    >
+      <span>live ·</span>
+      <select
+        value={FHIR_BASE_URL}
+        onChange={onChange}
+        className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700"
+        data-testid="server-picker"
+        aria-label="FHIR server"
+      >
+        {FHIR_SERVERS.map((server) => (
+          <option key={server.url} value={server.url}>
+            {server.label} — {server.url}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/apps/demo/src/components/ServerPicker.tsx
+++ b/apps/demo/src/components/ServerPicker.tsx
@@ -1,39 +1,55 @@
 import type { ChangeEvent } from "react";
-import { FHIR_BASE_URL, FHIR_SERVERS, setStoredFhirBaseUrl } from "../config.js";
+import { Link } from "react-router-dom";
+import {
+  ACTIVE_SERVER_CONFIG,
+  loadServers,
+  saveActiveServerId,
+} from "../config.js";
 
 /**
- * Header dropdown that lets visitors point the demo at any FHIR R4 server in
- * `FHIR_SERVERS`. Persisted to localStorage and applied via a full reload so
- * the singleton `FetchFhirClient` in `main.tsx` rebuilds with the new base URL
- * (and TanStack Query's cache is dropped along with it).
+ * Header dropdown that lets visitors switch between configured FHIR servers.
+ * The list is loaded from `loadServers()` (built-ins + custom from
+ * localStorage). Switching saves the active id and reloads the page so the
+ * singleton `FetchFhirClient` in `main.tsx` rebuilds with the new base URL
+ * and headers.
  */
 export function ServerPicker() {
+  const servers = loadServers();
+  const activeId = ACTIVE_SERVER_CONFIG.id;
+
   const onChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const next = event.target.value;
-    if (next === FHIR_BASE_URL) return;
-    setStoredFhirBaseUrl(next);
+    if (next === activeId) return;
+    saveActiveServerId(next);
     window.location.reload();
   };
 
   return (
-    <label
+    <div
       className="flex items-center gap-2 text-xs text-slate-500"
       data-testid="base-url"
     >
       <span>live ·</span>
       <select
-        value={FHIR_BASE_URL}
+        value={activeId}
         onChange={onChange}
         className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700"
         data-testid="server-picker"
         aria-label="FHIR server"
       >
-        {FHIR_SERVERS.map((server) => (
-          <option key={server.url} value={server.url}>
-            {server.label} — {server.url}
+        {servers.map((server) => (
+          <option key={server.id} value={server.id}>
+            {server.label} — {server.baseUrl}
           </option>
         ))}
       </select>
-    </label>
+      <Link
+        to="/settings"
+        className="text-slate-600 underline hover:text-slate-900"
+        data-testid="settings-link"
+      >
+        Settings
+      </Link>
+    </div>
   );
 }

--- a/apps/demo/src/config.test.ts
+++ b/apps/demo/src/config.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type ServerConfig,
+  BUILTIN_SERVERS,
+  buildRequestHeaders,
+  loadActiveServerId,
+  loadServers,
+  resolveActiveServer,
+  saveActiveServerId,
+  saveServers,
+} from "./config.js";
+
+const installLocalStorage = (initial: Record<string, string> = {}) => {
+  const store: Record<string, string> = { ...initial };
+  const localStorage = {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => {
+      store[k] = String(v);
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+    },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+  vi.stubGlobal("window", { localStorage });
+  return store;
+};
+
+beforeEach(() => {
+  installLocalStorage();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("buildRequestHeaders", () => {
+  const base: ServerConfig = {
+    id: "x",
+    label: "x",
+    baseUrl: "https://example.org/fhir",
+    authMode: "none",
+  };
+
+  it("returns no headers for authMode=none and no custom headers", () => {
+    expect(buildRequestHeaders(base)).toEqual({});
+  });
+
+  it("attaches Authorization for bearer mode with a token", () => {
+    expect(
+      buildRequestHeaders({ ...base, authMode: "bearer", bearerToken: "abc" }),
+    ).toEqual({ Authorization: "Bearer abc" });
+  });
+
+  it("omits Authorization for bearer mode when token is empty", () => {
+    expect(
+      buildRequestHeaders({ ...base, authMode: "bearer", bearerToken: "" }),
+    ).toEqual({});
+  });
+
+  it("includes custom headers", () => {
+    expect(
+      buildRequestHeaders({
+        ...base,
+        headers: [
+          { key: "Epic-Client-ID", value: "abc-123" },
+          { key: "X-Tenant", value: "acme" },
+        ],
+      }),
+    ).toEqual({ "Epic-Client-ID": "abc-123", "X-Tenant": "acme" });
+  });
+
+  it("skips headers with empty/whitespace keys", () => {
+    expect(
+      buildRequestHeaders({
+        ...base,
+        headers: [
+          { key: "", value: "ignored" },
+          { key: "   ", value: "also-ignored" },
+          { key: "X-Real", value: "kept" },
+        ],
+      }),
+    ).toEqual({ "X-Real": "kept" });
+  });
+
+  it("custom headers override Authorization on key collision", () => {
+    expect(
+      buildRequestHeaders({
+        ...base,
+        authMode: "bearer",
+        bearerToken: "from-config",
+        headers: [{ key: "Authorization", value: "Custom override" }],
+      }),
+    ).toEqual({ Authorization: "Custom override" });
+  });
+});
+
+describe("loadServers", () => {
+  it("returns built-ins when storage is empty", () => {
+    const servers = loadServers();
+    expect(servers.map((s) => s.id)).toEqual(BUILTIN_SERVERS.map((s) => s.id));
+    expect(servers.every((s) => s.builtin)).toBe(true);
+  });
+
+  it("returns built-ins when storage has invalid JSON", () => {
+    installLocalStorage({ "fhir-place:servers": "{not json" });
+    expect(loadServers().map((s) => s.id)).toEqual(
+      BUILTIN_SERVERS.map((s) => s.id),
+    );
+  });
+
+  it("returns built-ins when storage holds a non-array value", () => {
+    installLocalStorage({ "fhir-place:servers": JSON.stringify({ foo: 1 }) });
+    expect(loadServers().map((s) => s.id)).toEqual(
+      BUILTIN_SERVERS.map((s) => s.id),
+    );
+  });
+
+  it("preserves stored overrides on built-ins (e.g. user-added bearer token)", () => {
+    installLocalStorage({
+      "fhir-place:servers": JSON.stringify([
+        {
+          id: "builtin-hapi",
+          label: "HAPI (mine)",
+          baseUrl: "https://hapi.fhir.org/baseR4",
+          authMode: "bearer",
+          bearerToken: "tok",
+        },
+      ]),
+    });
+    const servers = loadServers();
+    const hapi = servers.find((s) => s.id === "builtin-hapi");
+    expect(hapi).toMatchObject({
+      label: "HAPI (mine)",
+      authMode: "bearer",
+      bearerToken: "tok",
+      builtin: true,
+    });
+    // Other built-ins still present.
+    expect(servers.find((s) => s.id === "builtin-smart")).toBeDefined();
+  });
+
+  it("includes user-added custom servers, marking them non-builtin", () => {
+    installLocalStorage({
+      "fhir-place:servers": JSON.stringify([
+        {
+          id: "custom-1",
+          label: "My Server",
+          baseUrl: "https://example.org/fhir",
+          authMode: "none",
+        },
+      ]),
+    });
+    const servers = loadServers();
+    const custom = servers.find((s) => s.id === "custom-1");
+    expect(custom).toMatchObject({
+      label: "My Server",
+      baseUrl: "https://example.org/fhir",
+      builtin: false,
+    });
+    // Built-ins are still merged in.
+    expect(servers.find((s) => s.id === "builtin-hapi")).toBeDefined();
+  });
+
+  it("silently drops malformed entries", () => {
+    installLocalStorage({
+      "fhir-place:servers": JSON.stringify([
+        { id: "ok", label: "Ok", baseUrl: "https://example", authMode: "none" },
+        { id: 42, label: "bad-id" },
+        { id: "no-url", label: "x" },
+        { id: "bad-auth", label: "y", baseUrl: "https://x", authMode: "weird" },
+        null,
+        "not-an-object",
+      ]),
+    });
+    const ids = loadServers().map((s) => s.id);
+    expect(ids).toContain("ok");
+    expect(ids).not.toContain("bad-id");
+    expect(ids).not.toContain("no-url");
+    expect(ids).not.toContain("bad-auth");
+  });
+});
+
+describe("saveServers", () => {
+  it("round-trips through localStorage", () => {
+    const next: ServerConfig[] = [
+      {
+        id: "custom-1",
+        label: "Custom",
+        baseUrl: "https://example.org/fhir",
+        authMode: "bearer",
+        bearerToken: "tok",
+        headers: [{ key: "X", value: "Y" }],
+      },
+    ];
+    saveServers(next);
+    const reloaded = loadServers();
+    expect(reloaded.find((s) => s.id === "custom-1")).toMatchObject({
+      label: "Custom",
+      authMode: "bearer",
+      bearerToken: "tok",
+      headers: [{ key: "X", value: "Y" }],
+    });
+  });
+});
+
+describe("active server id", () => {
+  it("returns null when no id is stored", () => {
+    expect(loadActiveServerId()).toBeNull();
+  });
+
+  it("round-trips via saveActiveServerId", () => {
+    saveActiveServerId("builtin-smart");
+    expect(loadActiveServerId()).toBe("builtin-smart");
+  });
+});
+
+describe("resolveActiveServer", () => {
+  it("returns the active server when its id is stored", () => {
+    saveActiveServerId("builtin-smart");
+    expect(resolveActiveServer().id).toBe("builtin-smart");
+  });
+
+  it("falls back to the first server when no active id is stored", () => {
+    expect(resolveActiveServer().id).toBe(BUILTIN_SERVERS[0]!.id);
+  });
+
+  it("falls back to the first server when active id matches nothing", () => {
+    saveActiveServerId("never-existed");
+    expect(resolveActiveServer().id).toBe(BUILTIN_SERVERS[0]!.id);
+  });
+});

--- a/apps/demo/src/config.ts
+++ b/apps/demo/src/config.ts
@@ -4,46 +4,192 @@ export const USE_MOCK =
 /** Vite's BASE_URL — "/" locally, "/fhir-place/" on GitHub Pages. */
 const BASE = import.meta.env.BASE_URL;
 
+export type AuthMode = "none" | "bearer";
+
+export type CustomHeader = { key: string; value: string };
+
+export interface ServerConfig {
+  id: string;
+  label: string;
+  baseUrl: string;
+  authMode: AuthMode;
+  bearerToken?: string;
+  headers?: CustomHeader[];
+  /** Built-in servers can't be deleted, but their auth/headers can still be edited. */
+  builtin?: boolean;
+}
+
 /**
- * Public FHIR R4 test servers offered in the demo's server picker. The first
- * entry is the default. All listed servers must support open (no-auth) access
- * and CORS so the browser can reach them directly. Demonstrates that
- * `@fhir-place/react-fhir` is server-agnostic — drop in any FHIR REST API.
+ * Built-in public FHIR R4 servers. Both support open access and CORS so the
+ * browser can reach them directly. Users can layer auth/custom headers on top
+ * via the Settings page (e.g. a personal access token for HAPI).
  */
-export const FHIR_SERVERS = [
-  { label: "HAPI Public Test Server", url: "https://hapi.fhir.org/baseR4" },
-  { label: "SMART Health IT (R4)", url: "https://r4.smarthealthit.org" },
-] as const satisfies ReadonlyArray<{ label: string; url: string }>;
+export const BUILTIN_SERVERS: ReadonlyArray<ServerConfig> = [
+  {
+    id: "builtin-hapi",
+    label: "HAPI Public Test Server",
+    baseUrl: "https://hapi.fhir.org/baseR4",
+    authMode: "none",
+    builtin: true,
+  },
+  {
+    id: "builtin-smart",
+    label: "SMART Health IT (R4)",
+    baseUrl: "https://r4.smarthealthit.org",
+    authMode: "none",
+    builtin: true,
+  },
+];
 
-const DEFAULT_LIVE_URL: string = FHIR_SERVERS[0].url;
+const SERVERS_STORAGE_KEY = "fhir-place:servers";
+const ACTIVE_SERVER_STORAGE_KEY = "fhir-place:active-server";
 
-const SERVER_STORAGE_KEY = "fhir-place:base-url";
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
 
-const isKnownServer = (url: string): boolean =>
-  FHIR_SERVERS.some((s) => s.url === url);
+const parseServer = (v: unknown): ServerConfig | null => {
+  if (!isPlainObject(v)) return null;
+  const { id, label, baseUrl, authMode, bearerToken, headers, builtin } = v;
+  if (typeof id !== "string" || typeof label !== "string" || typeof baseUrl !== "string") {
+    return null;
+  }
+  if (authMode !== "none" && authMode !== "bearer") return null;
+  const parsedHeaders = Array.isArray(headers)
+    ? headers
+        .filter(isPlainObject)
+        .filter((h) => typeof h.key === "string" && typeof h.value === "string")
+        .map((h) => ({ key: h.key as string, value: h.value as string }))
+    : undefined;
+  return {
+    id,
+    label,
+    baseUrl,
+    authMode,
+    ...(typeof bearerToken === "string" && bearerToken ? { bearerToken } : {}),
+    ...(parsedHeaders && parsedHeaders.length > 0 ? { headers: parsedHeaders } : {}),
+    ...(builtin === true ? { builtin: true } : {}),
+  };
+};
 
-const getStoredBaseUrl = (): string | null => {
+const readStoredServers = (): ServerConfig[] | null => {
   if (typeof window === "undefined") return null;
   try {
-    const stored = window.localStorage.getItem(SERVER_STORAGE_KEY);
-    return stored && isKnownServer(stored) ? stored : null;
+    const raw = window.localStorage.getItem(SERVERS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    const servers = parsed.map(parseServer).filter((s): s is ServerConfig => s !== null);
+    return servers.length > 0 ? servers : null;
   } catch {
     return null;
   }
 };
 
-export const setStoredFhirBaseUrl = (url: string): void => {
+/**
+ * Merge built-ins with stored config so:
+ * - Built-ins always exist (even if storage is empty/corrupt).
+ * - Stored edits to built-ins (auth, headers, label) survive.
+ * - Custom user-added servers come through unchanged.
+ */
+const mergeWithBuiltins = (stored: ServerConfig[] | null): ServerConfig[] => {
+  if (!stored) return BUILTIN_SERVERS.map((s) => ({ ...s }));
+  const byId = new Map(stored.map((s) => [s.id, s]));
+  const merged: ServerConfig[] = [];
+  for (const builtin of BUILTIN_SERVERS) {
+    const override = byId.get(builtin.id);
+    merged.push(override ? { ...override, builtin: true } : { ...builtin });
+    byId.delete(builtin.id);
+  }
+  for (const remaining of byId.values()) {
+    merged.push({ ...remaining, builtin: false });
+  }
+  return merged;
+};
+
+export const loadServers = (): ServerConfig[] => mergeWithBuiltins(readStoredServers());
+
+export const saveServers = (servers: ReadonlyArray<ServerConfig>): void => {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(SERVER_STORAGE_KEY, url);
+    window.localStorage.setItem(SERVERS_STORAGE_KEY, JSON.stringify(servers));
   } catch {
-    // localStorage may be unavailable (private mode); the picker just won't persist.
+    // localStorage unavailable (private mode, quota); changes simply don't persist.
   }
 };
 
-export const FHIR_BASE_URL: string =
-  import.meta.env.VITE_FHIR_BASE_URL ??
-  (USE_MOCK ? `${BASE}fhir` : (getStoredBaseUrl() ?? DEFAULT_LIVE_URL));
+export const loadActiveServerId = (): string | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(ACTIVE_SERVER_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+export const saveActiveServerId = (id: string): void => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(ACTIVE_SERVER_STORAGE_KEY, id);
+  } catch {
+    // see saveServers
+  }
+};
+
+const FALLBACK_SERVER: ServerConfig = {
+  id: "builtin-hapi",
+  label: "HAPI Public Test Server",
+  baseUrl: "https://hapi.fhir.org/baseR4",
+  authMode: "none",
+  builtin: true,
+};
+
+export const resolveActiveServer = (): ServerConfig => {
+  const servers = loadServers();
+  const activeId = loadActiveServerId();
+  if (activeId) {
+    const match = servers.find((s) => s.id === activeId);
+    if (match) return match;
+  }
+  return servers[0] ?? { ...FALLBACK_SERVER };
+};
+
+const ACTIVE_SERVER: ServerConfig = (() => {
+  if (USE_MOCK) {
+    return {
+      id: "mock",
+      label: "Mock (MSW)",
+      baseUrl: `${BASE}fhir`,
+      authMode: "none",
+      builtin: true,
+    };
+  }
+  if (import.meta.env.VITE_FHIR_BASE_URL) {
+    return {
+      id: "env-override",
+      label: "Env override",
+      baseUrl: import.meta.env.VITE_FHIR_BASE_URL,
+      authMode: "none",
+      builtin: true,
+    };
+  }
+  return resolveActiveServer();
+})();
+
+export const ACTIVE_SERVER_CONFIG: ServerConfig = ACTIVE_SERVER;
+
+export const FHIR_BASE_URL: string = ACTIVE_SERVER.baseUrl;
+
+/** Static headers derived from the active server's auth + custom headers. */
+export const buildRequestHeaders = (server: ServerConfig): Record<string, string> => {
+  const headers: Record<string, string> = {};
+  if (server.authMode === "bearer" && server.bearerToken) {
+    headers.Authorization = `Bearer ${server.bearerToken}`;
+  }
+  for (const h of server.headers ?? []) {
+    if (h.key.trim()) headers[h.key] = h.value;
+  }
+  return headers;
+};
 
 export const ROUTER_BASENAME: string = BASE.replace(/\/$/, "") || "/";
 
@@ -57,3 +203,10 @@ export const ROUTER_BASENAME: string = BASE.replace(/\/$/, "") || "/";
 export const USE_HASH_ROUTER: boolean =
   import.meta.env.VITE_USE_HASH_ROUTER === "true" ||
   (BASE !== "/" && !import.meta.env.DEV);
+
+/**
+ * Whether the in-app server picker / settings UI should be shown. Hidden in
+ * mock mode and when an env override pins the base URL.
+ */
+export const SETTINGS_ENABLED: boolean =
+  !USE_MOCK && !import.meta.env.VITE_FHIR_BASE_URL;

--- a/apps/demo/src/config.ts
+++ b/apps/demo/src/config.ts
@@ -4,9 +4,46 @@ export const USE_MOCK =
 /** Vite's BASE_URL — "/" locally, "/fhir-place/" on GitHub Pages. */
 const BASE = import.meta.env.BASE_URL;
 
+/**
+ * Public FHIR R4 test servers offered in the demo's server picker. The first
+ * entry is the default. All listed servers must support open (no-auth) access
+ * and CORS so the browser can reach them directly. Demonstrates that
+ * `@fhir-place/react-fhir` is server-agnostic — drop in any FHIR REST API.
+ */
+export const FHIR_SERVERS = [
+  { label: "HAPI Public Test Server", url: "https://hapi.fhir.org/baseR4" },
+  { label: "SMART Health IT (R4)", url: "https://r4.smarthealthit.org" },
+] as const satisfies ReadonlyArray<{ label: string; url: string }>;
+
+const DEFAULT_LIVE_URL: string = FHIR_SERVERS[0].url;
+
+const SERVER_STORAGE_KEY = "fhir-place:base-url";
+
+const isKnownServer = (url: string): boolean =>
+  FHIR_SERVERS.some((s) => s.url === url);
+
+const getStoredBaseUrl = (): string | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    const stored = window.localStorage.getItem(SERVER_STORAGE_KEY);
+    return stored && isKnownServer(stored) ? stored : null;
+  } catch {
+    return null;
+  }
+};
+
+export const setStoredFhirBaseUrl = (url: string): void => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(SERVER_STORAGE_KEY, url);
+  } catch {
+    // localStorage may be unavailable (private mode); the picker just won't persist.
+  }
+};
+
 export const FHIR_BASE_URL: string =
   import.meta.env.VITE_FHIR_BASE_URL ??
-  (USE_MOCK ? `${BASE}fhir` : "https://hapi.fhir.org/baseR4");
+  (USE_MOCK ? `${BASE}fhir` : (getStoredBaseUrl() ?? DEFAULT_LIVE_URL));
 
 export const ROUTER_BASENAME: string = BASE.replace(/\/$/, "") || "/";
 

--- a/apps/demo/src/main.tsx
+++ b/apps/demo/src/main.tsx
@@ -4,7 +4,14 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, HashRouter } from "react-router-dom";
 import { App } from "./App.js";
-import { FHIR_BASE_URL, ROUTER_BASENAME, USE_HASH_ROUTER, USE_MOCK } from "./config.js";
+import {
+  ACTIVE_SERVER_CONFIG,
+  FHIR_BASE_URL,
+  ROUTER_BASENAME,
+  USE_HASH_ROUTER,
+  USE_MOCK,
+  buildRequestHeaders,
+} from "./config.js";
 import "./index.css";
 
 // 4xx responses (404, 410, 422…) aren't transient — retrying them just pads
@@ -29,7 +36,10 @@ const queryClient = new QueryClient({
   },
 });
 
-const fhirClient = new FetchFhirClient({ baseUrl: FHIR_BASE_URL });
+const fhirClient = new FetchFhirClient({
+  baseUrl: FHIR_BASE_URL,
+  headers: buildRequestHeaders(ACTIVE_SERVER_CONFIG),
+});
 
 async function bootstrap() {
   if (USE_MOCK) {

--- a/apps/demo/src/pages/SettingsPage.tsx
+++ b/apps/demo/src/pages/SettingsPage.tsx
@@ -1,16 +1,15 @@
-import type { CapabilityStatement } from "fhir/r4";
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   type AuthMode,
   type CustomHeader,
   type ServerConfig,
-  buildRequestHeaders,
   loadActiveServerId,
   loadServers,
   saveActiveServerId,
   saveServers,
 } from "../config.js";
+import { probeFhirServer } from "../serverProbe.js";
 
 type TestState =
   | { status: "idle" }
@@ -66,42 +65,17 @@ export function SettingsPage() {
 
   const testConnection = async (server: ServerConfig) => {
     setTestState((prev) => ({ ...prev, [server.id]: { status: "pending" } }));
-    try {
-      const headers = {
-        Accept: "application/fhir+json",
-        ...buildRequestHeaders(server),
-      };
-      const url = `${server.baseUrl.replace(/\/+$/, "")}/metadata`;
-      const res = await fetch(url, { headers });
-      if (!res.ok) {
-        setTestState((prev) => ({
-          ...prev,
-          [server.id]: {
-            status: "error",
-            message: `HTTP ${res.status} ${res.statusText}`,
-          },
-        }));
-        return;
-      }
-      const cs = (await res.json()) as CapabilityStatement;
-      setTestState((prev) => ({
-        ...prev,
-        [server.id]: {
-          status: "ok",
-          ...(cs.software?.name ? { software: cs.software.name } : {}),
-          ...(cs.fhirVersion ? { fhirVersion: cs.fhirVersion } : {}),
-        },
-      }));
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      const hint = /failed to fetch|networkerror/i.test(message)
-        ? `${message} — likely a CORS or network issue. Check the browser console for details.`
-        : message;
-      setTestState((prev) => ({
-        ...prev,
-        [server.id]: { status: "error", message: hint },
-      }));
-    }
+    const result = await probeFhirServer(server);
+    setTestState((prev) => ({
+      ...prev,
+      [server.id]: result.ok
+        ? {
+            status: "ok",
+            ...(result.software ? { software: result.software } : {}),
+            ...(result.fhirVersion ? { fhirVersion: result.fhirVersion } : {}),
+          }
+        : { status: "error", message: result.message },
+    }));
   };
 
   return (

--- a/apps/demo/src/pages/SettingsPage.tsx
+++ b/apps/demo/src/pages/SettingsPage.tsx
@@ -1,0 +1,372 @@
+import type { CapabilityStatement } from "fhir/r4";
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  type AuthMode,
+  type CustomHeader,
+  type ServerConfig,
+  buildRequestHeaders,
+  loadActiveServerId,
+  loadServers,
+  saveActiveServerId,
+  saveServers,
+} from "../config.js";
+
+type TestState =
+  | { status: "idle" }
+  | { status: "pending" }
+  | { status: "ok"; software?: string; fhirVersion?: string }
+  | { status: "error"; message: string };
+
+const newServerId = (): string =>
+  `custom-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+const blankServer = (): ServerConfig => ({
+  id: newServerId(),
+  label: "My FHIR Server",
+  baseUrl: "",
+  authMode: "none",
+});
+
+export function SettingsPage() {
+  const [servers, setServers] = useState<ServerConfig[]>(() => loadServers());
+  const [activeId, setActiveId] = useState<string | null>(() => loadActiveServerId());
+  const [testState, setTestState] = useState<Record<string, TestState>>({});
+
+  const persist = (next: ServerConfig[]) => {
+    setServers(next);
+    saveServers(next);
+  };
+
+  const updateServer = (id: string, patch: Partial<ServerConfig>) => {
+    persist(servers.map((s) => (s.id === id ? { ...s, ...patch } : s)));
+  };
+
+  const removeServer = (id: string) => {
+    persist(servers.filter((s) => s.id !== id));
+    if (activeId === id) {
+      saveActiveServerId(servers[0]?.id ?? "");
+      setActiveId(servers[0]?.id ?? null);
+    }
+  };
+
+  const addServer = () => {
+    persist([...servers, blankServer()]);
+  };
+
+  const setActive = (id: string) => {
+    saveActiveServerId(id);
+    setActiveId(id);
+  };
+
+  const applyAndReload = (id: string) => {
+    setActive(id);
+    window.location.reload();
+  };
+
+  const testConnection = async (server: ServerConfig) => {
+    setTestState((prev) => ({ ...prev, [server.id]: { status: "pending" } }));
+    try {
+      const headers = {
+        Accept: "application/fhir+json",
+        ...buildRequestHeaders(server),
+      };
+      const url = `${server.baseUrl.replace(/\/+$/, "")}/metadata`;
+      const res = await fetch(url, { headers });
+      if (!res.ok) {
+        setTestState((prev) => ({
+          ...prev,
+          [server.id]: {
+            status: "error",
+            message: `HTTP ${res.status} ${res.statusText}`,
+          },
+        }));
+        return;
+      }
+      const cs = (await res.json()) as CapabilityStatement;
+      setTestState((prev) => ({
+        ...prev,
+        [server.id]: {
+          status: "ok",
+          ...(cs.software?.name ? { software: cs.software.name } : {}),
+          ...(cs.fhirVersion ? { fhirVersion: cs.fhirVersion } : {}),
+        },
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const hint = /failed to fetch|networkerror/i.test(message)
+        ? `${message} — likely a CORS or network issue. Check the browser console for details.`
+        : message;
+      setTestState((prev) => ({
+        ...prev,
+        [server.id]: { status: "error", message: hint },
+      }));
+    }
+  };
+
+  return (
+    <div className="space-y-6" data-testid="settings-page">
+      <nav className="text-sm text-slate-500">
+        <Link to="/" className="underline">
+          ← Back
+        </Link>
+      </nav>
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold text-slate-900">FHIR server settings</h1>
+        <p className="text-sm text-slate-600">
+          Point the demo at any FHIR R4 server. Settings are stored in your browser
+          (localStorage) — nothing leaves your device. Bearer tokens are saved in
+          plaintext, so use a personal access token, not a privileged credential.
+        </p>
+      </header>
+
+      <ul className="space-y-4">
+        {servers.map((server) => (
+          <li key={server.id}>
+            <ServerForm
+              server={server}
+              isActive={activeId === server.id}
+              testState={testState[server.id] ?? { status: "idle" }}
+              onChange={(patch) => updateServer(server.id, patch)}
+              onTest={() => testConnection(server)}
+              onUse={() => applyAndReload(server.id)}
+              onDelete={server.builtin ? null : () => removeServer(server.id)}
+            />
+          </li>
+        ))}
+      </ul>
+
+      <button
+        type="button"
+        onClick={addServer}
+        className="rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 hover:bg-slate-50"
+        data-testid="add-server"
+      >
+        + Add server
+      </button>
+    </div>
+  );
+}
+
+interface ServerFormProps {
+  server: ServerConfig;
+  isActive: boolean;
+  testState: TestState;
+  onChange: (patch: Partial<ServerConfig>) => void;
+  onTest: () => void;
+  onUse: () => void;
+  onDelete: (() => void) | null;
+}
+
+function ServerForm({
+  server,
+  isActive,
+  testState,
+  onChange,
+  onTest,
+  onUse,
+  onDelete,
+}: ServerFormProps) {
+  const headers = useMemo<CustomHeader[]>(() => server.headers ?? [], [server.headers]);
+
+  const updateHeaders = (next: CustomHeader[]) => {
+    onChange({ headers: next.length > 0 ? next : undefined });
+  };
+
+  return (
+    <section
+      className="space-y-3 rounded border border-slate-200 bg-white p-4 shadow-sm"
+      data-testid="server-form"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <h2 className="text-base font-semibold text-slate-900">
+            {server.label || "(unnamed)"}
+          </h2>
+          {server.builtin && (
+            <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] uppercase text-slate-500">
+              built-in
+            </span>
+          )}
+          {isActive && (
+            <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] uppercase text-emerald-700">
+              active
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onTest}
+            className="rounded border border-slate-300 bg-white px-3 py-1 text-xs text-slate-700 hover:bg-slate-50"
+            data-testid="test-connection"
+          >
+            Test connection
+          </button>
+          {!isActive && (
+            <button
+              type="button"
+              onClick={onUse}
+              className="rounded bg-slate-900 px-3 py-1 text-xs text-white hover:bg-slate-700"
+              data-testid="use-server"
+            >
+              Use this server
+            </button>
+          )}
+          {onDelete && (
+            <button
+              type="button"
+              onClick={onDelete}
+              className="rounded border border-red-200 bg-white px-3 py-1 text-xs text-red-700 hover:bg-red-50"
+              data-testid="delete-server"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Field label="Label">
+          <input
+            type="text"
+            value={server.label}
+            onChange={(e) => onChange({ label: e.target.value })}
+            className={inputClass}
+          />
+        </Field>
+        <Field label="Base URL">
+          <input
+            type="url"
+            value={server.baseUrl}
+            onChange={(e) => onChange({ baseUrl: e.target.value })}
+            placeholder="https://example.org/fhir"
+            className={inputClass}
+          />
+        </Field>
+      </div>
+
+      <Field label="Auth">
+        <select
+          value={server.authMode}
+          onChange={(e) => onChange({ authMode: e.target.value as AuthMode })}
+          className={inputClass}
+        >
+          <option value="none">None</option>
+          <option value="bearer">Bearer token</option>
+        </select>
+      </Field>
+
+      {server.authMode === "bearer" && (
+        <Field label="Bearer token">
+          <input
+            type="password"
+            value={server.bearerToken ?? ""}
+            onChange={(e) => onChange({ bearerToken: e.target.value })}
+            placeholder="paste token"
+            className={inputClass}
+            autoComplete="off"
+          />
+        </Field>
+      )}
+
+      <fieldset className="space-y-2">
+        <legend className="text-xs font-medium text-slate-700">
+          Custom headers
+        </legend>
+        {headers.length === 0 && (
+          <p className="text-xs text-slate-500">
+            None. Add e.g. <code>Epic-Client-ID</code> or a tenant header.
+          </p>
+        )}
+        {headers.map((h, i) => (
+          <div key={i} className="flex gap-2">
+            <input
+              type="text"
+              value={h.key}
+              onChange={(e) =>
+                updateHeaders(
+                  headers.map((existing, j) =>
+                    j === i ? { ...existing, key: e.target.value } : existing,
+                  ),
+                )
+              }
+              placeholder="Header name"
+              className={`${inputClass} flex-1`}
+            />
+            <input
+              type="text"
+              value={h.value}
+              onChange={(e) =>
+                updateHeaders(
+                  headers.map((existing, j) =>
+                    j === i ? { ...existing, value: e.target.value } : existing,
+                  ),
+                )
+              }
+              placeholder="Value"
+              className={`${inputClass} flex-1`}
+            />
+            <button
+              type="button"
+              onClick={() => updateHeaders(headers.filter((_, j) => j !== i))}
+              className="rounded border border-slate-300 bg-white px-2 text-xs text-slate-600 hover:bg-slate-50"
+              aria-label="Remove header"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={() => updateHeaders([...headers, { key: "", value: "" }])}
+          className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 hover:bg-slate-50"
+        >
+          + Add header
+        </button>
+      </fieldset>
+
+      <TestResult state={testState} />
+    </section>
+  );
+}
+
+function TestResult({ state }: { state: TestState }) {
+  if (state.status === "idle") return null;
+  if (state.status === "pending") {
+    return <p className="text-xs text-slate-500">Testing…</p>;
+  }
+  if (state.status === "ok") {
+    const parts = [state.software, state.fhirVersion && `FHIR ${state.fhirVersion}`]
+      .filter(Boolean)
+      .join(" · ");
+    return (
+      <p
+        className="rounded border border-emerald-200 bg-emerald-50 p-2 text-xs text-emerald-800"
+        data-testid="test-ok"
+      >
+        ✓ Connected{parts ? ` — ${parts}` : ""}
+      </p>
+    );
+  }
+  return (
+    <p
+      className="rounded border border-red-200 bg-red-50 p-2 text-xs text-red-700"
+      data-testid="test-error"
+    >
+      ✗ {state.message}
+    </p>
+  );
+}
+
+const inputClass =
+  "w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-800 focus:border-slate-500 focus:outline-none";
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1">
+      <span className="block text-xs font-medium text-slate-700">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/apps/demo/src/serverProbe.test.ts
+++ b/apps/demo/src/serverProbe.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ServerConfig } from "./config.js";
+import { probeFhirServer } from "./serverProbe.js";
+
+const baseServer: ServerConfig = {
+  id: "test",
+  label: "Test",
+  baseUrl: "https://example.org/fhir",
+  authMode: "none",
+};
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/fhir+json" },
+    ...init,
+  });
+};
+
+describe("probeFhirServer", () => {
+  it("returns ok with software + fhirVersion on success", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        resourceType: "CapabilityStatement",
+        software: { name: "HAPI FHIR Server" },
+        fhirVersion: "4.0.1",
+      }),
+    );
+    const result = await probeFhirServer(baseServer, { fetchImpl });
+    expect(result).toEqual({
+      ok: true,
+      software: "HAPI FHIR Server",
+      fhirVersion: "4.0.1",
+    });
+  });
+
+  it("omits software/fhirVersion fields when the response lacks them", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ resourceType: "CapabilityStatement" }),
+    );
+    const result = await probeFhirServer(baseServer, { fetchImpl });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("hits the /metadata endpoint on the configured base URL", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse({}));
+    await probeFhirServer(baseServer, { fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(fetchImpl.mock.calls[0]![0]).toBe("https://example.org/fhir/metadata");
+  });
+
+  it("trims trailing slashes from baseUrl when constructing /metadata", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse({}));
+    await probeFhirServer(
+      { ...baseServer, baseUrl: "https://example.org/fhir///" },
+      { fetchImpl },
+    );
+    expect(fetchImpl.mock.calls[0]![0]).toBe("https://example.org/fhir/metadata");
+  });
+
+  it("forwards Authorization header for bearer auth", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse({}));
+    await probeFhirServer(
+      { ...baseServer, authMode: "bearer", bearerToken: "tok-xyz" },
+      { fetchImpl },
+    );
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer tok-xyz",
+      Accept: "application/fhir+json",
+    });
+  });
+
+  it("forwards custom headers", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse({}));
+    await probeFhirServer(
+      {
+        ...baseServer,
+        headers: [{ key: "Epic-Client-ID", value: "abc-123" }],
+      },
+      { fetchImpl },
+    );
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(init.headers).toMatchObject({ "Epic-Client-ID": "abc-123" });
+  });
+
+  it("returns an http error on non-2xx", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response("nope", { status: 401, statusText: "Unauthorized" }),
+    );
+    const result = await probeFhirServer(baseServer, { fetchImpl });
+    expect(result).toEqual({
+      ok: false,
+      kind: "http",
+      message: "HTTP 401 Unauthorized",
+    });
+  });
+
+  it("returns a network error with a CORS hint on TypeError", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    const result = await probeFhirServer(baseServer, { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.kind).toBe("network");
+    expect(result.message).toMatch(/Failed to fetch/);
+    expect(result.message).toMatch(/CORS or network issue/);
+  });
+
+  it("treats other thrown errors as http-kind so the message surfaces verbatim", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const result = await probeFhirServer(baseServer, { fetchImpl });
+    expect(result).toEqual({ ok: false, kind: "http", message: "boom" });
+  });
+});

--- a/apps/demo/src/serverProbe.ts
+++ b/apps/demo/src/serverProbe.ts
@@ -1,0 +1,62 @@
+import type { CapabilityStatement } from "fhir/r4";
+import { type ServerConfig, buildRequestHeaders } from "./config.js";
+
+export type ProbeResult =
+  | { ok: true; software?: string; fhirVersion?: string }
+  | { ok: false; kind: "http" | "network"; message: string };
+
+export interface ProbeOptions {
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Hit `${baseUrl}/metadata` with the server's auth/custom headers and report
+ * back a tiny summary (software name, FHIR version) or a typed error. Keeps
+ * the SettingsPage UI dumb and lets us cover the success / HTTP / CORS /
+ * network paths in a node test environment without jsdom.
+ */
+export async function probeFhirServer(
+  server: ServerConfig,
+  options: ProbeOptions = {},
+): Promise<ProbeResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = `${server.baseUrl.replace(/\/+$/, "")}/metadata`;
+  const headers: Record<string, string> = {
+    Accept: "application/fhir+json",
+    ...buildRequestHeaders(server),
+  };
+
+  let res: Response;
+  try {
+    res = await fetchImpl(url, { headers });
+  } catch (err) {
+    // Browsers surface CORS and offline as `TypeError: Failed to fetch`. The
+    // hint nudges users toward the real fix (proxy / CORS-enabled host)
+    // instead of having them stare at a generic message.
+    const message = err instanceof Error ? err.message : String(err);
+    const isNetwork =
+      err instanceof TypeError || /failed to fetch|networkerror/i.test(message);
+    return {
+      ok: false,
+      kind: isNetwork ? "network" : "http",
+      message: isNetwork
+        ? `${message} — likely a CORS or network issue. Check the browser console for details.`
+        : message,
+    };
+  }
+
+  if (!res.ok) {
+    return {
+      ok: false,
+      kind: "http",
+      message: `HTTP ${res.status} ${res.statusText}`,
+    };
+  }
+
+  const cs = (await res.json()) as CapabilityStatement;
+  return {
+    ok: true,
+    ...(cs.software?.name ? { software: cs.software.name } : {}),
+    ...(cs.fhirVersion ? { fhirVersion: cs.fhirVersion } : {}),
+  };
+}


### PR DESCRIPTION
Lets visitors switch the live demo between known public FHIR R4 servers
(HAPI + SMART Health IT) without rebuilding, demonstrating that the
spec-driven UI is server-agnostic. Selection persists in localStorage
and is applied via a page reload so the singleton FetchFhirClient
rebuilds against the new base URL. HAPI remains the default; the picker
is hidden in mock mode and when VITE_FHIR_BASE_URL is set.

https://claude.ai/code/session_01X5BEXx7fNUQ1VuLTPaJVRo