### PR TITLE
Auto-file issues for failed integration tests and rename live-monitor issues to [demo]

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: integration-${{ github.ref }}
@@ -38,7 +39,81 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @fhir-place/react-fhir build
       - name: Run integration suite against live FHIR server
+        id: integration
         env:
           FHIR_BASE_URL: ${{ inputs.fhir_base_url || 'https://hapi.fhir.org/baseR4' }}
           SKIP_IF_UNREACHABLE: "1"
-        run: pnpm --filter @fhir-place/react-fhir test:integration
+        run: pnpm --filter @fhir-place/react-fhir exec vitest run --config vitest.integration.config.ts --reporter=default --reporter=json --outputFile=test-results/integration-results.json
+        continue-on-error: true
+
+      - name: File / update GitHub issues for failed integration tests
+        if: steps.integration.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const resultsPath = path.join(
+              process.env.GITHUB_WORKSPACE,
+              'packages/react-fhir/test-results/integration-results.json',
+            );
+            if (!fs.existsSync(resultsPath)) {
+              core.warning('No integration-results.json — Vitest crashed before writing results.');
+              return;
+            }
+            const report = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+            const failed = (report.testResults ?? []).filter((t) => t.status === 'failed');
+            if (failed.length === 0) {
+              core.info('Workflow failed but no failed tests found in JSON. Skipping issue creation.');
+              return;
+            }
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            for (const t of failed) {
+              const testName = t.assertionResults?.find((a) => a.status === 'failed')?.fullName ?? t.name ?? t.message ?? 'integration failure';
+              const issueTitle = `[react-fhir] ${testName}`;
+              const failureText = (t.message || t.assertionResults?.find((a) => a.status === 'failed')?.failureMessages?.join('\n\n') || '(no error captured)').slice(0, 4000);
+              const body = [
+                `**Failed in run:** ${runUrl}`,
+                `**Suite:** \`${t.name || 'unknown suite'}\``,
+                `**Source:** \`${t.name || 'unknown test'}\``,
+                '',
+                '**Error:**',
+                '```',
+                failureText,
+                '```',
+                '',
+                '_This issue was opened automatically by `.github/workflows/integration.yml`._',
+              ].join('\n');
+
+              const existing = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${issueTitle}"`,
+                per_page: 5,
+              });
+              const match = existing.data.items.find((i) => i.title === issueTitle);
+
+              if (match) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: match.number,
+                  body: `Failed again in ${runUrl}
+
+\`\`\`
+${failureText}
+\`\`\``,
+                });
+              } else {
+                await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: issueTitle,
+                  body,
+                  labels: ['bug', 'react-fhir', 'integration'],
+                });
+              }
+            }
+
+      - name: Fail the job if integration tests failed
+        if: steps.integration.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/live-site-monitor.yml
+++ b/.github/workflows/live-site-monitor.yml
@@ -111,7 +111,7 @@ jobs:
             }
 
             for (const g of grouped.values()) {
-              const issueTitle = `[live-monitor] ${g.title}`;
+              const issueTitle = `[demo] ${g.title}`;
               const body = [
                 `**Failed in run:** ${runUrl}`,
                 `**Affected projects:** ${g.projects.join(', ')}`,

--- a/apps/demo/e2e-live/smoke.spec.ts
+++ b/apps/demo/e2e-live/smoke.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from "@playwright/test";
  * Live-site smoke tests. Run nightly by `.github/workflows/live-site-monitor.yml`
  * against the deployed demo, hitting real HAPI. Failures auto-file GitHub
  * issues — keep test names short and stable so the dedupe logic
- * (`[live-monitor] <test name>`) works.
+ * (`[demo] <test name>`) works.
  *
  * Tests should be data-shape tolerant — HAPI is a shared public server, the
  * specific patients there change. Assert structure and behavior, not literal


### PR DESCRIPTION
### Motivation

- Automatically surface and track failing nightly integration tests by opening or updating GitHub issues when runs against live HAPI fail. 
- Allow the integration step to report results without immediately stopping the workflow so that failure metadata can be collected and processed. 
- Standardize issue titles for the demo site monitor by changing the prefix used for deduplication.

### Description

- Added `issues: write` permission to `.github/workflows/integration.yml` and changed the integration run to `pnpm --filter @fhir-place/react-fhir exec vitest run --config vitest.integration.config.ts --reporter=default --reporter=json --outputFile=test-results/integration-results.json` with `continue-on-error: true` and step `id: integration`.
- Added a step using `actions/github-script@v7` to parse `packages/react-fhir/test-results/integration-results.json` and open or comment on issues for each failed test, and a final step to fail the job if integration tests failed.
- Updated `.github/workflows/live-site-monitor.yml` to change the issue title prefix from `[live-monitor]` to `[demo]` for deduplication, and updated the comment in `apps/demo/e2e-live/smoke.spec.ts` to reflect the new prefix.

### Testing

- No automated test runs were performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51432595c8333ae05bfff8f36c8e2)