### PR TITLE
feat(renderers): expandable Meta with one row per field

### DIFF
--- a/packages/react-fhir/src/components/renderers.test.tsx
+++ b/packages/react-fhir/src/components/renderers.test.tsx
@@ -1,4 +1,4 @@
-import type { CodeableConcept } from "fhir/r4";
+import type { CodeableConcept, Meta } from "fhir/r4";
 import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import {
@@ -170,6 +170,71 @@ describe("CodeableConcept renderer", () => {
     };
     const { container } = render(<>{renderer(cc, ctx)}</>);
     expect(container.querySelector("button")).toBeNull();
+  });
+});
+
+describe("Meta renderer", () => {
+  const renderer = defaultTypeRenderers.Meta!;
+  const ctx = { path: "Patient.meta", typeCode: "Meta" };
+
+  it("renders a summary line with versionId, lastUpdated, and source", () => {
+    const m: Meta = {
+      versionId: "1",
+      lastUpdated: "2026-02-10T17:48:37.700+00:00",
+      source: "#wiWDxr1Jk1z1zMIZ",
+    };
+    const { container } = render(<>{renderer(m, ctx)}</>);
+    const summary = container.querySelector("summary");
+    expect(summary).not.toBeNull();
+    expect(summary!.textContent).toContain("v1");
+    expect(summary!.textContent).toContain("2026-02-10T17:48:37.700+00:00");
+    expect(summary!.textContent).toContain("#wiWDxr1Jk1z1zMIZ");
+  });
+
+  it("exposes one row per Meta field inside the expandable", () => {
+    const m: Meta = {
+      versionId: "3",
+      lastUpdated: "2026-02-10T17:48:37.700+00:00",
+      source: "#abc",
+      profile: ["http://hl7.org/fhir/StructureDefinition/Patient"],
+      security: [{ system: "http://example.org/sec", code: "TOP" }],
+      tag: [{ system: "http://example.org/tag", code: "demo" }],
+    };
+    const { container } = render(<>{renderer(m, ctx)}</>);
+    const labels = Array.from(container.querySelectorAll("dt")).map((n) => n.textContent);
+    expect(labels).toEqual([
+      "Version Id",
+      "Last Updated",
+      "Source",
+      "Profile",
+      "Security",
+      "Tag",
+    ]);
+    expect(container.textContent).toContain("http://hl7.org/fhir/StructureDefinition/Patient");
+    expect(container.textContent).toContain("TOP");
+    expect(container.textContent).toContain("demo");
+  });
+
+  it("toggles open and closed via the summary element", () => {
+    const m: Meta = { versionId: "1", lastUpdated: "2026-02-10T17:48:37.700+00:00" };
+    const { container } = render(<>{renderer(m, ctx)}</>);
+    const details = container.querySelector("details") as HTMLDetailsElement;
+    expect(details.open).toBe(false);
+    fireEvent.click(container.querySelector("summary")!);
+    expect(details.open).toBe(true);
+  });
+
+  it("hides rows for fields that are absent", () => {
+    const m: Meta = { versionId: "1" };
+    const { container } = render(<>{renderer(m, ctx)}</>);
+    const labels = Array.from(container.querySelectorAll("dt")).map((n) => n.textContent);
+    expect(labels).toEqual(["Version Id"]);
+  });
+
+  it("renders an em-dash when there are no fields", () => {
+    const { container } = render(<>{renderer({} as Meta, ctx)}</>);
+    expect(container.querySelector("details")).toBeNull();
+    expect(container.textContent).toBe("—");
   });
 });
 

--- a/packages/react-fhir/src/components/renderers.tsx
+++ b/packages/react-fhir/src/components/renderers.tsx
@@ -16,7 +16,7 @@ import type {
   Reference,
 } from "fhir/r4";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import {
   formatAddress,
   formatHumanName,
@@ -407,14 +407,84 @@ const AttachmentRenderer: FhirTypeRenderer = (value) => {
   return <span>{label}</span>;
 };
 
-const MetaRenderer: FhirTypeRenderer = (value) => {
+const MetaRenderer: FhirTypeRenderer = (value, ctx) => {
   const m = value as Meta;
-  const parts = [
+  const summaryParts = [
     m.versionId && `v${m.versionId}`,
     m.lastUpdated,
     m.source,
   ].filter(Boolean);
-  return <span className="text-slate-600">{parts.join(" · ")}</span>;
+  const fields: { label: string; node: ReactNode }[] = [];
+  if (m.versionId) {
+    fields.push({ label: "Version Id", node: <span>{m.versionId}</span> });
+  }
+  if (m.lastUpdated) {
+    fields.push({
+      label: "Last Updated",
+      node: <time dateTime={m.lastUpdated}>{m.lastUpdated}</time>,
+    });
+  }
+  if (m.source) {
+    fields.push({ label: "Source", node: <span className="break-all">{m.source}</span> });
+  }
+  if (m.profile?.length) {
+    fields.push({
+      label: "Profile",
+      node: (
+        <ul className="space-y-1">
+          {m.profile.map((p, i) => (
+            <li key={`${p}-${i}`} className="break-all">
+              {Uri_(p, ctx)}
+            </li>
+          ))}
+        </ul>
+      ),
+    });
+  }
+  if (m.security?.length) {
+    fields.push({
+      label: "Security",
+      node: (
+        <ul className="space-y-1">
+          {m.security.map((c, i) => (
+            <li key={`${c.system ?? ""}#${c.code ?? ""}#${i}`}>{CodingRenderer(c, ctx)}</li>
+          ))}
+        </ul>
+      ),
+    });
+  }
+  if (m.tag?.length) {
+    fields.push({
+      label: "Tag",
+      node: (
+        <ul className="space-y-1">
+          {m.tag.map((c, i) => (
+            <li key={`${c.system ?? ""}#${c.code ?? ""}#${i}`}>{CodingRenderer(c, ctx)}</li>
+          ))}
+        </ul>
+      ),
+    });
+  }
+
+  if (fields.length === 0) {
+    return <span className="text-slate-400">—</span>;
+  }
+
+  return (
+    <details className="group">
+      <summary className="cursor-pointer text-slate-600 marker:text-slate-400">
+        {summaryParts.join(" · ")}
+      </summary>
+      <dl className="mt-2 grid grid-cols-1 gap-x-3 gap-y-1 border-l-2 border-slate-200 pl-3 sm:grid-cols-[minmax(6rem,1fr)_3fr]">
+        {fields.map((f) => (
+          <Fragment key={f.label}>
+            <dt className="text-xs font-medium text-slate-500">{f.label}</dt>
+            <dd className="text-sm">{f.node}</dd>
+          </Fragment>
+        ))}
+      </dl>
+    </details>
+  );
 };
 
 const AnnotationRenderer: FhirTypeRenderer = (value) => {


### PR DESCRIPTION
Replace the single-line Meta summary with a <details> block: the summary
keeps the existing "v1 · lastUpdated · source" line, and expanding it
reveals a row for each populated Meta field (versionId, lastUpdated,
source, profile, security, tag) so the values are individually readable
on the resource detail page.