### PR TITLE
feat(demo): cql-runner UI — paste, run against FHIR, render results well

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -18,6 +18,8 @@
     "@anthropic-ai/sdk": "^0.65.0",
     "@fhir-place/react-fhir": "workspace:*",
     "@tanstack/react-query": "^5.62.0",
+    "cql-execution": "^3.3.0",
+    "cql-exec-fhir": "^2.1.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.0.0"

--- a/apps/demo/src/routes/cql-runner/CqlRunner.tsx
+++ b/apps/demo/src/routes/cql-runner/CqlRunner.tsx
@@ -1,0 +1,124 @@
+import { useMemo, useState } from "react";
+import { useFhirClient } from "@fhir-place/react-fhir";
+import { CQL_EXAMPLES } from "./examples.js";
+import { ErrorPanel } from "./errors/ErrorPanel.js";
+import { PatientContextPicker } from "./PatientContextPicker.js";
+import { CqlResult } from "./results/CqlResult.js";
+import { runCql, type RunFailure, type RunOutcome } from "./runCql.js";
+
+export function CqlRunner() {
+  const client = useFhirClient();
+  const [cql, setCql] = useState<string>(CQL_EXAMPLES[0]!.cql);
+  const [patientId, setPatientId] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+  const [outcome, setOutcome] = useState<RunOutcome | null>(null);
+  const [failure, setFailure] = useState<RunFailure | null>(null);
+
+  const canRun = useMemo(
+    () => Boolean(cql.trim()) && Boolean(patientId) && !running,
+    [cql, patientId, running],
+  );
+
+  const handleRun = async () => {
+    if (!patientId) return;
+    setRunning(true);
+    setFailure(null);
+    setOutcome(null);
+    try {
+      const result = await runCql({ cql, client, patientId });
+      if (result.ok) setOutcome(result.outcome);
+      else setFailure(result.failure);
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const handleLoadExample = (id: string) => {
+    const ex = CQL_EXAMPLES.find((e) => e.id === id);
+    if (ex) {
+      setCql(ex.cql);
+      setOutcome(null);
+      setFailure(null);
+    }
+  };
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[260px_minmax(0,1fr)]">
+      <aside className="space-y-4">
+        <PatientContextPicker
+          selectedPatientId={patientId}
+          onSelect={setPatientId}
+        />
+        <div className="space-y-1">
+          <label className="block text-sm font-medium text-slate-700">
+            Load example
+          </label>
+          <select
+            className="w-full rounded border border-slate-300 px-2 py-1 text-sm"
+            onChange={(e) => handleLoadExample(e.target.value)}
+            data-testid="cql-example-picker"
+            defaultValue=""
+          >
+            <option value="" disabled>
+              Choose…
+            </option>
+            {CQL_EXAMPLES.map((ex) => (
+              <option key={ex.id} value={ex.id}>
+                {ex.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </aside>
+      <div className="space-y-4">
+        <div className="space-y-1">
+          <label className="block text-sm font-medium text-slate-700">CQL</label>
+          <textarea
+            value={cql}
+            onChange={(e) => setCql(e.target.value)}
+            className="h-64 w-full rounded border border-slate-300 p-2 font-mono text-xs"
+            spellCheck={false}
+            data-testid="cql-source"
+          />
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={handleRun}
+            disabled={!canRun}
+            className="rounded bg-slate-900 px-4 py-1.5 text-sm font-medium text-white disabled:bg-slate-300"
+            data-testid="cql-run"
+          >
+            {running ? "Running…" : "Run"}
+          </button>
+          {!patientId && (
+            <span className="text-xs text-slate-500">
+              Pick a patient to scope the run.
+            </span>
+          )}
+        </div>
+        <ErrorPanel
+          translation={failure?.kind === "translation" ? failure.errors : undefined}
+          execution={failure?.kind === "execution" ? failure.error : null}
+          fhir={failure?.kind === "fhir" ? failure.error : undefined}
+        />
+        {outcome && (
+          <div className="space-y-3" data-testid="cql-results">
+            {Object.entries(outcome.values)
+              // ELM emits a synthetic "Patient" expression name from the
+              // `context Patient` line; surfacing it adds noise without value.
+              .filter(([name]) => name !== "Patient")
+              .map(([name, value]) => (
+                <CqlResult key={name} name={name} value={value} />
+              ))}
+            {Object.keys(outcome.values).length === 0 && (
+              <p className="text-sm text-slate-500">
+                Run produced no expression results.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/demo/src/routes/cql-runner/CqlRunnerPage.tsx
+++ b/apps/demo/src/routes/cql-runner/CqlRunnerPage.tsx
@@ -1,8 +1,17 @@
+import { CqlRunner } from "./CqlRunner.js";
+
 export function CqlRunnerPage() {
   return (
-    <section className="space-y-2" data-testid="cql-runner-placeholder">
-      <h1 className="text-2xl font-semibold text-slate-900">CQL Runner</h1>
-      <p className="text-sm text-slate-600">Coming soon.</p>
+    <section className="space-y-4">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold text-slate-900">CQL Runner</h1>
+        <p className="text-sm text-slate-600">
+          Paste CQL, run it against the active FHIR server, and view rendered
+          results. Translation runs in a small Java service; ELM is executed in
+          the browser.
+        </p>
+      </header>
+      <CqlRunner />
     </section>
   );
 }

--- a/apps/demo/src/routes/cql-runner/PatientContextPicker.tsx
+++ b/apps/demo/src/routes/cql-runner/PatientContextPicker.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import type { Patient } from "fhir/r4";
+import { useSearch } from "@fhir-place/react-fhir";
+
+/**
+ * Minimal patient picker for the runner: type-to-search by name, click to
+ * select. No need for the full PatientListPage feature set here — the runner
+ * just needs an id to scope the CQL execution to.
+ */
+export interface PatientContextPickerProps {
+  selectedPatientId: string | null;
+  onSelect: (id: string | null) => void;
+}
+
+const formatName = (p: Patient): string => {
+  const n = p.name?.[0];
+  if (!n) return p.id ?? "(no name)";
+  const given = (n.given ?? []).join(" ");
+  return `${given} ${n.family ?? ""}`.trim() || p.id || "(no name)";
+};
+
+export function PatientContextPicker({
+  selectedPatientId,
+  onSelect,
+}: PatientContextPickerProps) {
+  const [query, setQuery] = useState("");
+  const params = query.trim() ? { name: query.trim(), _count: 10 } : { _count: 10 };
+  const search = useSearch<Patient>("Patient", params);
+
+  const patients = (search.data?.entry ?? [])
+    .map((e) => e.resource)
+    .filter((r): r is Patient => !!r && r.resourceType === "Patient");
+
+  return (
+    <div className="space-y-2" data-testid="patient-context-picker">
+      <label className="block text-sm font-medium text-slate-700">
+        Patient context
+      </label>
+      <input
+        type="search"
+        placeholder="Search patients by name…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className="w-full rounded border border-slate-300 px-2 py-1 text-sm"
+      />
+      <div className="max-h-40 overflow-y-auto rounded border border-slate-200">
+        {search.isLoading && (
+          <p className="p-2 text-xs text-slate-500">Loading…</p>
+        )}
+        {search.error && (
+          <p className="p-2 text-xs text-red-700">
+            {(search.error as Error).message}
+          </p>
+        )}
+        {!search.isLoading && patients.length === 0 && (
+          <p className="p-2 text-xs text-slate-500">No matches.</p>
+        )}
+        <ul>
+          {patients.map((p) => {
+            const id = p.id!;
+            const selected = id === selectedPatientId;
+            return (
+              <li key={id}>
+                <button
+                  type="button"
+                  onClick={() => onSelect(selected ? null : id)}
+                  className={`block w-full px-2 py-1 text-left text-sm ${
+                    selected
+                      ? "bg-blue-50 text-blue-900"
+                      : "hover:bg-slate-50"
+                  }`}
+                  data-testid={`patient-option-${id}`}
+                >
+                  <span className="font-medium">{formatName(p)}</span>{" "}
+                  <span className="text-xs text-slate-500">{id}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+      {selectedPatientId && (
+        <p className="text-xs text-slate-600">
+          Selected: <span className="font-mono">{selectedPatientId}</span>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/demo/src/routes/cql-runner/errors/ErrorPanel.tsx
+++ b/apps/demo/src/routes/cql-runner/errors/ErrorPanel.tsx
@@ -1,0 +1,82 @@
+import { FhirError } from "@fhir-place/react-fhir";
+import type { TranslationError } from "../translator.js";
+
+export interface ErrorPanelProps {
+  translation?: TranslationError[];
+  execution?: Error | null;
+  fhir?: unknown;
+}
+
+const isFhirError = (e: unknown): e is FhirError => e instanceof FhirError;
+
+export function ErrorPanel({ translation, execution, fhir }: ErrorPanelProps) {
+  const hasTranslation = translation && translation.length > 0;
+  const hasExecution = !!execution;
+  const hasFhir = !!fhir;
+
+  if (!hasTranslation && !hasExecution && !hasFhir) return null;
+
+  return (
+    <div className="space-y-3" data-testid="cql-error-panel">
+      {hasTranslation && (
+        <Bucket title="Translator errors" tone="amber">
+          <ul className="space-y-1 text-sm">
+            {translation!.map((err, i) => (
+              <li key={i}>
+                {err.line != null && err.col != null && (
+                  <span className="mr-2 font-mono text-xs text-amber-700">
+                    {err.line}:{err.col}
+                  </span>
+                )}
+                {err.message}
+              </li>
+            ))}
+          </ul>
+        </Bucket>
+      )}
+      {hasExecution && (
+        <Bucket title="Execution error" tone="red">
+          <p className="font-mono text-xs">{execution!.message}</p>
+        </Bucket>
+      )}
+      {hasFhir && (
+        <Bucket title="FHIR fetch error" tone="red">
+          {isFhirError(fhir) ? (
+            <p className="text-sm">
+              <span className="font-mono text-xs">HTTP {fhir.status}</span>{" "}
+              {fhir.message}
+              <br />
+              <span className="font-mono text-[11px] text-slate-500">{fhir.url}</span>
+            </p>
+          ) : (
+            <p className="font-mono text-xs">
+              {fhir instanceof Error ? fhir.message : String(fhir)}
+            </p>
+          )}
+        </Bucket>
+      )}
+    </div>
+  );
+}
+
+const TONE: Record<"amber" | "red", string> = {
+  amber: "border-amber-300 bg-amber-50 text-amber-900",
+  red: "border-red-300 bg-red-50 text-red-900",
+};
+
+function Bucket({
+  title,
+  tone,
+  children,
+}: {
+  title: string;
+  tone: "amber" | "red";
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`rounded border px-3 py-2 ${TONE[tone]}`}>
+      <p className="text-xs font-semibold uppercase tracking-wide">{title}</p>
+      <div className="mt-1">{children}</div>
+    </div>
+  );
+}

--- a/apps/demo/src/routes/cql-runner/examples.ts
+++ b/apps/demo/src/routes/cql-runner/examples.ts
@@ -1,0 +1,70 @@
+/**
+ * Hand-picked CQL snippets, each chosen to exercise a different result shape
+ * in <CqlResult>. The set should stay small — five entries — so the dropdown
+ * remains scannable.
+ */
+export interface CqlExample {
+  id: string;
+  label: string;
+  description: string;
+  cql: string;
+}
+
+const HEADER = `library Demo version '1.0.0'
+using FHIR version '4.0.1'
+include FHIRHelpers version '4.0.1'
+
+context Patient
+`;
+
+export const CQL_EXAMPLES: ReadonlyArray<CqlExample> = [
+  {
+    id: "boolean",
+    label: "Boolean — has any condition",
+    description: "Renders as a pass/fail badge.",
+    cql: `${HEADER}
+define HasAnyCondition:
+  exists [Condition]
+`,
+  },
+  {
+    id: "list-resource",
+    label: "List of resources — observations",
+    description: "Renders via the FHIR ResourceTable.",
+    cql: `${HEADER}
+define AllObservations:
+  [Observation]
+`,
+  },
+  {
+    id: "tuple",
+    label: "Tuple — counts by type",
+    description: "Renders as a key/value table.",
+    cql: `${HEADER}
+define Counts:
+  Tuple {
+    Conditions: Count([Condition]),
+    Observations: Count([Observation]),
+    Encounters: Count([Encounter])
+  }
+`,
+  },
+  {
+    id: "interval",
+    label: "Interval — lifetime",
+    description: "Renders start/end with date formatting.",
+    cql: `${HEADER}
+define Lifetime:
+  Interval[Patient.birthDate, Today()]
+`,
+  },
+  {
+    id: "list-primitive",
+    label: "List of primitives — observation codes",
+    description: "Renders as a one-column table.",
+    cql: `${HEADER}
+define ObservationCodes:
+  [Observation] O return O.code.coding[0].code.value
+`,
+  },
+];

--- a/apps/demo/src/routes/cql-runner/fhirDataSource.test.ts
+++ b/apps/demo/src/routes/cql-runner/fhirDataSource.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import type { FhirClient } from "@fhir-place/react-fhir";
+import { buildFhirDataSource } from "./fhirDataSource.js";
+
+const fakeBundle = {
+  resourceType: "Bundle",
+  type: "searchset",
+  entry: [
+    { resource: { resourceType: "Patient", id: "p1" } },
+    { resource: { resourceType: "Observation", id: "o1" } },
+  ],
+};
+
+const stubClient = (overrides: Partial<FhirClient> = {}): FhirClient => ({
+  baseUrl: "http://fhir.local",
+  fhirVersion: "4.0",
+  capabilities: vi.fn(),
+  read: vi.fn(),
+  vread: vi.fn(),
+  history: vi.fn(),
+  search: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  readReference: vi.fn(),
+  request: vi.fn(),
+  ...overrides,
+});
+
+describe("buildFhirDataSource", () => {
+  it("calls $everything and feeds the bundle to cql-exec-fhir", async () => {
+    const request = vi.fn().mockResolvedValue(fakeBundle);
+    const client = stubClient({ request });
+
+    const built = await buildFhirDataSource({ client, patientId: "p1" });
+
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "Patient/p1/$everything", method: "GET" }),
+    );
+    expect(built.bundle).toBe(fakeBundle);
+    // Sanity-check that cql-exec-fhir loaded the patient.
+    const patient = built.source.currentPatient();
+    expect(patient).toBeDefined();
+  });
+
+  it("falls back to compartment search when $everything fails", async () => {
+    const request = vi.fn().mockRejectedValue(new Error("404"));
+    const read = vi.fn().mockResolvedValue({ resourceType: "Patient", id: "p1" });
+    const search = vi
+      .fn()
+      .mockResolvedValue({ resourceType: "Bundle", entry: [] });
+
+    const client = stubClient({ request, read, search });
+    const built = await buildFhirDataSource({ client, patientId: "p1" });
+
+    expect(read).toHaveBeenCalledWith("Patient", "p1", expect.any(Object));
+    expect(search).toHaveBeenCalled();
+    expect(built.bundle.entry?.[0]?.resource).toEqual({
+      resourceType: "Patient",
+      id: "p1",
+    });
+  });
+
+  it("URL-encodes the patient id", async () => {
+    const request = vi.fn().mockResolvedValue(fakeBundle);
+    const client = stubClient({ request });
+    await buildFhirDataSource({ client, patientId: "weird/id" });
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "Patient/weird%2Fid/$everything" }),
+    );
+  });
+});

--- a/apps/demo/src/routes/cql-runner/fhirDataSource.ts
+++ b/apps/demo/src/routes/cql-runner/fhirDataSource.ts
@@ -1,0 +1,109 @@
+import type { FhirClient } from "@fhir-place/react-fhir";
+import type { Bundle } from "fhir/r4";
+// `cql-exec-fhir` ships only loose .d.ts globals, no top-level type export.
+// The .js entry exposes PatientSource / FHIRWrapper as named exports; we
+// shape them as `any` here and wrap behind a typed surface below.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import * as cqlExecFhir from "cql-exec-fhir";
+
+/**
+ * Builds a `cql-execution`-compatible DataProvider for a single patient by
+ * fetching the patient's compartment from the active FHIR server up-front
+ * and feeding the resulting Bundle into `cql-exec-fhir`. Only the seam at
+ * the top of `runCql.ts` should know about cql-execution internals; this
+ * file is the only place that talks FHIR REST on behalf of CQL.
+ *
+ * Why pre-fetch instead of streaming retrieves: cql-execution's DataProvider
+ * is synchronous-ish (returns arrays from `findRecords`) and doesn't fit a
+ * REST-per-retrieve pattern. `$everything` is the standard FHIR way to grab
+ * a patient's compartment in one call, and HAPI / SMART both support it.
+ */
+
+export interface FhirDataSourceOptions {
+  client: FhirClient;
+  patientId: string;
+  signal?: AbortSignal;
+}
+
+export interface BuiltDataSource {
+  /** Pass directly to `Executor.exec()`. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  source: any;
+  /** The bundle that was loaded; useful for debugging in the UI. */
+  bundle: Bundle;
+}
+
+export async function buildFhirDataSource({
+  client,
+  patientId,
+  signal,
+}: FhirDataSourceOptions): Promise<BuiltDataSource> {
+  const bundle = await fetchPatientEverything(client, patientId, signal);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const factory = (cqlExecFhir as any).PatientSource ?? (cqlExecFhir as any).default?.PatientSource;
+  if (!factory || typeof factory.FHIRv401 !== "function") {
+    throw new Error(
+      "cql-exec-fhir is missing PatientSource.FHIRv401 — peer dep mismatch with cql-execution?",
+    );
+  }
+  const source = factory.FHIRv401();
+  source.loadBundles([bundle]);
+  return { source, bundle };
+}
+
+async function fetchPatientEverything(
+  client: FhirClient,
+  patientId: string,
+  signal?: AbortSignal,
+): Promise<Bundle> {
+  // $everything returns a searchset Bundle with the Patient + compartment
+  // resources. Some servers paginate; for Phase 1 a single page is enough —
+  // a "no $everything" or paginated server can layer pagination later.
+  try {
+    return await client.request<Bundle>({
+      path: `Patient/${encodeURIComponent(patientId)}/$everything`,
+      method: "GET",
+      signal,
+    });
+  } catch {
+    // Fall back to a Patient read + a small compartment search if the server
+    // doesn't expose $everything. Keeps the demo usable on minimal servers.
+    return fallbackCompartment(client, patientId, signal);
+  }
+}
+
+const FALLBACK_TYPES: ReadonlyArray<string> = [
+  "Condition",
+  "Observation",
+  "Encounter",
+  "MedicationRequest",
+  "AllergyIntolerance",
+  "Procedure",
+  "Immunization",
+];
+
+async function fallbackCompartment(
+  client: FhirClient,
+  patientId: string,
+  signal?: AbortSignal,
+): Promise<Bundle> {
+  const patient = await client.read("Patient", patientId, { signal });
+  const compartments = await Promise.all(
+    FALLBACK_TYPES.map((type) =>
+      client
+        .search(type, { patient: patientId }, { signal })
+        .then((b) => b.entry ?? [])
+        .catch(() => []),
+    ),
+  );
+  const entries = [
+    { resource: patient },
+    ...compartments.flat().filter((e) => e.resource),
+  ];
+  return {
+    resourceType: "Bundle",
+    type: "searchset",
+    entry: entries,
+  } as Bundle;
+}

--- a/apps/demo/src/routes/cql-runner/results/CqlResult.tsx
+++ b/apps/demo/src/routes/cql-runner/results/CqlResult.tsx
@@ -1,0 +1,264 @@
+import type { Resource } from "fhir/r4";
+import { ResourceTable } from "@fhir-place/react-fhir";
+import { inferShape, type CqlResultShape } from "./shape.js";
+
+export interface CqlResultProps {
+  name: string;
+  value: unknown;
+}
+
+/**
+ * Result renderer dispatcher. The wedge for the CQL runner is *good*
+ * rendering of CQL results — picking the right view per shape so users
+ * stop staring at JSON. Add new shapes here, not in caller components.
+ */
+export function CqlResult({ name, value }: CqlResultProps) {
+  const shape = inferShape(value);
+  return (
+    <section
+      className="space-y-2 rounded border border-slate-200 bg-white p-3"
+      data-testid={`cql-result-${name}`}
+      data-shape={shape}
+    >
+      <header className="flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold text-slate-900">{name}</h3>
+        <span className="font-mono text-[10px] uppercase tracking-wide text-slate-400">
+          {shape}
+        </span>
+      </header>
+      <Body value={value} shape={shape} />
+    </section>
+  );
+}
+
+function Body({ value, shape }: { value: unknown; shape: CqlResultShape }) {
+  switch (shape) {
+    case "null":
+      return <p className="text-sm text-slate-500">null</p>;
+    case "boolean":
+      return <BooleanBadge value={value as boolean} />;
+    case "number":
+    case "string":
+      return <p className="text-sm">{String(value)}</p>;
+    case "date":
+    case "datetime":
+      return <p className="text-sm font-mono">{formatDateLike(value)}</p>;
+    case "code":
+      return <CodeView value={value as Record<string, unknown>} />;
+    case "concept":
+      return <ConceptView value={value as { coding: unknown[]; text?: string }} />;
+    case "quantity":
+      return <QuantityView value={value as { value: number; unit?: string }} />;
+    case "interval":
+      return <IntervalView value={value as Record<string, unknown>} />;
+    case "tuple":
+      return <TupleView value={value as Record<string, unknown>} />;
+    case "list-empty":
+      return <p className="text-sm text-slate-500">(empty list)</p>;
+    case "list-resource":
+      return <ResourceListView value={value as Resource[]} />;
+    case "list-tuple":
+      return <TupleListView value={value as Array<Record<string, unknown>>} />;
+    case "list-primitive":
+      return <PrimitiveListView value={value as unknown[]} />;
+    case "resource":
+      return <ResourceListView value={[value as Resource]} />;
+    default:
+      return (
+        <div>
+          <p className="text-xs text-slate-500">No nice view yet — falling back to JSON.</p>
+          <pre className="mt-1 overflow-x-auto rounded bg-slate-50 p-2 text-xs">
+            {safeJson(value)}
+          </pre>
+        </div>
+      );
+  }
+}
+
+function BooleanBadge({ value }: { value: boolean }) {
+  return (
+    <span
+      className={`inline-block rounded px-3 py-1 text-sm font-semibold ${
+        value
+          ? "bg-emerald-100 text-emerald-900"
+          : "bg-rose-100 text-rose-900"
+      }`}
+    >
+      {value ? "PASS" : "FAIL"}
+    </span>
+  );
+}
+
+function CodeView({ value }: { value: Record<string, unknown> }) {
+  return (
+    <p className="text-sm font-mono">
+      {String(value.code)}
+      {value.system ? (
+        <span className="text-xs text-slate-500"> ({String(value.system)})</span>
+      ) : null}
+    </p>
+  );
+}
+
+function ConceptView({ value }: { value: { coding: unknown[]; text?: string } }) {
+  const first = (value.coding[0] ?? {}) as Record<string, unknown>;
+  return (
+    <div className="text-sm">
+      {value.text && <p>{String(value.text)}</p>}
+      <p className="font-mono text-xs text-slate-500">
+        {String(first.code ?? "")}
+        {first.system ? ` (${String(first.system)})` : ""}
+      </p>
+    </div>
+  );
+}
+
+function QuantityView({ value }: { value: { value: number; unit?: string } }) {
+  return (
+    <p className="text-sm">
+      {value.value}
+      {value.unit ? <span className="ml-1 text-slate-500">{value.unit}</span> : null}
+    </p>
+  );
+}
+
+function IntervalView({ value }: { value: Record<string, unknown> }) {
+  return (
+    <p className="text-sm font-mono">
+      [{formatDateLike(value.low) ?? "…"}, {formatDateLike(value.high) ?? "…"}]
+    </p>
+  );
+}
+
+function TupleView({ value }: { value: Record<string, unknown> }) {
+  const entries = Object.entries(value).filter(([k]) => !k.startsWith("_"));
+  if (entries.length === 0) return <p className="text-sm text-slate-500">(empty tuple)</p>;
+  return (
+    <table className="w-full text-sm">
+      <tbody>
+        {entries.map(([k, v]) => (
+          <tr key={k} className="border-t border-slate-100">
+            <td className="py-1 pr-4 font-medium text-slate-700">{k}</td>
+            <td className="py-1 font-mono text-xs">{formatScalar(v)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function ResourceListView({ value }: { value: Resource[] }) {
+  // `cql-execution` returns FHIRObject wrappers, not plain JSON; dig out the
+  // underlying resource if present so the existing ResourceTable can render.
+  const resources = value.map(unwrapFhirObject).filter((r): r is Resource => !!r);
+  if (resources.length === 0) return <p className="text-sm text-slate-500">(empty)</p>;
+  const type = resources[0]!.resourceType;
+  const columns = defaultColumnsFor(type);
+  return (
+    <div className="overflow-x-auto">
+      <ResourceTable resources={resources} columns={columns} />
+    </div>
+  );
+}
+
+function TupleListView({ value }: { value: Array<Record<string, unknown>> }) {
+  const columns = Array.from(
+    new Set(value.flatMap((row) => Object.keys(row).filter((k) => !k.startsWith("_")))),
+  );
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-slate-200 text-left text-xs uppercase tracking-wide text-slate-500">
+            {columns.map((c) => (
+              <th key={c} className="py-1 pr-4">
+                {c}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {value.map((row, i) => (
+            <tr key={i} className="border-t border-slate-100">
+              {columns.map((c) => (
+                <td key={c} className="py-1 pr-4 font-mono text-xs">
+                  {formatScalar(row[c])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function PrimitiveListView({ value }: { value: unknown[] }) {
+  return (
+    <table className="w-full text-sm">
+      <tbody>
+        {value.map((v, i) => (
+          <tr key={i} className="border-t border-slate-100">
+            <td className="py-1 font-mono text-xs">{formatScalar(v)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+const formatDateLike = (v: unknown): string | null => {
+  if (!v) return null;
+  if (typeof v === "string") return v;
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  if (typeof v === "object") {
+    const o = v as Record<string, unknown>;
+    if (typeof o.year === "number") {
+      const y = String(o.year).padStart(4, "0");
+      const m = typeof o.month === "number" ? String(o.month).padStart(2, "0") : "01";
+      const d = typeof o.day === "number" ? String(o.day).padStart(2, "0") : "01";
+      return `${y}-${m}-${d}`;
+    }
+  }
+  return null;
+};
+
+const formatScalar = (v: unknown): string => {
+  if (v === null || v === undefined) return "—";
+  if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") {
+    return String(v);
+  }
+  return safeJson(v);
+};
+
+const safeJson = (v: unknown): string => {
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const unwrapFhirObject = (v: any): Resource | null => {
+  if (!v) return null;
+  if (typeof v === "object" && typeof v.resourceType === "string") return v as Resource;
+  // cql-exec-fhir wraps each FHIR resource in a FHIRObject; the original JSON
+  // hangs off `_json`. Both shapes appear in real outputs depending on whether
+  // the CQL projects (`return X.foo`) or returns the raw retrieve.
+  if (typeof v === "object" && v._json && typeof v._json.resourceType === "string") {
+    return v._json as Resource;
+  }
+  return null;
+};
+
+const COLUMN_DEFAULTS: Record<string, string[]> = {
+  Patient: ["name", "gender", "birthDate"],
+  Observation: ["status", "code.text", "valueQuantity", "effectiveDateTime"],
+  Condition: ["code.text", "clinicalStatus", "onsetDateTime"],
+  Encounter: ["status", "type", "period.start"],
+  MedicationRequest: ["status", "medicationCodeableConcept.text", "authoredOn"],
+};
+
+const defaultColumnsFor = (type: string): string[] =>
+  COLUMN_DEFAULTS[type] ?? ["id"];

--- a/apps/demo/src/routes/cql-runner/results/shape.test.ts
+++ b/apps/demo/src/routes/cql-runner/results/shape.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { inferShape } from "./shape.js";
+
+describe("inferShape", () => {
+  it("classifies primitives", () => {
+    expect(inferShape(true)).toBe("boolean");
+    expect(inferShape(0)).toBe("number");
+    expect(inferShape("hi")).toBe("string");
+    expect(inferShape(null)).toBe("null");
+    expect(inferShape(undefined)).toBe("null");
+  });
+
+  it("classifies CQL Date / DateTime", () => {
+    expect(inferShape({ isDate: true, year: 2024, month: 1, day: 1 })).toBe("date");
+    expect(inferShape({ isDateTime: true, year: 2024, month: 1, day: 1 })).toBe("datetime");
+  });
+
+  it("classifies Quantity / Code / Concept / Interval", () => {
+    expect(inferShape({ value: 10, unit: "mg" })).toBe("quantity");
+    expect(inferShape({ code: "abc", system: "http://x" })).toBe("code");
+    expect(inferShape({ coding: [{ code: "x", system: "http://x" }], text: "X" })).toBe(
+      "concept",
+    );
+    expect(
+      inferShape({ low: { isDate: true, year: 2020 }, high: null, lowClosed: true }),
+    ).toBe("interval");
+  });
+
+  it("classifies tuples vs FHIR resources", () => {
+    expect(inferShape({ a: 1, b: 2 })).toBe("tuple");
+    expect(inferShape({ resourceType: "Patient", id: "1" })).toBe("resource");
+  });
+
+  it("classifies list shapes", () => {
+    expect(inferShape([])).toBe("list-empty");
+    expect(inferShape([1, 2, 3])).toBe("list-primitive");
+    expect(inferShape([{ resourceType: "Observation" }])).toBe("list-resource");
+    expect(inferShape([{ a: 1 }, { a: 2 }])).toBe("list-tuple");
+  });
+
+  it("falls back to unknown for opaque shapes", () => {
+    class Box {}
+    expect(inferShape(new Box())).toBe("tuple");
+    expect(inferShape(Symbol("x") as unknown)).toBe("unknown");
+  });
+});

--- a/apps/demo/src/routes/cql-runner/results/shape.ts
+++ b/apps/demo/src/routes/cql-runner/results/shape.ts
@@ -1,0 +1,86 @@
+/**
+ * Lightweight shape inference over a CQL evaluation result so <CqlResult>
+ * can pick a renderer. CQL values can be primitives, arrays, plain objects
+ * (Tuples), Intervals, Code/Concept, or FHIR resources — and `cql-execution`
+ * returns a mix of class instances and plain objects, so duck-type rather
+ * than `instanceof`-test.
+ */
+
+export type CqlResultShape =
+  | "boolean"
+  | "number"
+  | "string"
+  | "date"
+  | "datetime"
+  | "code"
+  | "concept"
+  | "quantity"
+  | "interval"
+  | "tuple"
+  | "list-resource"
+  | "list-tuple"
+  | "list-primitive"
+  | "list-empty"
+  | "resource"
+  | "null"
+  | "unknown";
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  v !== null && typeof v === "object" && !Array.isArray(v);
+
+const isFhirResource = (v: unknown): boolean =>
+  isPlainObject(v) && typeof v.resourceType === "string";
+
+const isInterval = (v: unknown): boolean =>
+  isPlainObject(v) &&
+  ("low" in v || "high" in v) &&
+  // Intervals from cql-execution carry a `lowClosed`/`highClosed` flag.
+  ("lowClosed" in v || "highClosed" in v || ("low" in v && "high" in v));
+
+const isCode = (v: unknown): boolean =>
+  isPlainObject(v) && typeof v.code === "string" && "system" in v && !("coding" in v);
+
+const isConcept = (v: unknown): boolean =>
+  isPlainObject(v) && Array.isArray(v.coding);
+
+const isQuantity = (v: unknown): boolean =>
+  isPlainObject(v) && "value" in v && "unit" in v && typeof v.value === "number";
+
+const isCqlDate = (v: unknown): boolean =>
+  isPlainObject(v) &&
+  v.isDate === true &&
+  typeof v.year === "number";
+
+const isCqlDateTime = (v: unknown): boolean =>
+  isPlainObject(v) &&
+  v.isDateTime === true &&
+  typeof v.year === "number";
+
+export function inferShape(value: unknown): CqlResultShape {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "boolean") return "boolean";
+  if (typeof value === "number") return "number";
+  if (typeof value === "string") return "string";
+  if (value instanceof Date) return "datetime";
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "list-empty";
+    const sample = value.find((v) => v !== null && v !== undefined) ?? value[0];
+    if (isFhirResource(sample)) return "list-resource";
+    if (isPlainObject(sample) && !isInterval(sample) && !isCode(sample) && !isConcept(sample)) {
+      return "list-tuple";
+    }
+    return "list-primitive";
+  }
+
+  if (isCqlDate(value)) return "date";
+  if (isCqlDateTime(value)) return "datetime";
+  if (isQuantity(value)) return "quantity";
+  if (isInterval(value)) return "interval";
+  if (isCode(value)) return "code";
+  if (isConcept(value)) return "concept";
+  if (isFhirResource(value)) return "resource";
+  if (isPlainObject(value)) return "tuple";
+
+  return "unknown";
+}

--- a/apps/demo/src/routes/cql-runner/runCql.ts
+++ b/apps/demo/src/routes/cql-runner/runCql.ts
@@ -1,0 +1,85 @@
+import type { FhirClient } from "@fhir-place/react-fhir";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import * as cqlExecution from "cql-execution";
+import { buildFhirDataSource } from "./fhirDataSource.js";
+import { translateCql, type TranslationError } from "./translator.js";
+
+/**
+ * Single seam between the UI and the CQL runtime. Long-term, swapping in a
+ * server-side execution path means replacing the body of this file without
+ * touching any component code.
+ */
+
+export interface RunOutcome {
+  /** ELM expression name → evaluated value. */
+  values: Record<string, unknown>;
+  patientId: string;
+}
+
+export type RunFailure =
+  | { kind: "translation"; errors: TranslationError[] }
+  | { kind: "execution"; error: Error }
+  | { kind: "fhir"; error: unknown };
+
+export type RunResult =
+  | { ok: true; outcome: RunOutcome }
+  | { ok: false; failure: RunFailure };
+
+export interface RunCqlOptions {
+  cql: string;
+  client: FhirClient;
+  patientId: string;
+  signal?: AbortSignal;
+}
+
+export async function runCql({
+  cql,
+  client,
+  patientId,
+  signal,
+}: RunCqlOptions): Promise<RunResult> {
+  const translation = await translateCql(cql, { signal });
+  if (!translation.ok) {
+    return { ok: false, failure: { kind: "translation", errors: translation.errors } };
+  }
+
+  let dataSource;
+  try {
+    dataSource = await buildFhirDataSource({ client, patientId, signal });
+  } catch (error) {
+    return { ok: false, failure: { kind: "fhir", error } };
+  }
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { Library, Executor } = cqlExecution as any;
+    const library = new Library(translation.elm);
+    const executor = new Executor(library);
+    const results = await executor.exec(dataSource.source);
+    const values = extractPatientResults(results, patientId);
+    return { ok: true, outcome: { values, patientId } };
+  } catch (err) {
+    return {
+      ok: false,
+      failure: {
+        kind: "execution",
+        error: err instanceof Error ? err : new Error(String(err)),
+      },
+    };
+  }
+}
+
+/**
+ * `Executor.exec` returns a `Results` object with `patientResults[patientId]`
+ * keyed by ELM expression name. Phase 1 only supports single-patient runs,
+ * so collapse to one expression-name → value map.
+ */
+const extractPatientResults = (
+  results: unknown,
+  patientId: string,
+): Record<string, unknown> => {
+  if (!results || typeof results !== "object") return {};
+  const r = results as { patientResults?: Record<string, Record<string, unknown>> };
+  const byPatient = r.patientResults ?? {};
+  return byPatient[patientId] ?? Object.values(byPatient)[0] ?? {};
+};

--- a/apps/demo/src/routes/cql-runner/translator.test.ts
+++ b/apps/demo/src/routes/cql-runner/translator.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { translateCql } from "./translator.js";
+
+const okResponse = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+const errResponse = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+describe("translateCql", () => {
+  it("returns ok with the parsed ELM payload", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(okResponse({ library: { name: "Foo" } }));
+    const result = await translateCql("library Foo", {
+      url: "http://t.local",
+      fetchImpl,
+    });
+    expect(result).toEqual({ ok: true, elm: { library: { name: "Foo" } } });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://t.local/translate",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ cql: "library Foo" }),
+      }),
+    );
+  });
+
+  it("surfaces translator-reported errors", async () => {
+    const errors = [{ message: "boom", line: 3, col: 5, severity: "Error" }];
+    const fetchImpl = vi.fn().mockResolvedValue(errResponse(400, { errors }));
+    const result = await translateCql("oops", { url: "http://t.local", fetchImpl });
+    expect(result).toEqual({
+      ok: false,
+      errors: [
+        { message: "boom", line: 3, col: 5, severity: "Error" },
+      ],
+    });
+  });
+
+  it("returns a synthetic error when the translator is unreachable", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+    const result = await translateCql("x", { url: "http://t.local", fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors[0]!.message).toMatch(/Translator unreachable/);
+    }
+  });
+
+  it("falls back to a generic error when payload has no error array", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(errResponse(500, { other: "x" }));
+    const result = await translateCql("x", { url: "http://t.local", fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors[0]!.message).toMatch(/HTTP 500/);
+    }
+  });
+});

--- a/apps/demo/src/routes/cql-runner/translator.ts
+++ b/apps/demo/src/routes/cql-runner/translator.ts
@@ -1,0 +1,123 @@
+/**
+ * Thin client for `services/cql-translator`. Single endpoint: POST /translate.
+ *
+ * License note: the underlying cqframework translator is Apache-2.0; the
+ * `cql-execution` package consuming the ELM output is Apache-2.0.
+ */
+
+export interface TranslationError {
+  message: string;
+  severity?: string;
+  line?: number;
+  col?: number;
+}
+
+export interface TranslationFailure {
+  ok: false;
+  errors: TranslationError[];
+}
+
+export interface TranslationSuccess {
+  ok: true;
+  /** ELM library JSON, ready to feed into `new Library(json)` from cql-execution. */
+  elm: unknown;
+}
+
+export type TranslationResult = TranslationSuccess | TranslationFailure;
+
+const DEFAULT_URL = "http://localhost:8081";
+
+const resolveTranslatorUrl = (override?: string): string => {
+  if (override) return override.replace(/\/$/, "");
+  // import.meta.env is the Vite-provided env shim; tests can pass an override.
+  const env = (import.meta as { env?: Record<string, string | undefined> }).env;
+  return (env?.VITE_CQL_TRANSLATOR_URL ?? DEFAULT_URL).replace(/\/$/, "");
+};
+
+export async function translateCql(
+  cql: string,
+  options: { url?: string; signal?: AbortSignal; fetchImpl?: typeof fetch } = {},
+): Promise<TranslationResult> {
+  const url = `${resolveTranslatorUrl(options.url)}/translate`;
+  const fetchFn = options.fetchImpl ?? fetch;
+
+  let response: Response;
+  try {
+    response = await fetchFn(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cql }),
+      signal: options.signal,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          message:
+            err instanceof Error
+              ? `Translator unreachable: ${err.message}`
+              : "Translator unreachable",
+          severity: "Error",
+        },
+      ],
+    };
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          message: `Translator returned non-JSON (${response.status}): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          severity: "Error",
+        },
+      ],
+    };
+  }
+
+  if (!response.ok) {
+    const errors = extractErrors(payload);
+    return {
+      ok: false,
+      errors:
+        errors.length > 0
+          ? errors
+          : [{ message: `Translator HTTP ${response.status}`, severity: "Error" }],
+    };
+  }
+
+  return { ok: true, elm: payload };
+}
+
+const extractErrors = (payload: unknown): TranslationError[] => {
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "errors" in payload &&
+    Array.isArray((payload as { errors: unknown[] }).errors)
+  ) {
+    return (payload as { errors: unknown[] }).errors
+      .map(coerceError)
+      .filter((e): e is TranslationError => e !== null);
+  }
+  return [];
+};
+
+const coerceError = (raw: unknown): TranslationError | null => {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  const message = typeof o.message === "string" ? o.message : null;
+  if (!message) return null;
+  return {
+    message,
+    severity: typeof o.severity === "string" ? o.severity : undefined,
+    line: typeof o.line === "number" ? o.line : undefined,
+    col: typeof o.col === "number" ? o.col : undefined,
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.62.0
         version: 5.99.2(react@18.3.1)
+      cql-exec-fhir:
+        specifier: ^2.1.6
+        version: 2.1.6(cql-execution@3.3.0)
+      cql-execution:
+        specifier: ^3.3.0
+        version: 3.3.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -898,6 +904,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@lhncbc/ucum-lhc@4.2.0':
+    resolution: {integrity: sha512-OEiWX7IHFHLTFs7+w5EvGtI5dhXhhL0341LqZ9WEBWErtoY0/9xl/vn+wwT9vnBHnjQ7Ux0o7iEUXvN8uVn4xg==}
+
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
@@ -1357,6 +1366,11 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  coffeescript@2.7.0:
+    resolution: {integrity: sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1379,6 +1393,17 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cql-exec-fhir@2.1.6:
+    resolution: {integrity: sha512-P2H5yp+PukoaOtIS7Hos+RXZfc8ExNaV9q1jR2bX8DrCCgVOplP7loSLHRer9UOaYJf68CzXPyy5f3KIoEKG+w==}
+    peerDependencies:
+      cql-execution: '>=1.3.0 || ^3.0.0-beta'
+
+  cql-execution@3.3.0:
+    resolution: {integrity: sha512-Zs0sD7liz7tqfVUJVcEY281f8HtqFhfyngR4LsqWj5jusCMyy9a0flE914tA1QewOa4dpr90kov2lnm0C3J20w==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1397,6 +1422,12 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  csv-parse@4.16.3:
+    resolution: {integrity: sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==}
+
+  csv-stringify@1.1.2:
+    resolution: {integrity: sha512-3NmNhhd+AkYs5YtM1GEh01VR6PKj6qch2ayfQaltx5xpcAdThjnbbI5eT8CzRVpXfGKAxnmrSYLsNl/4f3eWiw==}
 
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -1459,6 +1490,9 @@ packages:
   electron-to-chromium@1.5.342:
     resolution: {integrity: sha512-GTuy59SdGxYgz+HN8KwOjFAVF2gfoKEmv0PFholcvVtbI9GPDND0m6ynGX3gAKOavcHRLrcfNy0QMbHbAemYdw==}
 
+  emitter-component@1.1.2:
+    resolution: {integrity: sha512-QdXO3nXOzZB4pAjM0n6ZE+R9/+kPpECA/XSELIcc54NeYVnBqIk+4DFiBgK+8QbV3mdvTG6nedl7dTYgO+5wDw==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1510,6 +1544,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -1688,9 +1725,15 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immutable@4.3.8:
+    resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -1704,6 +1747,10 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-finite@1.1.0:
+    resolution: {integrity: sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -1711,6 +1758,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-integer@1.0.7:
+    resolution: {integrity: sha512-RPQc/s9yBHSvpi+hs9dYiJ2cuFeU6x3TyyIp8O2H6SKEltIvJOzRj9ToyvcStDvPR/pS4rxgr1oBFajQjZ2Szg==}
 
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
@@ -1729,6 +1779,9 @@ packages:
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1790,6 +1843,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonfile@2.4.0:
+    resolution: {integrity: sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==}
+
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
@@ -1803,6 +1859,10 @@ packages:
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
+
+  lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
@@ -1819,6 +1879,9 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  luxon@1.28.1:
+    resolution: {integrity: sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -2070,6 +2133,9 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2120,6 +2186,9 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -2165,8 +2234,14 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sax@1.1.6:
+    resolution: {integrity: sha512-8zci48uUQyfqynGDSkUMD7FCJB96hwLnlZOXlgs1l3TX+LW27t3psSWKUxC0fxVgA86i8tL4NwGcY1h/6t3ESg==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -2229,8 +2304,17 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stream-transform@0.1.2:
+    resolution: {integrity: sha512-3HXId/0W8sktQnQM6rOZf2LuDDMbakMgAjpViLk758/h0br+iGqZFFfUxxJSqEvGvT742PyFr4v/TBXUtowdCg==}
+
+  stream@0.0.2:
+    resolution: {integrity: sha512-gCq3NDI2P35B2n6t76YJuOp7d6cN/C7Rt0577l91wllh0sY9ZBuw9KaSGqH/b0hzn3CWWJbpbW0W0WvQ1H/Q7g==}
+
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
+  string-to-stream@1.1.1:
+    resolution: {integrity: sha512-QySF2+3Rwq0SdO3s7BAp4x+c3qsClpPQ6abAmb0DGViiSBAkT5kL6JT2iyzEVP+T1SmzHrQD1TwlP9QAHCc+Sw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2239,6 +2323,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -2543,8 +2630,19 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xmldoc@0.4.0:
+    resolution: {integrity: sha512-rJ/+/UzYCSlFNuAzGuRyYgkH2G5agdX1UQn4+5siYw9pkNC3Hu/grYNDx/dqYLreeSjnY5oKg74CMBKxJHSg6Q==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -3152,6 +3250,19 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@lhncbc/ucum-lhc@4.2.0':
+    dependencies:
+      coffeescript: 2.7.0
+      csv-parse: 4.16.3
+      csv-stringify: 1.1.2
+      escape-html: 1.0.3
+      is-integer: 1.0.7
+      jsonfile: 2.4.0
+      stream: 0.0.2
+      stream-transform: 0.1.2
+      string-to-stream: 1.1.1
+      xmldoc: 0.4.0
+
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -3580,6 +3691,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  coffeescript@2.7.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3595,6 +3708,19 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  core-util-is@1.0.3: {}
+
+  cql-exec-fhir@2.1.6(cql-execution@3.3.0):
+    dependencies:
+      cql-execution: 3.3.0
+      xml2js: 0.6.2
+
+  cql-execution@3.3.0:
+    dependencies:
+      '@lhncbc/ucum-lhc': 4.2.0
+      immutable: 4.3.8
+      luxon: 1.28.1
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3612,6 +3738,12 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
+
+  csv-parse@4.16.3: {}
+
+  csv-stringify@1.1.2:
+    dependencies:
+      lodash.get: 4.4.2
 
   data-urls@5.0.0:
     dependencies:
@@ -3657,6 +3789,8 @@ snapshots:
   eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.342: {}
+
+  emitter-component@1.1.2: {}
 
   emoji-regex@8.0.0: {}
 
@@ -3772,6 +3906,8 @@ snapshots:
     optional: true
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   esprima@4.0.1: {}
 
@@ -3961,7 +4097,11 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immutable@4.3.8: {}
+
   indent-string@4.0.0: {}
+
+  inherits@2.0.4: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -3973,11 +4113,17 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-finite@1.1.0: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-integer@1.0.7:
+    dependencies:
+      is-finite: 1.1.0
 
   is-node-process@1.2.0: {}
 
@@ -3990,6 +4136,8 @@ snapshots:
       better-path-resolve: 1.0.0
 
   is-windows@1.0.2: {}
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -4070,6 +4218,10 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonfile@2.4.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
@@ -4081,6 +4233,8 @@ snapshots:
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
+
+  lodash.get@4.4.2: {}
 
   lodash.startcase@4.4.0: {}
 
@@ -4095,6 +4249,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  luxon@1.28.1: {}
 
   lz-string@1.5.0: {}
 
@@ -4303,6 +4459,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  process-nextick-args@2.0.1: {}
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
@@ -4347,6 +4505,16 @@ snapshots:
       js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readdirp@3.6.0:
     dependencies:
@@ -4414,7 +4582,11 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.1.2: {}
+
   safer-buffer@2.1.2: {}
+
+  sax@1.1.6: {}
 
   saxes@6.0.0:
     dependencies:
@@ -4459,7 +4631,18 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  stream-transform@0.1.2: {}
+
+  stream@0.0.2:
+    dependencies:
+      emitter-component: 1.1.2
+
   strict-event-emitter@0.5.1: {}
+
+  string-to-stream@1.1.1:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 2.3.8
 
   string-width@4.2.3:
     dependencies:
@@ -4472,6 +4655,10 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   strip-ansi@6.0.1:
     dependencies:
@@ -4745,7 +4932,18 @@ snapshots:
 
   xml-name-validator@5.0.0: {}
 
+  xml2js@0.6.2:
+    dependencies:
+      sax: 1.1.6
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
+
   xmlchars@2.2.0: {}
+
+  xmldoc@0.4.0:
+    dependencies:
+      sax: 1.1.6
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary
Phase 1b of the CQL runner work. Replaces the `/cql-runner` placeholder landed in Phase 0 with a working runner: paste CQL, pick a patient, click Run, see results rendered for their shape (not raw JSON).

> **Stacked on #1 (Phase 0).** Base will retarget to `main` once #1 lands. Marked draft until then.

## Architecture
- `translator.ts` — `POST /translate` against `services/cql-translator` (URL via `VITE_CQL_TRANSLATOR_URL`, defaults to `http://localhost:8081`), shaping responses into a discriminated `TranslationResult`.
- `fhirDataSource.ts` — wraps the active `FhirClient` as a `cql-execution` `DataProvider` via `cql-exec-fhir`. Pre-fetches the patient compartment with `Patient/$everything` (with a per-type compartment-search fallback for servers that don't expose it).
- `runCql.ts` — single seam between the UI and the CQL runtime; a future server-side execution path replaces this file's body without touching components.
- `PatientContextPicker.tsx` — type-to-search patient picker reusing `useSearch` from `@fhir-place/react-fhir`.
- `results/CqlResult.tsx` + `shape.ts` — shape dispatcher: booleans → pass/fail badges, lists of FHIR resources reuse `ResourceTable`, intervals/tuples/quantities/codes/concepts get purpose-built views, unknown shapes fall back to JSON with an affordance.
- `errors/ErrorPanel.tsx` — translator / execution / FHIR errors land in three distinct labeled buckets; `FhirError` gets HTTP-status formatting.
- `examples.ts` — five hand-picked CQL snippets, one per renderer shape, exposed via a "Load example" dropdown.

## Dependencies (both Apache-2.0)
- `cql-execution@^3.3.0` — ELM execution in-browser
- `cql-exec-fhir@^2.1.6` — FHIR DataProvider

## Test plan
- [x] 13 new unit tests (`inferShape`, `translateCql`, `buildFhirDataSource`)
- [x] `pnpm --filter @fhir-place/demo test:run` — 69 tests pass (existing 56 + 13 new)
- [x] `pnpm --filter @fhir-place/demo typecheck` — clean
- [x] `pnpm --filter @fhir-place/demo e2e` — 29 chromium specs still pass
- [ ] Reviewer: `docker compose up hapi cql-translator`, then in the demo pick a patient and run each of the 5 seed examples. Each should render in its own shape (badge / table / tuple / interval / list).
- [ ] Reviewer: paste malformed CQL → translator error appears in the amber bucket. Stop HAPI → FHIR error appears in the red bucket.

## Follow-ups (deferred)
- Code-split the runner route — the `cql-execution` + `cql-exec-fhir` payload pushes the bundle past Vite's 500 kB warning.
- Phase 2: CodeMirror editor, library store with `LocalStorageLibraryStore`, multi-library `include` resolution.

Depends on #1. Independent of the Phase 1a translator-service PR.

https://claude.ai/code/session_01HuKYCX7X4VhFxJjApNKaMY


---
_Generated by [Claude Code](https://claude.ai/code/session_01HuKYCX7X4VhFxJjApNKaMY)_