### PR TITLE
feat(reference-picker): optional birthdate filter for person types

### DIFF
--- a/packages/react-fhir/src/components/ReferencePicker.test.tsx
+++ b/packages/react-fhir/src/components/ReferencePicker.test.tsx
@@ -113,4 +113,80 @@ describe("ReferencePicker", () => {
       expect(screen.getByText(/no matches/i)).toBeInTheDocument(),
     );
   });
+
+  it("does not render a birth-date input for non-person target types", () => {
+    render(
+      <ReferencePicker targets={["Organization"]} value={undefined} onChange={() => {}} />,
+      { wrapper: wrap() },
+    );
+    expect(screen.queryByLabelText(/birth date/i)).not.toBeInTheDocument();
+  });
+
+  it("searches by birthdate alone (no free-text query) for Patient", async () => {
+    const seen: string[] = [];
+    server.use(
+      http.get(`${BASE}/Patient`, ({ request }) => {
+        seen.push(request.url);
+        return HttpResponse.json({
+          resourceType: "Bundle",
+          type: "searchset",
+          entry: [{ resource: patients[0] }],
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <ReferencePicker
+        targets={["Patient"]}
+        value={undefined}
+        onChange={() => {}}
+        debounceMs={0}
+      />,
+      { wrapper: wrap() },
+    );
+
+    await user.type(screen.getByLabelText(/birth date/i), "1815-12-10");
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /Ada Lovelace/ })).toBeInTheDocument(),
+    );
+    const url = new URL(seen[seen.length - 1]!);
+    expect(url.searchParams.get("birthdate")).toBe("1815-12-10");
+    expect(url.searchParams.get("name")).toBeNull();
+  });
+
+  it("combines name and birthdate when both are set", async () => {
+    const seen: string[] = [];
+    server.use(
+      http.get(`${BASE}/Patient`, ({ request }) => {
+        seen.push(request.url);
+        return HttpResponse.json({
+          resourceType: "Bundle",
+          type: "searchset",
+          entry: [{ resource: patients[0] }],
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <ReferencePicker
+        targets={["Patient"]}
+        value={undefined}
+        onChange={() => {}}
+        debounceMs={0}
+      />,
+      { wrapper: wrap() },
+    );
+
+    await user.type(screen.getByRole("searchbox", { name: /search patient/i }), "Lovelace");
+    await user.type(screen.getByLabelText(/birth date/i), "1815-12-10");
+    await waitFor(() => {
+      const last = seen[seen.length - 1];
+      if (!last) throw new Error("no request yet");
+      const url = new URL(last);
+      expect(url.searchParams.get("name")).toBe("Lovelace");
+      expect(url.searchParams.get("birthdate")).toBe("1815-12-10");
+    });
+  });
 });

--- a/packages/react-fhir/src/components/ReferencePicker.tsx
+++ b/packages/react-fhir/src/components/ReferencePicker.tsx
@@ -1,5 +1,6 @@
 import type { Reference, Resource } from "fhir/r4";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
+import type { SearchParams } from "../client/types.js";
 import { useSearch } from "../hooks/queries.js";
 import { formatReferenceLabel } from "../structure/format.js";
 
@@ -17,6 +18,14 @@ export interface ReferencePickerProps {
   className?: string;
 }
 
+/** Resource types that support the `birthdate` search parameter in FHIR R4. */
+const birthdateTypes = new Set([
+  "Patient",
+  "Practitioner",
+  "RelatedPerson",
+  "Person",
+]);
+
 /**
  * Debounced search-and-pick picker for FHIR References. Pairs with the
  * library's existing `<ResourceEditor>` by replacing the raw `Type/id` text
@@ -29,6 +38,7 @@ export function ReferencePicker(props: ReferencePickerProps) {
   );
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [birthdate, setBirthdate] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
@@ -37,13 +47,22 @@ export function ReferencePicker(props: ReferencePickerProps) {
   }, [query, debounceMs]);
 
   const searchField = props.searchParam ?? defaultSearchParamFor(selectedType);
+  const supportsBirthdate = birthdateTypes.has(selectedType);
+  const activeBirthdate = supportsBirthdate ? birthdate : "";
+  const hasFilter = Boolean(debouncedQuery) || Boolean(activeBirthdate);
+
+  const searchParams = useMemo<SearchParams | undefined>(() => {
+    if (!hasFilter) return undefined;
+    const p: SearchParams = { _count: limit };
+    if (debouncedQuery) p[searchField] = debouncedQuery;
+    if (activeBirthdate) p.birthdate = activeBirthdate;
+    return p;
+  }, [hasFilter, debouncedQuery, searchField, activeBirthdate, limit]);
 
   const { data, isFetching } = useSearch<Resource>(
     selectedType,
-    debouncedQuery
-      ? { [searchField]: debouncedQuery, _count: limit }
-      : undefined,
-    { enabled: Boolean(debouncedQuery) },
+    searchParams,
+    { enabled: hasFilter },
   );
 
   const results = useMemo(
@@ -59,6 +78,7 @@ export function ReferencePicker(props: ReferencePickerProps) {
     });
     setIsOpen(false);
     setQuery("");
+    setBirthdate("");
   };
 
   return (
@@ -84,7 +104,7 @@ export function ReferencePicker(props: ReferencePickerProps) {
           </button>
         </div>
       ) : (
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           {targets.length > 1 && (
             <select
               aria-label="target type"
@@ -109,12 +129,26 @@ export function ReferencePicker(props: ReferencePickerProps) {
               setIsOpen(true);
             }}
             onFocus={() => setIsOpen(true)}
-            className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
+            className="min-w-[12rem] flex-1 rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
           />
+          {supportsBirthdate && (
+            <input
+              type="date"
+              aria-label="Birth date"
+              title="Filter by date of birth (optional)"
+              value={birthdate}
+              onChange={(e) => {
+                setBirthdate(e.target.value);
+                setIsOpen(true);
+              }}
+              onFocus={() => setIsOpen(true)}
+              className="rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
+            />
+          )}
         </div>
       )}
 
-      {!value?.reference && isOpen && debouncedQuery && (
+      {!value?.reference && isOpen && hasFilter && (
         <ul
           role="listbox"
           className="absolute left-2 right-2 z-10 max-h-64 overflow-auto rounded border border-slate-200 bg-white shadow-lg"


### PR DESCRIPTION
Adds a date-of-birth input alongside the name search for Patient,
Practitioner, RelatedPerson, and Person targets. Either filter alone
triggers a search; when both are set they're combined into a single
FHIR query (name=…&birthdate=YYYY-MM-DD).