### PR TITLE
feat(react-fhir): collapsed dataAbsentReason editor with standard-code dropdown

### DIFF
--- a/packages/react-fhir/src/components/ResourceEditor.test.tsx
+++ b/packages/react-fhir/src/components/ResourceEditor.test.tsx
@@ -1,11 +1,12 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { Patient } from "fhir/r4";
+import type { Observation, Patient } from "fhir/r4";
 import { describe, expect, it, vi } from "vitest";
 import { FetchFhirClient } from "../client/FetchFhirClient.js";
 import { FhirClientProvider } from "../hooks/FhirClientProvider.js";
 import { PatientStructureDefinition } from "../../test/fixtures/StructureDefinition-Patient.js";
+import { ObservationStructureDefinition } from "../structure/core/Observation.js";
 import { ResourceEditor } from "./ResourceEditor.js";
 
 const wrap = (ui: React.ReactElement) => {
@@ -162,6 +163,34 @@ describe("ResourceEditor", () => {
       />,
     );
     expect(screen.getByRole("button", { name: /saving/i })).toBeDisabled();
+  });
+
+  it("uses the path-based override for Observation.dataAbsentReason instead of the generic CodeableConcept input", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const obs: Observation = {
+      resourceType: "Observation",
+      status: "final",
+      code: { text: "BP" },
+    };
+    wrap(
+      <ResourceEditor
+        resource={obs}
+        structureDefinition={ObservationStructureDefinition}
+        onChange={onChange}
+      />,
+    );
+    // Before the toggle is clicked, the raw CodeableConcept fields for
+    // dataAbsentReason should not be visible — only the trigger button is.
+    expect(
+      screen.getByRole("button", { name: /mark result as missing/i }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /mark result as missing/i }));
+    const last = onChange.mock.calls.at(-1)?.[0] as Observation;
+    expect(last.dataAbsentReason?.coding?.[0]).toMatchObject({
+      system: "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+      code: "unknown",
+    });
   });
 
   it("falls back to JSON textarea for datatypes without a built-in input", () => {

--- a/packages/react-fhir/src/components/ResourceEditor.tsx
+++ b/packages/react-fhir/src/components/ResourceEditor.tsx
@@ -15,9 +15,11 @@ import {
   type Path,
 } from "../structure/index.js";
 import {
+  defaultPathInputs,
   defaultTypeInputs,
   JsonFallbackInput,
   type FhirTypeInput,
+  type PathInputs,
   type TypeInputs,
 } from "./inputs/index.js";
 
@@ -31,6 +33,8 @@ export interface ResourceEditorProps {
   onCancel?: () => void;
   /** Override input components by FHIR datatype code. */
   inputs?: TypeInputs;
+  /** Override input components by full ElementDefinition path (e.g. "Observation.dataAbsentReason"). Wins over `inputs`. */
+  pathInputs?: PathInputs;
   saveLabel?: string;
   /** When true, the Save button shows a spinner and becomes disabled. */
   saving?: boolean;
@@ -89,6 +93,10 @@ export function ResourceEditor(props: ResourceEditorProps) {
     () => ({ ...defaultTypeInputs, ...props.inputs }),
     [props.inputs],
   );
+  const pathInputs = useMemo(
+    () => ({ ...defaultPathInputs, ...props.pathInputs }),
+    [props.pathInputs],
+  );
 
   const setAt = useCallback(
     (path: Path, value: unknown) => {
@@ -144,6 +152,7 @@ export function ResourceEditor(props: ResourceEditorProps) {
         pathPrefix={[]}
         draft={draft as unknown as Record<string, unknown>}
         inputs={inputs}
+        pathInputs={pathInputs}
         setAt={setAt}
       />
 
@@ -175,6 +184,7 @@ interface FieldGroupProps {
   pathPrefix: Path;
   draft: Record<string, unknown>;
   inputs: TypeInputs;
+  pathInputs: PathInputs;
   setAt: (path: Path, value: unknown) => void;
 }
 
@@ -184,6 +194,7 @@ function FieldGroup({
   pathPrefix,
   draft,
   inputs,
+  pathInputs,
   setAt,
 }: FieldGroupProps): ReactNode {
   const children = directChildren(sd, parentPath).filter((el) => {
@@ -204,6 +215,7 @@ function FieldGroup({
           pathPrefix={pathPrefix}
           draft={draft}
           inputs={inputs}
+          pathInputs={pathInputs}
           setAt={setAt}
         />
       ))}
@@ -222,6 +234,7 @@ function Field({
   pathPrefix,
   draft,
   inputs,
+  pathInputs,
   setAt,
 }: FieldProps): ReactNode {
   const path = element.path!;
@@ -239,6 +252,7 @@ function Field({
         label={label}
         draft={draft}
         inputs={inputs}
+        pathInputs={pathInputs}
         setAt={setAt}
       />
     );
@@ -269,6 +283,7 @@ function Field({
                 path={[...fullPath, i]}
                 draft={draft}
                 inputs={inputs}
+                pathInputs={pathInputs}
                 setAt={setAt}
               />
             </ArrayRow>
@@ -296,6 +311,7 @@ function Field({
           path={fullPath}
           draft={draft}
           inputs={inputs}
+          pathInputs={pathInputs}
           setAt={setAt}
         />
       </dd>
@@ -311,6 +327,7 @@ interface ChoiceFieldProps {
   label: string;
   draft: Record<string, unknown>;
   inputs: TypeInputs;
+  pathInputs: PathInputs;
   setAt: (path: Path, value: unknown) => void;
 }
 
@@ -322,6 +339,7 @@ function ChoiceField({
   label,
   draft,
   inputs,
+  pathInputs,
   setAt,
 }: ChoiceFieldProps): ReactNode {
   const base = relative.slice(0, -3);
@@ -373,6 +391,7 @@ function ChoiceField({
             path={activePath}
             draft={draft}
             inputs={inputs}
+            pathInputs={pathInputs}
             setAt={setAt}
             override={activeValue}
           />
@@ -389,6 +408,7 @@ interface SingleValueInputProps {
   path: Path;
   draft: Record<string, unknown>;
   inputs: TypeInputs;
+  pathInputs: PathInputs;
   setAt: (path: Path, value: unknown) => void;
   override?: unknown;
 }
@@ -400,6 +420,7 @@ function SingleValueInput({
   path,
   draft,
   inputs,
+  pathInputs,
   setAt,
   override,
 }: SingleValueInputProps): ReactNode {
@@ -414,6 +435,7 @@ function SingleValueInput({
           pathPrefix={path}
           draft={draft}
           inputs={inputs}
+          pathInputs={pathInputs}
           setAt={setAt}
         />
       </div>
@@ -421,7 +443,9 @@ function SingleValueInput({
   }
 
   const input: FhirTypeInput =
-    (typeCode ? inputs[typeCode] : undefined) ?? JsonFallbackInput;
+    pathInputs[element.path!] ??
+    (typeCode ? inputs[typeCode] : undefined) ??
+    JsonFallbackInput;
   return (
     <>
       {input({

--- a/packages/react-fhir/src/components/inputs/DataAbsentReason.test.tsx
+++ b/packages/react-fhir/src/components/inputs/DataAbsentReason.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { CodeableConcept, ElementDefinition } from "fhir/r4";
+import { describe, expect, it, vi } from "vitest";
+import { DataAbsentReasonInput } from "./DataAbsentReason.js";
+
+const element: ElementDefinition = {
+  path: "Observation.dataAbsentReason",
+  type: [{ code: "CodeableConcept" }],
+  short: "Why the result is missing",
+};
+
+const renderInput = (
+  value: CodeableConcept | undefined,
+  onChange: (v: CodeableConcept | undefined) => void = () => {},
+) =>
+  render(
+    <DataAbsentReasonInput
+      value={value}
+      onChange={onChange}
+      context={{ path: element.path!, typeCode: "CodeableConcept", element }}
+    />,
+  );
+
+describe("DataAbsentReasonInput", () => {
+  it("renders a trigger button when no reason is set", () => {
+    renderInput(undefined);
+    expect(
+      screen.getByRole("button", { name: /mark result as missing/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("clicking the trigger seeds a default standard reason ('unknown')", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderInput(undefined, onChange);
+    await user.click(screen.getByRole("button", { name: /mark result as missing/i }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0]?.[0]).toEqual({
+      coding: [
+        {
+          system: "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+          code: "unknown",
+          display: "Unknown",
+        },
+      ],
+    });
+  });
+
+  it("renders the standard-reason dropdown when a standard coding is set", () => {
+    renderInput({
+      coding: [
+        {
+          system: "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+          code: "asked-declined",
+          display: "Asked but declined",
+        },
+      ],
+    });
+    const select = screen.getByRole("combobox", { name: /reason/i });
+    expect(select).toHaveValue("asked-declined");
+    // Raw CodeableConcept fields stay hidden for standard reasons.
+    expect(screen.queryByText(/^Text$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^System$/)).not.toBeInTheDocument();
+  });
+
+  it("changing the dropdown emits a new standard CodeableConcept", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderInput(
+      {
+        coding: [
+          {
+            system: "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+            code: "unknown",
+            display: "Unknown",
+          },
+        ],
+      },
+      onChange,
+    );
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: /reason/i }),
+      "masked",
+    );
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual({
+      coding: [
+        {
+          system: "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+          code: "masked",
+          display: "Masked",
+        },
+      ],
+    });
+  });
+
+  it("selecting 'Other (custom code)' clears the standard coding and reveals raw fields", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderInput(
+      {
+        coding: [
+          {
+            system: "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+            code: "unknown",
+            display: "Unknown",
+          },
+        ],
+      },
+      onChange,
+    );
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: /reason/i }),
+      "__custom__",
+    );
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual({});
+  });
+
+  it("renders the raw CodeableConcept fields when value is custom (non-standard system)", () => {
+    renderInput({
+      text: "see attached",
+      coding: [{ system: "https://example/local", code: "x" }],
+    });
+    expect(screen.getByText(/^Text$/)).toBeInTheDocument();
+    expect(screen.getByText(/^System$/)).toBeInTheDocument();
+    expect(screen.getByText(/^Code$/)).toBeInTheDocument();
+    expect(screen.getByText(/^Display$/)).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: /reason/i })).toHaveValue("__custom__");
+  });
+
+  it("clicking the clear button emits undefined", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderInput(
+      {
+        coding: [
+          {
+            system: "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+            code: "unknown",
+            display: "Unknown",
+          },
+        ],
+      },
+      onChange,
+    );
+    await user.click(screen.getByRole("button", { name: /clear reason/i }));
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/packages/react-fhir/src/components/inputs/DataAbsentReason.tsx
+++ b/packages/react-fhir/src/components/inputs/DataAbsentReason.tsx
@@ -1,0 +1,98 @@
+import type { CodeableConcept } from "fhir/r4";
+import { CodeableConceptInput } from "./CodeableConcept.js";
+import { baseField, type FhirTypeInput } from "./types.js";
+
+const DAR_SYSTEM = "http://terminology.hl7.org/CodeSystem/data-absent-reason";
+
+const STANDARD_REASONS = [
+  { code: "unknown", display: "Unknown" },
+  { code: "asked-unknown", display: "Asked but unknown" },
+  { code: "temp-unknown", display: "Temporarily unknown" },
+  { code: "not-asked", display: "Not asked" },
+  { code: "asked-declined", display: "Asked but declined" },
+  { code: "masked", display: "Masked" },
+  { code: "not-applicable", display: "Not applicable" },
+  { code: "unsupported", display: "Unsupported" },
+  { code: "as-text", display: "As text" },
+  { code: "error", display: "Error" },
+  { code: "not-a-number", display: "Not a number (NaN)" },
+  { code: "negative-infinity", display: "Negative infinity" },
+  { code: "positive-infinity", display: "Positive infinity" },
+  { code: "not-performed", display: "Not performed" },
+  { code: "not-permitted", display: "Not permitted" },
+] as const;
+
+const STANDARD_CODES = new Set<string>(STANDARD_REASONS.map((r) => r.code));
+const CUSTOM_OPTION = "__custom__";
+
+const isStandard = (cc: CodeableConcept | undefined): boolean => {
+  const c = cc?.coding?.[0];
+  return !!c && c.system === DAR_SYSTEM && !!c.code && STANDARD_CODES.has(c.code);
+};
+
+const standardConcept = (code: string): CodeableConcept => {
+  const display = STANDARD_REASONS.find((r) => r.code === code)?.display;
+  return { coding: [{ system: DAR_SYSTEM, code, display }] };
+};
+
+export const DataAbsentReasonInput: FhirTypeInput<CodeableConcept> = ({
+  value,
+  onChange,
+  context,
+}) => {
+  if (value === undefined) {
+    return (
+      <button
+        type="button"
+        data-testid="data-absent-reason-toggle"
+        onClick={() => onChange(standardConcept("unknown"))}
+        className="rounded border border-dashed border-slate-300 px-2 py-1 text-xs text-slate-600 hover:border-slate-400"
+      >
+        + Mark result as missing
+      </button>
+    );
+  }
+
+  const standard = isStandard(value);
+  const currentCode = value.coding?.[0]?.code ?? "";
+  const selectValue = standard ? currentCode : CUSTOM_OPTION;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-start gap-2">
+        <select
+          aria-label="Reason"
+          data-testid="data-absent-reason-select"
+          className={`${baseField} sm:max-w-xs`}
+          value={selectValue}
+          onChange={(e) => {
+            const next = e.target.value;
+            if (next === CUSTOM_OPTION) {
+              onChange(standard ? {} : value);
+            } else {
+              onChange(standardConcept(next));
+            }
+          }}
+        >
+          {STANDARD_REASONS.map((r) => (
+            <option key={r.code} value={r.code}>
+              {r.display}
+            </option>
+          ))}
+          <option value={CUSTOM_OPTION}>Other (custom code)…</option>
+        </select>
+        <button
+          type="button"
+          onClick={() => onChange(undefined)}
+          aria-label="Clear reason"
+          className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-600 hover:border-red-400 hover:text-red-600"
+        >
+          ×
+        </button>
+      </div>
+      {!standard && (
+        <CodeableConceptInput value={value} onChange={onChange} context={context} />
+      )}
+    </div>
+  );
+};

--- a/packages/react-fhir/src/components/inputs/index.ts
+++ b/packages/react-fhir/src/components/inputs/index.ts
@@ -2,6 +2,7 @@ import { AddressInput } from "./Address.js";
 import { CodeableConceptInput } from "./CodeableConcept.js";
 import { CodingInput } from "./Coding.js";
 import { ContactPointInput } from "./ContactPoint.js";
+import { DataAbsentReasonInput } from "./DataAbsentReason.js";
 import { HumanNameInput } from "./HumanName.js";
 import { IdentifierInput } from "./Identifier.js";
 import { PeriodInput } from "./Period.js";
@@ -18,15 +19,17 @@ import {
 } from "./primitives.js";
 import { QuantityInput } from "./Quantity.js";
 import { ReferenceInput } from "./Reference.js";
-import { type FhirTypeInput, type TypeInputs } from "./types.js";
+import { type FhirTypeInput, type PathInputs, type TypeInputs } from "./types.js";
 
 export type {
   FhirInputProps,
   FhirTypeInput,
   InputContext,
+  PathInputs,
   TypeInputs,
 } from "./types.js";
 
+export { DataAbsentReasonInput } from "./DataAbsentReason.js";
 export { JsonFallbackInput } from "./JsonFallback.js";
 
 export const defaultTypeInputs: TypeInputs = {
@@ -62,4 +65,9 @@ export const defaultTypeInputs: TypeInputs = {
   SimpleQuantity: QuantityInput as FhirTypeInput,
   Coding: CodingInput as FhirTypeInput,
   CodeableConcept: CodeableConceptInput as FhirTypeInput,
+};
+
+/** Path-based input overrides applied by ResourceEditor on top of `defaultTypeInputs`. */
+export const defaultPathInputs: PathInputs = {
+  "Observation.dataAbsentReason": DataAbsentReasonInput as FhirTypeInput,
 };

--- a/packages/react-fhir/src/components/inputs/types.ts
+++ b/packages/react-fhir/src/components/inputs/types.ts
@@ -17,6 +17,9 @@ export interface FhirInputProps<T = unknown> {
 export type FhirTypeInput<T = unknown> = (props: FhirInputProps<T>) => ReactNode;
 export type TypeInputs = Record<string, FhirTypeInput>;
 
+/** Per-path overrides keyed by full ElementDefinition.path (e.g. "Observation.dataAbsentReason"). */
+export type PathInputs = Record<string, FhirTypeInput>;
+
 /** Shared form-field classes so every datatype renders consistently. */
 export const baseField =
   "w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none";


### PR DESCRIPTION
The generic CodeableConcept input rendered "Why the result is missing"
as Text + Coding (System/Code/Display) — a verbose schema dump for a
field that almost always uses one of fifteen standard codes.

Replace it with a path-scoped input that hides the section behind a
"+ Mark result as missing" trigger, then exposes a dropdown of the
standard data-absent-reason codes (with an "Other (custom code)…"
escape hatch falling back to the raw CodeableConcept fields). To keep
this scoped without polluting the type-keyed registry, add a new
`pathInputs` registry to ResourceEditor keyed on ElementDefinition.path.

https://claude.ai/code/session_01N7et2vLuvUjCMjjJHDB4Na