### PR TITLE
Fix patient name showing as raw JSON in table view

### DIFF
--- a/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
@@ -341,6 +341,7 @@ export function ResourceListPage() {
             cellRenderers={
               resourceType === "Patient"
                 ? {
+                    name: (r) => <span>{config!.formatPrimary!(r)}</span>,
                     __counts: (patient) =>
                       patient.id ? (
                         <PatientRowCounts patientId={patient.id} />


### PR DESCRIPTION
Add a `name` cell renderer for the Patient table that uses the existing
`formatPrimary` function, so names display as "Given Family" regardless
of whether the StructureDefinition has loaded.

https://claude.ai/code/session_01PuEhs1dHSTQpAJ4jMbHAs8