### PR TITLE
Add per-resource sort options to the resource list page

### DIFF
--- a/apps/demo/src/resourceListConfig.ts
+++ b/apps/demo/src/resourceListConfig.ts
@@ -17,6 +17,13 @@ export interface ResourceListColumn {
   label: string;
 }
 
+export interface SortOption {
+  /** Human-readable label, e.g. "Date (newest)". */
+  label: string;
+  /** FHIR _sort value, e.g. "-date" for descending. */
+  param: string;
+}
+
 export interface ResourceListConfig<T extends Resource = Resource> {
   /** Heading on the unscoped index page, e.g. "Patients". */
   title: string;
@@ -28,6 +35,8 @@ export interface ResourceListConfig<T extends Resource = Resource> {
   tableColumns: ResourceListColumn[];
   /** Column subset shown by default. */
   defaultVisibleColumns: string[];
+  /** Resource-specific sort options exposed in the sort picker. */
+  sortOptions?: SortOption[];
   /** Optional list-view title. When omitted the type only renders in table view. */
   formatPrimary?: (resource: T) => string;
   /** Optional list-view metadata items rendered after the title. */
@@ -68,6 +77,12 @@ const PATIENT: ResourceListConfig<Patient> = {
   title: "Patients",
   singular: "patient",
   priorityParams: ["name", "family", "given", "gender", "birthdate", "address-city"],
+  sortOptions: [
+    { label: "Name (A → Z)", param: "family" },
+    { label: "Name (Z → A)", param: "-family" },
+    { label: "Birth date (newest)", param: "-birthdate" },
+    { label: "Birth date (oldest)", param: "birthdate" },
+  ],
   tableColumns: [
     { path: "name", label: "Name" },
     { path: "gender", label: "Gender" },
@@ -103,6 +118,11 @@ const OBSERVATION: ResourceListConfig<Observation> = {
   title: "Observations",
   singular: "observation",
   priorityParams: ["patient", "code", "category", "status", "date"],
+  sortOptions: [
+    { label: "Date (newest)", param: "-date" },
+    { label: "Date (oldest)", param: "date" },
+    { label: "Code (A → Z)", param: "code" },
+  ],
   tableColumns: [
     { path: "status", label: "Status" },
     { path: "code.text", label: "Observation" },
@@ -122,6 +142,13 @@ const CONDITION: ResourceListConfig<Condition> = {
   title: "Conditions",
   singular: "condition",
   priorityParams: ["patient", "code", "category", "clinical-status", "onset-date"],
+  sortOptions: [
+    { label: "Onset (newest)", param: "-onset-date" },
+    { label: "Onset (oldest)", param: "onset-date" },
+    { label: "Recorded (newest)", param: "-recorded-date" },
+    { label: "Recorded (oldest)", param: "recorded-date" },
+    { label: "Code (A → Z)", param: "code" },
+  ],
   tableColumns: [
     { path: "clinicalStatus.text", label: "Status" },
     { path: "code.text", label: "Condition" },
@@ -140,6 +167,11 @@ const MEDICATION_REQUEST: ResourceListConfig<MedicationRequest> = {
   title: "Medication requests",
   singular: "medication request",
   priorityParams: ["patient", "code", "status", "intent", "authoredon"],
+  sortOptions: [
+    { label: "Ordered (newest)", param: "-authoredon" },
+    { label: "Ordered (oldest)", param: "authoredon" },
+    { label: "Medication (A → Z)", param: "code" },
+  ],
   tableColumns: [
     { path: "status", label: "Status" },
     { path: "intent", label: "Intent" },
@@ -158,6 +190,11 @@ const ALLERGY_INTOLERANCE: ResourceListConfig<AllergyIntolerance> = {
   title: "Allergies & intolerances",
   singular: "allergy",
   priorityParams: ["patient", "code", "clinical-status", "type", "category"],
+  sortOptions: [
+    { label: "Substance (A → Z)", param: "code" },
+    { label: "Clinical status", param: "clinical-status" },
+    { label: "Criticality", param: "criticality" },
+  ],
   tableColumns: [
     { path: "clinicalStatus.text", label: "Status" },
     { path: "code.text", label: "Substance" },
@@ -177,6 +214,12 @@ const PROCEDURE: ResourceListConfig<Procedure> = {
   title: "Procedures",
   singular: "procedure",
   priorityParams: ["patient", "code", "status", "date"],
+  sortOptions: [
+    { label: "Date (newest)", param: "-date" },
+    { label: "Date (oldest)", param: "date" },
+    { label: "Code (A → Z)", param: "code" },
+    { label: "Status", param: "status" },
+  ],
   tableColumns: [
     { path: "status", label: "Status" },
     { path: "code.text", label: "Procedure" },
@@ -193,6 +236,12 @@ const ENCOUNTER: ResourceListConfig<Encounter> = {
   title: "Encounters",
   singular: "encounter",
   priorityParams: ["patient", "status", "class", "type", "date"],
+  sortOptions: [
+    { label: "Date (newest)", param: "-date" },
+    { label: "Date (oldest)", param: "date" },
+    { label: "Status", param: "status" },
+    { label: "Type (A → Z)", param: "type" },
+  ],
   tableColumns: [
     { path: "status", label: "Status" },
     { path: "class.code", label: "Class" },
@@ -211,6 +260,12 @@ const IMMUNIZATION: ResourceListConfig<Immunization> = {
   title: "Immunizations",
   singular: "immunization",
   priorityParams: ["patient", "vaccine-code", "status", "date"],
+  sortOptions: [
+    { label: "Date (newest)", param: "-date" },
+    { label: "Date (oldest)", param: "date" },
+    { label: "Vaccine (A → Z)", param: "vaccine-code" },
+    { label: "Status", param: "status" },
+  ],
   tableColumns: [
     { path: "status", label: "Status" },
     { path: "vaccineCode.text", label: "Vaccine" },
@@ -227,6 +282,13 @@ const DIAGNOSTIC_REPORT: ResourceListConfig<DiagnosticReport> = {
   title: "Diagnostic reports",
   singular: "diagnostic report",
   priorityParams: ["patient", "code", "category", "status", "date"],
+  sortOptions: [
+    { label: "Date (newest)", param: "-date" },
+    { label: "Date (oldest)", param: "date" },
+    { label: "Issued (newest)", param: "-issued" },
+    { label: "Issued (oldest)", param: "issued" },
+    { label: "Code (A → Z)", param: "code" },
+  ],
   tableColumns: [
     { path: "status", label: "Status" },
     { path: "code.text", label: "Report" },
@@ -245,6 +307,12 @@ const CARE_PLAN: ResourceListConfig<CarePlan> = {
   title: "Care plans",
   singular: "care plan",
   priorityParams: ["patient", "category", "status", "intent", "date"],
+  sortOptions: [
+    { label: "Date (newest)", param: "-date" },
+    { label: "Date (oldest)", param: "date" },
+    { label: "Status", param: "status" },
+    { label: "Intent", param: "intent" },
+  ],
   tableColumns: [
     { path: "status", label: "Status" },
     { path: "intent", label: "Intent" },

--- a/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
@@ -7,7 +7,7 @@ import {
   useStructureDefinition,
 } from "@fhir-place/react-fhir";
 import type { Resource } from "fhir/r4";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import type { SearchParams } from "@fhir-place/react-fhir";
 import { PatientRowCounts } from "../../../components/PatientRowCounts.js";
@@ -17,6 +17,7 @@ import {
   isTopResourceType,
   type ResourceListColumn,
   type ResourceListConfig,
+  type SortOption,
 } from "../../../resourceListConfig.js";
 
 type Layout = "list" | "table";
@@ -269,6 +270,23 @@ export function ResourceListPage() {
         onSubmit={submitFilters}
       />
 
+      {config?.sortOptions && config.sortOptions.length > 0 && (
+        <SortPicker
+          options={config.sortOptions}
+          value={searchParams.get("_sort") ?? undefined}
+          onChange={(param) => {
+            const entries: Array<[string, string]> = [];
+            if (patientId) entries.push(["patient", patientId]);
+            for (const [k, v] of searchParams.entries()) {
+              if (k === "patient" || k === "_sort") continue;
+              entries.push([k, v]);
+            }
+            if (param) entries.push(["_sort", param]);
+            setSearchParams(Object.fromEntries(entries), { replace: true });
+          }}
+        />
+      )}
+
       <SearchRequestPreview
         baseUrl={client.baseUrl}
         resourceType={resourceType}
@@ -377,6 +395,86 @@ export function ResourceListPage() {
           >
             {isFetchingNextPage ? "Loading…" : "Load more"}
           </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface SortPickerProps {
+  options: SortOption[];
+  value: string | undefined;
+  onChange: (param: string | undefined) => void;
+}
+
+function SortPicker({ options, value, onChange }: SortPickerProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const activeLabel = options.find((o) => o.param === value)?.label;
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className={`inline-flex items-center gap-1.5 rounded border px-3 py-1.5 text-sm shadow-sm ${
+          value
+            ? "border-blue-300 bg-blue-50 text-blue-700"
+            : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50"
+        }`}
+      >
+        <span>Sort{activeLabel ? `: ${activeLabel}` : ""}</span>
+        <svg
+          aria-hidden="true"
+          className={`h-3.5 w-3.5 transition-transform ${open ? "rotate-180" : ""}`}
+          viewBox="0 0 16 16"
+          fill="currentColor"
+        >
+          <path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full z-10 mt-1 w-max rounded border border-slate-200 bg-white p-2 shadow-md">
+          <div className="flex flex-wrap gap-1.5">
+            {options.map((opt) => (
+              <button
+                key={opt.param}
+                type="button"
+                onClick={() => {
+                  onChange(value === opt.param ? undefined : opt.param);
+                  setOpen(false);
+                }}
+                className={`rounded px-2.5 py-1 text-sm font-medium transition-colors ${
+                  value === opt.param
+                    ? "bg-blue-600 text-white"
+                    : "bg-slate-100 text-slate-700 hover:bg-slate-200"
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+          {value && (
+            <button
+              type="button"
+              onClick={() => { onChange(undefined); setOpen(false); }}
+              className="mt-2 w-full rounded border border-slate-200 px-2 py-1 text-xs text-slate-500 hover:bg-slate-50"
+            >
+              Clear sort
+            </button>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Adds a SortPicker dropdown below the search form that exposes curated
FHIR _sort parameters for each of the 10 configured resource types.
The selected sort is persisted in the URL so it survives reloads and
can be shared. The button turns blue when a sort is active and shows
the current label; a "Clear sort" option appears inside the dropdown.

https://claude.ai/code/session_014FEicSweh7ztKUR5LqRLUP