### PR TITLE
feat(renderers): show coding code alongside CodeableConcept text

### DIFF
--- a/packages/react-fhir/src/components/renderers.test.tsx
+++ b/packages/react-fhir/src/components/renderers.test.tsx
@@ -1,8 +1,10 @@
 import type { CodeableConcept } from "fhir/r4";
+import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import {
   codeSystemLabel,
   DEFAULT_CODING_PRIORITY,
+  defaultTypeRenderers,
   preferredCoding,
 } from "./renderers.js";
 
@@ -100,6 +102,40 @@ describe("preferredCoding", () => {
     expect(preferredCoding(undefined, "Any.path")).toBeUndefined();
     expect(preferredCoding({ text: "only text" }, "Any.path")).toBeUndefined();
     expect(preferredCoding({ coding: [] }, "Any.path")).toBeUndefined();
+  });
+});
+
+describe("CodeableConcept renderer", () => {
+  const renderer = defaultTypeRenderers.CodeableConcept!;
+  const ctx = { path: "Observation.code", typeCode: "CodeableConcept" };
+
+  it("renders the text alongside the preferred coding's code", () => {
+    const cc: CodeableConcept = {
+      text: "Diastolic blood pressure",
+      coding: [
+        { system: "http://loinc.org", code: "8462-4", display: "Diastolic blood pressure" },
+      ],
+    };
+    const { container } = render(<>{renderer(cc, ctx)}</>);
+    expect(container.textContent).toContain("Diastolic blood pressure");
+    expect(container.textContent).toContain("8462-4");
+    expect(container.textContent).toContain("LOINC");
+  });
+
+  it("falls back to plain text when no coding is present", () => {
+    const cc: CodeableConcept = { text: "free text only" };
+    const { container } = render(<>{renderer(cc, ctx)}</>);
+    expect(container.textContent).toBe("free text only");
+    expect(container.querySelector("code")).toBeNull();
+  });
+
+  it("renders just the coding when text is missing", () => {
+    const cc: CodeableConcept = {
+      coding: [{ system: "http://loinc.org", code: "8462-4", display: "Diastolic blood pressure" }],
+    };
+    const { container } = render(<>{renderer(cc, ctx)}</>);
+    expect(container.textContent).toContain("Diastolic blood pressure");
+    expect(container.textContent).toContain("8462-4");
   });
 });
 

--- a/packages/react-fhir/src/components/renderers.test.tsx
+++ b/packages/react-fhir/src/components/renderers.test.tsx
@@ -1,5 +1,5 @@
 import type { CodeableConcept } from "fhir/r4";
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import {
   codeSystemLabel,
@@ -136,6 +136,40 @@ describe("CodeableConcept renderer", () => {
     const { container } = render(<>{renderer(cc, ctx)}</>);
     expect(container.textContent).toContain("Diastolic blood pressure");
     expect(container.textContent).toContain("8462-4");
+  });
+
+  it("hides non-preferred codings behind a +N more toggle", () => {
+    const cc: CodeableConcept = {
+      text: "Diastolic blood pressure",
+      coding: [
+        { system: "http://loinc.org", code: "8462-4" },
+        { system: "http://snomed.info/sct", code: "271650006" },
+        { system: "http://example.org/custom", code: "DBP-9" },
+      ],
+    };
+    const { container, getByRole } = render(<>{renderer(cc, ctx)}</>);
+    // preferred coding visible
+    expect(container.textContent).toContain("8462-4");
+    // extras hidden initially
+    expect(container.textContent).not.toContain("271650006");
+    expect(container.textContent).not.toContain("DBP-9");
+    // expand toggle visible
+    const toggle = getByRole("button", { name: /show 2 other codings/i });
+    expect(toggle.textContent).toBe("+2 more");
+    fireEvent.click(toggle);
+    // extras now visible
+    expect(container.textContent).toContain("271650006");
+    expect(container.textContent).toContain("DBP-9");
+    expect(toggle.textContent).toBe("hide");
+  });
+
+  it("does not render the toggle when there is only one coding", () => {
+    const cc: CodeableConcept = {
+      text: "Diastolic blood pressure",
+      coding: [{ system: "http://loinc.org", code: "8462-4" }],
+    };
+    const { container } = render(<>{renderer(cc, ctx)}</>);
+    expect(container.querySelector("button")).toBeNull();
   });
 });
 

--- a/packages/react-fhir/src/components/renderers.tsx
+++ b/packages/react-fhir/src/components/renderers.tsx
@@ -256,6 +256,22 @@ const CodeableConceptRenderer: FhirTypeRenderer = (value, ctx) => {
       ?.map((c) => [codeSystemLabel(c.system), c.code].filter(Boolean).join(" "))
       .filter(Boolean)
       .join(", ");
+    const chosen = preferredCoding(cc, ctx.path);
+    if (chosen?.code) {
+      const sys = codeSystemLabel(chosen.system);
+      return (
+        <span title={codingSummary}>
+          {cc.text}
+          <code
+            className="ml-1 rounded bg-slate-100 px-1 py-0.5 text-xs"
+            title={chosen.system ? `${chosen.system}#${chosen.code}` : chosen.code}
+          >
+            {sys ? `${sys} ` : ""}
+            {chosen.code}
+          </code>
+        </span>
+      );
+    }
     return <span title={codingSummary}>{cc.text}</span>;
   }
   const chosen = preferredCoding(cc, ctx.path);

--- a/packages/react-fhir/src/components/renderers.tsx
+++ b/packages/react-fhir/src/components/renderers.tsx
@@ -16,6 +16,7 @@ import type {
   Reference,
 } from "fhir/r4";
 import type { ReactNode } from "react";
+import { useState } from "react";
 import {
   formatAddress,
   formatHumanName,
@@ -221,61 +222,91 @@ export function preferredCoding(
   return cc.coding[0];
 }
 
-const CodingRenderer: FhirTypeRenderer = (value) => {
-  const c = value as Coding;
-  const sys = codeSystemLabel(c.system);
-  if (c.display) {
-    return (
-      <span>
-        {c.display}
-        <code
-          className="ml-1 rounded bg-slate-100 px-1 py-0.5 text-xs"
-          title={c.system ? `${c.system}#${c.code}` : c.code}
-        >
-          {sys ? `${sys} ` : ""}
-          {c.code}
-        </code>
-      </span>
-    );
-  }
+function CodeChip({ coding }: { coding: Coding }) {
+  const sys = codeSystemLabel(coding.system);
   return (
     <code
       className="rounded bg-slate-100 px-1 py-0.5 text-xs"
-      title={c.system ? `${c.system}#${c.code}` : c.code}
+      title={coding.system ? `${coding.system}#${coding.code}` : coding.code}
     >
       {sys ? `${sys} ` : ""}
-      {c.code}
+      {coding.code}
     </code>
   );
+}
+
+function ExtraCodings({ codings }: { codings: readonly Coding[] }) {
+  const [open, setOpen] = useState(false);
+  if (codings.length === 0) return null;
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="ml-1 text-xs text-slate-500 underline"
+        aria-expanded={open}
+        aria-label={
+          open ? "Hide other codings" : `Show ${codings.length} other coding${codings.length === 1 ? "" : "s"}`
+        }
+      >
+        {open ? "hide" : `+${codings.length} more`}
+      </button>
+      {open && (
+        <span className="ml-1 inline-flex flex-wrap gap-1">
+          {codings.map((c, i) => (
+            <CodeChip key={`${c.system ?? ""}#${c.code ?? ""}#${i}`} coding={c} />
+          ))}
+        </span>
+      )}
+    </>
+  );
+}
+
+const CodingRenderer: FhirTypeRenderer = (value) => {
+  const c = value as Coding;
+  if (c.display) {
+    return (
+      <span>
+        {c.display} <CodeChip coding={c} />
+      </span>
+    );
+  }
+  return <CodeChip coding={c} />;
 };
 
 const CodeableConceptRenderer: FhirTypeRenderer = (value, ctx) => {
   const cc = value as CodeableConcept;
+  const all = cc.coding ?? [];
+  const chosen = preferredCoding(cc, ctx.path);
+  const extras = chosen ? all.filter((c) => c !== chosen) : all.slice();
+
   if (cc.text) {
-    const codingSummary = cc.coding
-      ?.map((c) => [codeSystemLabel(c.system), c.code].filter(Boolean).join(" "))
+    const codingSummary = all
+      .map((c) => [codeSystemLabel(c.system), c.code].filter(Boolean).join(" "))
       .filter(Boolean)
       .join(", ");
-    const chosen = preferredCoding(cc, ctx.path);
-    if (chosen?.code) {
-      const sys = codeSystemLabel(chosen.system);
-      return (
-        <span title={codingSummary}>
-          {cc.text}
-          <code
-            className="ml-1 rounded bg-slate-100 px-1 py-0.5 text-xs"
-            title={chosen.system ? `${chosen.system}#${chosen.code}` : chosen.code}
-          >
-            {sys ? `${sys} ` : ""}
-            {chosen.code}
-          </code>
-        </span>
-      );
-    }
-    return <span title={codingSummary}>{cc.text}</span>;
+    return (
+      <span title={codingSummary}>
+        {cc.text}
+        {chosen?.code && (
+          <>
+            {" "}
+            <CodeChip coding={chosen} />
+          </>
+        )}
+        <ExtraCodings codings={extras} />
+      </span>
+    );
   }
-  const chosen = preferredCoding(cc, ctx.path);
-  if (chosen) return CodingRenderer(chosen, ctx);
+  if (chosen) {
+    return (
+      <span>
+        {chosen.display ? <>{chosen.display} </> : null}
+        <CodeChip coding={chosen} />
+        <ExtraCodings codings={extras} />
+      </span>
+    );
+  }
   return <span className="text-slate-400">—</span>;
 };
 


### PR DESCRIPTION
When a CodeableConcept has both `text` and `coding`, also render the
preferred coding's code as a chip beside the text so users can see, for
example, "Diastolic blood pressure  LOINC 8462-4" instead of just the
human-friendly text.

https://claude.ai/code/session_01DjcFDj6HLi3faC7v4yQiXT