### PR TITLE
feat(goals-tasks): deploy to GitHub Pages under /goals

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,6 +33,16 @@ jobs:
           VITE_USE_MOCK: "false"
           VITE_FHIR_BASE_URL: "https://hapi.fhir.org/baseR4"
           VITE_BASE_PATH: "/${{ github.event.repository.name }}/"
+      - name: Build goals-tasks for GitHub Pages (live HAPI R4)
+        run: pnpm --filter @fhir-place/goals-tasks build
+        env:
+          VITE_USE_MOCK: "false"
+          VITE_FHIR_BASE_URL: "https://hapi.fhir.org/baseR4"
+          VITE_BASE_PATH: "/${{ github.event.repository.name }}/goals/"
+      - name: Stage goals-tasks under /goals
+        run: |
+          mkdir -p apps/demo/dist/goals
+          cp -R apps/goals-tasks/dist/. apps/demo/dist/goals/
       - name: SPA 404 fallback
         run: cp apps/demo/dist/index.html apps/demo/dist/404.html
       - uses: actions/upload-pages-artifact@v3

--- a/apps/goals-tasks/src/config.ts
+++ b/apps/goals-tasks/src/config.ts
@@ -9,5 +9,15 @@ export const FHIR_BASE_URL: string =
 
 export const ROUTER_BASENAME: string = BASE.replace(/\/$/, "") || "/";
 
+/**
+ * Use HashRouter when hosted on a static path other than the server root
+ * (e.g. `/fhir-place/goals/` on GitHub Pages). The Pages 404 fallback is at
+ * the site root, so deep links into a sub-app would otherwise render the
+ * sibling site instead of this one. Mirrors the demo's pattern (see #47).
+ */
+export const USE_HASH_ROUTER: boolean =
+  import.meta.env.VITE_USE_HASH_ROUTER === "true" ||
+  (BASE !== "/" && !import.meta.env.DEV);
+
 /** Hardcoded "current" patient for this demo — in a real app this would come from SMART launch context or a picker. */
 export const DEMO_PATIENT_ID = "demo-patient";

--- a/apps/goals-tasks/src/main.tsx
+++ b/apps/goals-tasks/src/main.tsx
@@ -2,9 +2,14 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { FetchFhirClient, FhirClientProvider } from "@fhir-place/react-fhir";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, HashRouter } from "react-router-dom";
 import { App } from "./App.js";
-import { FHIR_BASE_URL, ROUTER_BASENAME, USE_MOCK } from "./config.js";
+import {
+  FHIR_BASE_URL,
+  ROUTER_BASENAME,
+  USE_HASH_ROUTER,
+  USE_MOCK,
+} from "./config.js";
 import "./index.css";
 
 const queryClient = new QueryClient({
@@ -22,13 +27,16 @@ async function bootstrap() {
       serviceWorker: { url: `${import.meta.env.BASE_URL}mockServiceWorker.js` },
     });
   }
+  const Router = USE_HASH_ROUTER ? HashRouter : BrowserRouter;
+  const routerProps = USE_HASH_ROUTER ? {} : { basename: ROUTER_BASENAME };
+
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>
         <FhirClientProvider client={fhirClient}>
-          <BrowserRouter basename={ROUTER_BASENAME}>
+          <Router {...routerProps}>
             <App />
-          </BrowserRouter>
+          </Router>
         </FhirClientProvider>
       </QueryClientProvider>
     </React.StrictMode>,


### PR DESCRIPTION
Build and ship apps/goals-tasks alongside the demo so it's reachable at
`/fhir-place/goals/` on the live Pages site, against public HAPI R4.

- pages.yml: add a goals-tasks build step (live HAPI, base /fhir-place/goals/)
  and stage its dist into apps/demo/dist/goals/ for a single Pages artifact.
- goals-tasks: switch to HashRouter when hosted at a non-root base path so
  deep links survive the Pages 404 fallback (which serves the demo's
  index.html, not a per-subdir one). Mirrors the demo's pattern (#47).

https://claude.ai/code/session_019DBVTKAaNz4oLHeuAWkMUf