### PR TITLE
demo: show generated FHIR search HTTP request under the form

### DIFF
--- a/apps/demo/src/components/SearchRequestPreview.tsx
+++ b/apps/demo/src/components/SearchRequestPreview.tsx
@@ -1,0 +1,118 @@
+import { formatSearchRequest, type SearchParams } from "@fhir-place/react-fhir";
+import { useState } from "react";
+
+export interface SearchRequestPreviewProps {
+  baseUrl: string;
+  resourceType: string;
+  params: SearchParams;
+  /** Whether the panel starts open. Defaults to false. */
+  defaultOpen?: boolean;
+}
+
+/**
+ * Shows the GET request the FHIR client will send for the given form state:
+ * the full URL plus a name/value table of the query parameters. Read-only —
+ * round-tripping URL → form is a separate concern.
+ */
+export function SearchRequestPreview({
+  baseUrl,
+  resourceType,
+  params,
+  defaultOpen = false,
+}: SearchRequestPreviewProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  const [copied, setCopied] = useState(false);
+  const preview = formatSearchRequest(baseUrl, resourceType, params);
+
+  const copyUrl = async () => {
+    try {
+      await navigator.clipboard.writeText(preview.url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard blocked (insecure context, permission denied) — silently
+      // ignore; the URL is still selectable in the displayed code block.
+    }
+  };
+
+  return (
+    <details
+      className="rounded border border-slate-200 bg-white text-sm"
+      open={open}
+      onToggle={(e) => setOpen((e.target as HTMLDetailsElement).open)}
+      data-testid="request-preview"
+    >
+      <summary className="cursor-pointer select-none px-3 py-2 text-slate-600 hover:bg-slate-50">
+        <span className="font-medium text-slate-700">HTTP request</span>
+        <span className="ml-2 text-xs text-slate-400">
+          GET · {preview.params.length} param
+          {preview.params.length === 1 ? "" : "s"}
+        </span>
+      </summary>
+      <div className="space-y-3 border-t border-slate-200 px-3 py-3">
+        <div>
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <span className="text-xs font-medium uppercase tracking-wide text-slate-500">
+              URL
+            </span>
+            <button
+              type="button"
+              onClick={copyUrl}
+              className="rounded border border-slate-300 bg-white px-2 py-0.5 text-xs text-slate-600 hover:bg-slate-50"
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+          <code
+            data-testid="request-preview-url"
+            className="block break-all rounded bg-slate-50 px-2 py-1.5 font-mono text-xs text-slate-800"
+          >
+            <span className="text-slate-500">GET </span>
+            {preview.url}
+          </code>
+        </div>
+
+        <div>
+          <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-slate-500">
+            Query parameters
+          </span>
+          {preview.params.length === 0 ? (
+            <p className="text-xs text-slate-500">
+              No parameters yet — start typing in the form above.
+            </p>
+          ) : (
+            <table className="w-full table-fixed border-collapse text-xs">
+              <thead>
+                <tr className="text-left text-slate-500">
+                  <th className="w-1/3 border-b border-slate-200 py-1 pr-2 font-medium">
+                    Name
+                  </th>
+                  <th className="border-b border-slate-200 py-1 font-medium">
+                    Value
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="font-mono">
+                {preview.params.map(([name, value], i) => (
+                  <tr key={`${name}-${i}`} className="align-top">
+                    <td className="border-b border-slate-100 py-1 pr-2 text-slate-700">
+                      {name}
+                    </td>
+                    <td className="break-all border-b border-slate-100 py-1 text-slate-800">
+                      {value}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <div className="text-[11px] text-slate-400">
+          Headers: <span className="font-mono">Accept: application/fhir+json</span>
+          {" "}(plus any auth/custom headers configured for the active server)
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/apps/demo/src/pages/PatientListPage.tsx
+++ b/apps/demo/src/pages/PatientListPage.tsx
@@ -2,6 +2,7 @@ import {
   ColumnPicker,
   ResourceSearch,
   ResourceTable,
+  useFhirClient,
   useInfiniteSearch,
 } from "@fhir-place/react-fhir";
 import type { Patient } from "fhir/r4";
@@ -9,6 +10,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import type { SearchParams } from "@fhir-place/react-fhir";
 import { PatientRowCounts } from "../components/PatientRowCounts.js";
+import { SearchRequestPreview } from "../components/SearchRequestPreview.js";
 
 const formatName = (p: Patient): string => {
   const n = p.name?.[0];
@@ -82,12 +84,17 @@ export function PatientListPage() {
     () => DEFAULT_VISIBLE_COLUMNS,
   );
   const navigate = useNavigate();
+  const client = useFhirClient();
 
   // Derive search params from the URL so reload / share-link / browser back
   // all replay the same query. `_count` is paging metadata; we keep it out of
   // the URL so users see clean shareable links (`?name=hop`, not
   // `?name=hop&_count=20`).
   const params = useMemo(() => paramsFromUrl(searchParams), [searchParams]);
+  // Live form state, used by the request-preview panel so the URL updates as
+  // the user types (independent of pressing Search / committing to the URL).
+  const [draftParams, setDraftParams] = useState<SearchParams>(params);
+  useEffect(() => setDraftParams(params), [params]);
   // Snapshot the URL state for the form's `initialParams` — re-read whenever
   // the URL changes (e.g. browser back) so the form mirrors what's filtered.
   const formInitial = useMemo(
@@ -161,7 +168,14 @@ export function PatientListPage() {
         initialVisible={6}
         initialParams={formInitial}
         priorityParams={["name", "family", "given", "gender", "birthdate", "address-city"]}
+        onChange={(p) => setDraftParams({ _count: PAGE_SIZE, ...p })}
         onSubmit={submitFilters}
+      />
+
+      <SearchRequestPreview
+        baseUrl={client.baseUrl}
+        resourceType="Patient"
+        params={draftParams}
       />
 
       <div className="flex items-center justify-between gap-2">

--- a/apps/demo/src/pages/ResourceIndexPage.tsx
+++ b/apps/demo/src/pages/ResourceIndexPage.tsx
@@ -2,6 +2,7 @@ import {
   ColumnPicker,
   ResourceSearch,
   ResourceTable,
+  useFhirClient,
   useInfiniteSearch,
   useStructureDefinition,
 } from "@fhir-place/react-fhir";
@@ -10,6 +11,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import type { SearchParams } from "@fhir-place/react-fhir";
 import { PATIENT_COMPARTMENT } from "../compartment.js";
+import { SearchRequestPreview } from "../components/SearchRequestPreview.js";
 
 const columnLabelFromPath = (path: string): string => {
   const last = path.split(".").pop() ?? path;
@@ -63,12 +65,16 @@ export function ResourceIndexPage() {
   const { resourceType = "" } = useParams();
   const [query] = useSearchParams();
   const navigate = useNavigate();
+  const client = useFhirClient();
   const patientId = query.get("patient") ?? undefined;
 
   const [params, setParams] = useState<SearchParams>({
     _count: 20,
     ...(patientId ? { patient: patientId } : {}),
   });
+  // Live form state for the request-preview panel — updates as the user
+  // types, independent of when the search is actually submitted.
+  const [draftParams, setDraftParams] = useState<SearchParams>(params);
 
   const {
     data,
@@ -179,9 +185,18 @@ export function ResourceIndexPage() {
       <ResourceSearch
         resourceType={resourceType}
         initialVisible={6}
+        onChange={(p) =>
+          setDraftParams({ _count: 20, ...(patientId ? { patient: patientId } : {}), ...p })
+        }
         onSubmit={(p) =>
           setParams({ _count: 20, ...(patientId ? { patient: patientId } : {}), ...p })
         }
+      />
+
+      <SearchRequestPreview
+        baseUrl={client.baseUrl}
+        resourceType={resourceType}
+        params={draftParams}
       />
 
       <div className="flex justify-end">

--- a/packages/react-fhir/src/client/index.ts
+++ b/packages/react-fhir/src/client/index.ts
@@ -1,4 +1,5 @@
 export * from "./types.js";
 export * from "./searchParams.js";
 export * from "./searchBuilder.js";
+export * from "./requestPreview.js";
 export * from "./FetchFhirClient.js";

--- a/packages/react-fhir/src/client/requestPreview.test.ts
+++ b/packages/react-fhir/src/client/requestPreview.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { formatSearchRequest } from "./requestPreview.js";
+
+describe("formatSearchRequest", () => {
+  it("returns the bare resource path when no params are passed", () => {
+    const r = formatSearchRequest("https://fhir.example/r4", "Patient");
+    expect(r).toEqual({
+      method: "GET",
+      url: "https://fhir.example/r4/Patient",
+      path: "/Patient",
+      queryString: "",
+      params: [],
+    });
+  });
+
+  it("appends a query string when params are present", () => {
+    const r = formatSearchRequest("https://fhir.example/r4", "Patient", {
+      name: "smith",
+      _count: 20,
+    });
+    expect(r.url).toBe("https://fhir.example/r4/Patient?name=smith&_count=20");
+    expect(r.queryString).toBe("name=smith&_count=20");
+    expect(r.params).toEqual([
+      ["name", "smith"],
+      ["_count", "20"],
+    ]);
+  });
+
+  it("strips trailing slashes on the base URL", () => {
+    const r = formatSearchRequest("https://fhir.example/r4//", "Patient", {
+      name: "a",
+    });
+    expect(r.url).toBe("https://fhir.example/r4/Patient?name=a");
+  });
+
+  it("emits arrays as repeated keys (AND semantics)", () => {
+    const r = formatSearchRequest("https://x", "Patient", {
+      identifier: ["a", "b"],
+    });
+    expect(r.queryString).toBe("identifier=a&identifier=b");
+    expect(r.params).toEqual([
+      ["identifier", "a"],
+      ["identifier", "b"],
+    ]);
+  });
+
+  it("preserves FHIR prefix operators on date params", () => {
+    const r = formatSearchRequest("https://x", "Observation", {
+      date: "ge2024-01-01",
+    });
+    expect(r.queryString).toBe("date=ge2024-01-01");
+  });
+});

--- a/packages/react-fhir/src/client/requestPreview.ts
+++ b/packages/react-fhir/src/client/requestPreview.ts
@@ -1,0 +1,38 @@
+import { buildSearchParams } from "./searchParams.js";
+import type { SearchParams } from "./types.js";
+
+export interface SearchRequestPreview {
+  method: "GET";
+  /** Full request URL: base + path + query string. */
+  url: string;
+  /** Path portion the client appends to the base URL. */
+  path: string;
+  /** Query string without the leading `?`. */
+  queryString: string;
+  /** Ordered key/value pairs as they would appear on the wire. */
+  params: Array<[string, string]>;
+}
+
+const trimSlash = (s: string): string => s.replace(/\/+$/, "");
+
+/**
+ * Returns the GET request that `FhirClient.search(type, params)` would issue,
+ * without sending it. Useful for devtools / docs / agent prompts where you
+ * want to surface the URL the user's form is generating.
+ */
+export function formatSearchRequest(
+  baseUrl: string,
+  resourceType: string,
+  params?: SearchParams,
+): SearchRequestPreview {
+  const qs = buildSearchParams(params);
+  const queryString = qs.toString();
+  const path = `/${resourceType}${queryString ? `?${queryString}` : ""}`;
+  return {
+    method: "GET",
+    url: `${trimSlash(baseUrl)}${path}`,
+    path,
+    queryString,
+    params: Array.from(qs.entries()),
+  };
+}


### PR DESCRIPTION
Adds a `formatSearchRequest(baseUrl, type, params)` helper to
@fhir-place/react-fhir/client that returns the GET URL/path/query a
`FhirClient.search` call would issue, so consumers (devtools, docs,
agent prompts) can surface the request without sending it.

Wires a collapsible <SearchRequestPreview> panel under <ResourceSearch>
on the patient list and generic resource index pages — updates live as
the user types, with copy-URL action and a name/value parameter table.

https://claude.ai/code/session_012wnmhRvhkVV1cNEZZ6PyvH