### PR TITLE
docs(readme): cross-link newly-filed roadmap issues into Tracked

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The rest of this README is about the library.
 
 ---
 
-A React component library for building FHIR resource viewers and editors driven by the FHIR specification itself (`StructureDefinition`, `SearchParameter`, `CapabilityStatement`). Minimal resource-specific code — everything derives from the spec's own metadata, so the library works natively against any FHIR REST API.
+**Backend-agnostic, spec-driven React for any FHIR REST API.** A React component library for building FHIR resource viewers and editors driven by the FHIR specification itself (`StructureDefinition`, `SearchParameter`, `CapabilityStatement`). Minimal resource-specific code — everything derives from the spec's own metadata, so the library works natively against any FHIR REST API.
 
 **Live demo:** <https://samsuffolksperoni.github.io/fhir-place/> — hits the **public HAPI R4 server**. Patient data there is shared and reset periodically; creates / edits you make are visible to everyone (and won't last forever). Local `pnpm dev` uses an in-browser MSW mock by default so you can work offline.
 
@@ -240,6 +240,13 @@ Comment / upvote if one of these is blocking you — or pick one up; each issue 
 | [#6](https://github.com/samsuffolksperoni/fhir-place/issues/6) | Generic `<ResourceTable>` with column picker | We ship `<ResourceView>` (detail) and `<ResourceSearch>` (filter form) but no list/table component. |
 | [#7](https://github.com/samsuffolksperoni/fhir-place/issues/7) | Pagination via `Bundle.link[rel=next]` in `useSearch` | `useSearch` returns one Bundle; browsing more than `_count` matches needs `useInfiniteSearch`. |
 | [#11](https://github.com/samsuffolksperoni/fhir-place/issues/11) | Auto-populate `<ResourceSearch>` token fields from their ValueSet binding | Search by `gender` should be a dropdown of `male / female / other / unknown`, not a free-text field. Builds on #4. |
+| [#121](https://github.com/samsuffolksperoni/fhir-place/issues/121) | Typed search builder v0 — core API | `client.search('Patient', params)` is loosely typed today; chained search, `_include`, `_revinclude`, and `_has` lose type info. ADR [0004](docs/decisions/0004-positioning.md) commits to the "tRPC-of-FHIR" wedge. |
+| [#122](https://github.com/samsuffolksperoni/fhir-place/issues/122) | Typed search builder — hook + demo example | Wires the builder into `useTypedSearch` and a demo page so the DX win is visible in real React usage. Builds on #121. |
+| [#123](https://github.com/samsuffolksperoni/fhir-place/issues/123) | Profile-aware codegen spike (US Core 7 seed) | `@types/fhir` is broad; `value[x]` collapses to `any` and profile constraints aren't reflected. Spike learns the codegen pipeline shape before committing to a stable API. |
+| [#124](https://github.com/samsuffolksperoni/fhir-place/issues/124) | Experimental Zod schema generation from `StructureDefinition` | LLM tool-use surfaces (Anthropic, OpenAI, Gemini, MCP) want JSON Schema or Zod. Feeds client-side validation and structured-output surfaces. |
+| [#125](https://github.com/samsuffolksperoni/fhir-place/issues/125) | Interop demo matrix (HAPI + Medplum + Aidbox) | "Backend-agnostic" is asserted but only proven against public HAPI today. ADR [0004](docs/decisions/0004-positioning.md) commits to demonstrable proof across backends. |
+| [#127](https://github.com/samsuffolksperoni/fhir-place/issues/127) | Inferno (g)(10) CI badge | Inferno-passing demos against real EHR sandboxes are the highest-trust signal in healthcare OSS. Fits the existing nightly `integration.yml` pattern. |
+| [#128](https://github.com/samsuffolksperoni/fhir-place/issues/128) | Optional `@fhir-place/mcp` package | Wraps an arbitrary FHIR base URL + token as MCP tools. Existing MCP offerings (Aidbox, WSO2, Momentum) are server-bound; this is the client-side, BYO-server angle. |
 
 ### Deferred (open an issue if you need it)
 
@@ -250,12 +257,6 @@ These will become issues once a concrete use case surfaces — premature issues 
 - **SMART on FHIR v2 auth.** Deferred. Bearer-token auth works via `FhirClient.getHeaders`; launch flows need a dedicated adapter (peer-dep on [`fhirclient`](https://github.com/smart-on-fhir/client-js) rather than reimplementing the OAuth dance).
 - **R4B / R5.** R4 only for v1. The `FhirClient` interface will grow a `fhirVersion` discriminator for version-specific code.
 - **Subscriptions / realtime.** Out of scope; poll with TanStack Query's `refetchInterval` for now.
-- **Typed search builder.** `useSearch('Patient').where(...).include(...)` with chained-search and `_revinclude` narrowing. Covered by ADR [0004](docs/decisions/0004-positioning.md).
-- **Profile-aware codegen.** `npx fhir-place gen --ig hl7.fhir.us.core@7.0.0` produces typed components + Zod schemas. Lead-in is the "Profile support" item above.
-- **Zod schemas from `StructureDefinition`.** Feeds both client-side validation and `tool_use` / structured-output surfaces for LLM consumers.
-- **Optional `@fhir-place/mcp` package.** Wraps an arbitrary FHIR base URL + token as MCP tools. Library-side only; the workbench's Phase A constraint against an MCP server still holds.
-- **Inferno (g)(10) CI badge.** Run the [Inferno ONC](https://inferno.healthit.gov/) test kit nightly against Medplum + HAPI public sandboxes; publish badge. Fits the existing `integration.yml` pattern.
-- **Interop demo matrix.** `apps/demo` runnable against Medplum + Aidbox + HAPI with documented per-backend caveats. Epic / Cerner registration friction means those stay out of the matrix.
 
 PRs welcome on any tracked item. For a deferred item: open an issue describing your use case and we can prioritise.
 

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -16,7 +16,7 @@ export function App() {
               fhir-place
             </Link>
             <span className="ml-2 text-sm text-slate-500">
-              spec-driven FHIR viewer
+              backend-agnostic, spec-driven React for any FHIR REST API
             </span>
           </div>
           <div className="text-xs text-slate-500" data-testid="base-url">


### PR DESCRIPTION
Closes #126.

- Move typed search builder (#121, #122), profile-aware codegen
  spike (#123), Zod-from-SD (#124), interop matrix (#125), Inferno
  badge (#127), and `@fhir-place/mcp` (#128) from Deferred to Tracked.
- Drop the matching bullets from Deferred so no item is listed twice.
- Add the ADR 0004 wedge sentence to the README intro and reuse it
  as the apps/demo header subtitle.