### PR TITLE
feat(client): separate terminology FhirClient so $expand can target a SNOMED-capable server

### DIFF
--- a/apps/demo/src/config.test.ts
+++ b/apps/demo/src/config.test.ts
@@ -236,3 +236,39 @@ describe("resolveActiveServer", () => {
     expect(resolveActiveServer().id).toBe(BUILTIN_SERVERS[0]!.id);
   });
 });
+
+describe("terminology base URL persistence", () => {
+  it("returns the default tx.fhir.org URL when storage is empty", async () => {
+    const { DEFAULT_TERMINOLOGY_BASE_URL, loadStoredTerminologyBaseUrl } =
+      await import("./config.js");
+    expect(DEFAULT_TERMINOLOGY_BASE_URL).toBe("https://tx.fhir.org/r4");
+    expect(loadStoredTerminologyBaseUrl()).toBeNull();
+  });
+
+  it("round-trips through localStorage via save/load", async () => {
+    const { loadStoredTerminologyBaseUrl, saveTerminologyBaseUrl } = await import(
+      "./config.js"
+    );
+    saveTerminologyBaseUrl("https://ontoserver.example/fhir");
+    expect(loadStoredTerminologyBaseUrl()).toBe("https://ontoserver.example/fhir");
+  });
+
+  it("clears storage when an empty value is saved (revert to default)", async () => {
+    const { loadStoredTerminologyBaseUrl, saveTerminologyBaseUrl } = await import(
+      "./config.js"
+    );
+    saveTerminologyBaseUrl("https://ontoserver.example/fhir");
+    saveTerminologyBaseUrl("");
+    expect(loadStoredTerminologyBaseUrl()).toBeNull();
+  });
+
+  it("trims whitespace before storing, treats whitespace-only as clear", async () => {
+    const { loadStoredTerminologyBaseUrl, saveTerminologyBaseUrl } = await import(
+      "./config.js"
+    );
+    saveTerminologyBaseUrl("  https://x.example/fhir  ");
+    expect(loadStoredTerminologyBaseUrl()).toBe("https://x.example/fhir");
+    saveTerminologyBaseUrl("   ");
+    expect(loadStoredTerminologyBaseUrl()).toBeNull();
+  });
+});

--- a/apps/demo/src/config.ts
+++ b/apps/demo/src/config.ts
@@ -58,6 +58,7 @@ export const BUILTIN_SERVERS: ReadonlyArray<ServerConfig> = [
 const SERVERS_STORAGE_KEY = "fhir-place:servers";
 const ACTIVE_SERVER_STORAGE_KEY = "fhir-place:active-server";
 const ANTHROPIC_API_KEY_STORAGE_KEY = "fhir-place:anthropic-api-key";
+const TERMINOLOGY_BASE_URL_STORAGE_KEY = "fhir-place:terminology-base-url";
 
 export const loadAnthropicApiKey = (): string => {
   if (typeof window === "undefined") return "";
@@ -224,6 +225,54 @@ export const buildRequestHeaders = (server: ServerConfig): Record<string, string
   }
   return headers;
 };
+
+/**
+ * Separate terminology server for ValueSet/$expand. Most data servers (HAPI
+ * default, Aidbox without a SNOMED license, Medplum) cannot expand SNOMED,
+ * LOINC, ICD-10, or BCP-47, so dropdowns bound to those code systems return
+ * 4xx/5xx and stay empty. `tx.fhir.org` is the HL7 community terminology
+ * service, allows browser CORS, and covers the common bindings.
+ *
+ * Note: embedding this URL does NOT grant any user a SNOMED license. Self-
+ * hosted production deployments must use a licensed Ontoserver/Snowstorm and
+ * a CORS proxy. See https://www.hl7.org/fhir/snomedct.html and IHTSDO's
+ * licensing docs.
+ */
+export const DEFAULT_TERMINOLOGY_BASE_URL = "https://tx.fhir.org/r4";
+
+export const loadStoredTerminologyBaseUrl = (): string | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    const v = window.localStorage.getItem(TERMINOLOGY_BASE_URL_STORAGE_KEY);
+    return v && v.trim() ? v.trim() : null;
+  } catch {
+    return null;
+  }
+};
+
+export const saveTerminologyBaseUrl = (url: string): void => {
+  if (typeof window === "undefined") return;
+  try {
+    const trimmed = url.trim();
+    if (trimmed) {
+      window.localStorage.setItem(TERMINOLOGY_BASE_URL_STORAGE_KEY, trimmed);
+    } else {
+      window.localStorage.removeItem(TERMINOLOGY_BASE_URL_STORAGE_KEY);
+    }
+  } catch {
+    // localStorage unavailable; changes simply don't persist.
+  }
+};
+
+const TERMINOLOGY_BASE_URL_RESOLVED: string = (() => {
+  if (USE_MOCK) return FHIR_BASE_URL;
+  if (import.meta.env.VITE_TERMINOLOGY_BASE_URL) {
+    return import.meta.env.VITE_TERMINOLOGY_BASE_URL;
+  }
+  return loadStoredTerminologyBaseUrl() ?? DEFAULT_TERMINOLOGY_BASE_URL;
+})();
+
+export const TERMINOLOGY_BASE_URL: string = TERMINOLOGY_BASE_URL_RESOLVED;
 
 export const ROUTER_BASENAME: string = BASE.replace(/\/$/, "") || "/";
 

--- a/apps/demo/src/main.tsx
+++ b/apps/demo/src/main.tsx
@@ -8,6 +8,7 @@ import {
   ACTIVE_SERVER_CONFIG,
   FHIR_BASE_URL,
   ROUTER_BASENAME,
+  TERMINOLOGY_BASE_URL,
   USE_HASH_ROUTER,
   USE_MOCK,
   buildRequestHeaders,
@@ -40,6 +41,16 @@ const fhirClient = new FetchFhirClient({
   baseUrl: FHIR_BASE_URL,
   headers: buildRequestHeaders(ACTIVE_SERVER_CONFIG),
 });
+
+// Terminology calls (ValueSet/$expand for SNOMED, LOINC, ICD-10, BCP-47…)
+// route to a separate client so they hit a SNOMED-capable server independent
+// of the data server. Falls through to the data client when the URL matches —
+// this is the case under MSW, and lets users opt out of the split by clearing
+// the field on the Settings page.
+const terminologyClient =
+  TERMINOLOGY_BASE_URL && TERMINOLOGY_BASE_URL !== FHIR_BASE_URL
+    ? new FetchFhirClient({ baseUrl: TERMINOLOGY_BASE_URL })
+    : undefined;
 
 async function bootstrap() {
   if (USE_MOCK) {
@@ -90,7 +101,7 @@ async function bootstrap() {
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>
-        <FhirClientProvider client={fhirClient}>
+        <FhirClientProvider client={fhirClient} terminologyClient={terminologyClient}>
           <Router {...routerProps}>
             <App />
           </Router>

--- a/apps/demo/src/routes/fhir-ui/pages/SettingsPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/SettingsPage.tsx
@@ -2,15 +2,18 @@ import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   ACTIVE_SERVER_CONFIG,
+  DEFAULT_TERMINOLOGY_BASE_URL,
   type AuthMode,
   type CustomHeader,
   type ServerConfig,
   loadActiveServerId,
   loadAnthropicApiKey,
   loadServers,
+  loadStoredTerminologyBaseUrl,
   saveActiveServerId,
   saveAnthropicApiKey,
   saveServers,
+  saveTerminologyBaseUrl,
 } from "../../../config.js";
 import { probeFhirServer } from "../../../serverProbe.js";
 
@@ -37,6 +40,14 @@ export function SettingsPage() {
   );
   const [testState, setTestState] = useState<Record<string, TestState>>({});
   const [anthropicKey, setAnthropicKey] = useState<string>(() => loadAnthropicApiKey());
+  const [terminologyUrl, setTerminologyUrl] = useState<string>(
+    () => loadStoredTerminologyBaseUrl() ?? "",
+  );
+
+  const updateTerminologyUrl = (next: string) => {
+    setTerminologyUrl(next);
+    saveTerminologyBaseUrl(next);
+  };
 
   const updateAnthropicKey = (next: string) => {
     setAnthropicKey(next);
@@ -131,6 +142,43 @@ export function SettingsPage() {
       >
         + Add server
       </button>
+
+      <section
+        className="space-y-3 rounded border border-slate-200 bg-white p-4 shadow-sm"
+        data-testid="terminology-section"
+      >
+        <header className="space-y-1">
+          <h2 className="text-base font-semibold text-slate-900">
+            Terminology server
+          </h2>
+          <p className="text-xs text-slate-600">
+            Routes <code>ValueSet/$expand</code> to a separate server so SNOMED,
+            LOINC, ICD-10 and BCP-47 dropdowns populate even when the data
+            server can't expand them. Defaults to{" "}
+            <code>{DEFAULT_TERMINOLOGY_BASE_URL}</code> (HL7's community service)
+            when blank. Reload after changing.
+          </p>
+          <p className="text-xs text-slate-500">
+            Embedding a URL here does <em>not</em> grant a SNOMED license.
+            Production deployments must use a licensed Ontoserver/Snowstorm and
+            (for self-hosted) a CORS proxy.
+          </p>
+        </header>
+        <label className="block space-y-1">
+          <span className="block text-xs font-medium text-slate-700">
+            Terminology base URL
+          </span>
+          <input
+            type="url"
+            value={terminologyUrl}
+            onChange={(e) => updateTerminologyUrl(e.target.value)}
+            placeholder={DEFAULT_TERMINOLOGY_BASE_URL}
+            className={inputClass}
+            autoComplete="off"
+            data-testid="terminology-base-url-input"
+          />
+        </label>
+      </section>
 
       <section
         className="space-y-3 rounded border border-slate-200 bg-white p-4 shadow-sm"

--- a/packages/react-fhir/src/hooks/FhirClientProvider.tsx
+++ b/packages/react-fhir/src/hooks/FhirClientProvider.tsx
@@ -2,15 +2,31 @@ import { createContext, useContext, type ReactNode } from "react";
 import type { FhirClient } from "../client/types.js";
 
 const FhirClientContext = createContext<FhirClient | null>(null);
+const TerminologyClientContext = createContext<FhirClient | null>(null);
 
 export interface FhirClientProviderProps {
   client: FhirClient;
+  /**
+   * Optional separate client for ValueSet/CodeSystem operations. When omitted,
+   * terminology hooks fall through to the data `client`. Pass a distinct
+   * client (e.g. https://tx.fhir.org/r4) when the data server cannot expand
+   * large terminologies like SNOMED, LOINC, or BCP-47.
+   */
+  terminologyClient?: FhirClient;
   children: ReactNode;
 }
 
-export function FhirClientProvider({ client, children }: FhirClientProviderProps) {
+export function FhirClientProvider({
+  client,
+  terminologyClient,
+  children,
+}: FhirClientProviderProps) {
   return (
-    <FhirClientContext.Provider value={client}>{children}</FhirClientContext.Provider>
+    <FhirClientContext.Provider value={client}>
+      <TerminologyClientContext.Provider value={terminologyClient ?? null}>
+        {children}
+      </TerminologyClientContext.Provider>
+    </FhirClientContext.Provider>
   );
 }
 
@@ -22,4 +38,16 @@ export function useFhirClient(): FhirClient {
     );
   }
   return client;
+}
+
+/**
+ * Returns the terminology client when one was provided to
+ * `FhirClientProvider`, otherwise falls through to the data client. Use this
+ * for `ValueSet/$expand` and other terminology operations so they can target
+ * a SNOMED-capable server independent of the data server.
+ */
+export function useTerminologyClient(): FhirClient {
+  const tx = useContext(TerminologyClientContext);
+  const data = useFhirClient();
+  return tx ?? data;
 }

--- a/packages/react-fhir/src/hooks/queries.test.tsx
+++ b/packages/react-fhir/src/hooks/queries.test.tsx
@@ -22,26 +22,33 @@ import {
   useStructureDefinition,
   useUpdateResource,
   useValueSet,
+  useValueSetExpansion,
 } from "./queries.js";
 
 const BASE = "https://fhir.example.test/fhir";
+const TX_BASE = "https://tx.example.test/r4";
 const server = setupServer();
 
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-const mkWrapper = () => {
+const mkWrapper = (opts?: { terminologyBaseUrl?: string }) => {
   const client = new FetchFhirClient({ baseUrl: BASE });
+  const terminologyClient = opts?.terminologyBaseUrl
+    ? new FetchFhirClient({ baseUrl: opts.terminologyBaseUrl })
+    : undefined;
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={qc}>
-      <FhirClientProvider client={client}>{children}</FhirClientProvider>
+      <FhirClientProvider client={client} terminologyClient={terminologyClient}>
+        {children}
+      </FhirClientProvider>
     </QueryClientProvider>
   );
-  return { wrapper, qc, client };
+  return { wrapper, qc, client, terminologyClient };
 };
 
 describe("query hooks", () => {
@@ -288,6 +295,185 @@ describe("query hooks", () => {
       const { wrapper } = mkWrapper();
       const { result } = renderHook(() => useValueSet(undefined), { wrapper });
       expect(result.current.fetchStatus).toBe("idle");
+    });
+
+    it("routes $expand to the terminology client when one is provided", async () => {
+      const url = "http://snomed.info/sct?fhir_vs=isa/123037004";
+      const dataExpand = vi.fn();
+      const txExpand = vi.fn();
+      server.use(
+        http.get(`${BASE}/ValueSet/$expand`, () => {
+          dataExpand();
+          return HttpResponse.json({ resourceType: "OperationOutcome" }, { status: 501 });
+        }),
+        http.get(`${TX_BASE}/ValueSet/$expand`, ({ request }) => {
+          txExpand();
+          expect(new URL(request.url).searchParams.get("url")).toBe(url);
+          return HttpResponse.json({
+            resourceType: "ValueSet",
+            status: "active",
+            url,
+            expansion: {
+              identifier: "x",
+              timestamp: "2024-01-01T00:00:00Z",
+              contains: [{ system: "http://snomed.info/sct", code: "1" }],
+            },
+          });
+        }),
+      );
+      const { wrapper } = mkWrapper({ terminologyBaseUrl: TX_BASE });
+      const { result } = renderHook(() => useValueSet(url), { wrapper });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(txExpand).toHaveBeenCalled();
+      expect(dataExpand).not.toHaveBeenCalled();
+      expect(result.current.data?.expansion?.contains).toHaveLength(1);
+    });
+
+    it("falls through to the data client when no terminology client is provided", async () => {
+      const url = "http://hl7.org/fhir/ValueSet/administrative-gender";
+      const dataExpand = vi.fn();
+      server.use(
+        http.get(`${BASE}/ValueSet/$expand`, () => {
+          dataExpand();
+          return HttpResponse.json({
+            resourceType: "ValueSet",
+            status: "active",
+            url,
+            expansion: {
+              identifier: "x",
+              timestamp: "2024-01-01T00:00:00Z",
+              contains: [{ system: "s", code: "male" }],
+            },
+          });
+        }),
+      );
+      const { wrapper } = mkWrapper();
+      const { result } = renderHook(() => useValueSet(url), { wrapper });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(dataExpand).toHaveBeenCalled();
+    });
+
+    it("scopes the query cache by the terminology client's baseUrl", async () => {
+      const url = "http://hl7.org/fhir/ValueSet/administrative-gender";
+      server.use(
+        http.get(`${TX_BASE}/ValueSet/$expand`, () =>
+          HttpResponse.json({
+            resourceType: "ValueSet",
+            status: "active",
+            url,
+            expansion: {
+              identifier: "x",
+              timestamp: "2024-01-01T00:00:00Z",
+              contains: [],
+            },
+          }),
+        ),
+      );
+      const { wrapper, qc } = mkWrapper({ terminologyBaseUrl: TX_BASE });
+      const { result } = renderHook(() => useValueSet(url), { wrapper });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      const keys = qc.getQueryCache().getAll().map((q) => q.queryKey);
+      const valueSetKey = keys.find(
+        (k) => Array.isArray(k) && k.includes("ValueSet"),
+      );
+      expect(valueSetKey).toBeDefined();
+      expect((valueSetKey as readonly unknown[])[1]).toBe(TX_BASE);
+      expect((valueSetKey as readonly unknown[])[1]).not.toBe(BASE);
+    });
+  });
+
+  describe("useValueSetExpansion", () => {
+    const url = "http://snomed.info/sct?fhir_vs=isa/123037004";
+
+    it("hits the terminology client's base URL when one is provided", async () => {
+      const dataExpand = vi.fn();
+      const txExpand = vi.fn();
+      server.use(
+        http.get(`${BASE}/ValueSet/$expand`, () => {
+          dataExpand();
+          return HttpResponse.json({ resourceType: "OperationOutcome" }, { status: 501 });
+        }),
+        http.get(`${TX_BASE}/ValueSet/$expand`, ({ request }) => {
+          txExpand();
+          const params = new URL(request.url).searchParams;
+          expect(params.get("url")).toBe(url);
+          expect(params.get("filter")).toBe("body");
+          expect(params.get("count")).toBe("20");
+          return HttpResponse.json({
+            resourceType: "ValueSet",
+            status: "active",
+            url,
+            expansion: {
+              identifier: "x",
+              timestamp: "2024-01-01T00:00:00Z",
+              contains: [{ system: "http://snomed.info/sct", code: "1", display: "body part" }],
+            },
+          });
+        }),
+      );
+      const { wrapper } = mkWrapper({ terminologyBaseUrl: TX_BASE });
+      const { result } = renderHook(() => useValueSetExpansion(url, "body"), {
+        wrapper,
+      });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(txExpand).toHaveBeenCalled();
+      expect(dataExpand).not.toHaveBeenCalled();
+      expect(result.current.data?.expansion?.contains).toHaveLength(1);
+    });
+
+    it("falls through to the data client when no terminology client is provided", async () => {
+      const dataExpand = vi.fn();
+      server.use(
+        http.get(`${BASE}/ValueSet/$expand`, () => {
+          dataExpand();
+          return HttpResponse.json({
+            resourceType: "ValueSet",
+            status: "active",
+            url,
+            expansion: {
+              identifier: "x",
+              timestamp: "2024-01-01T00:00:00Z",
+              contains: [],
+            },
+          });
+        }),
+      );
+      const { wrapper } = mkWrapper();
+      const { result } = renderHook(() => useValueSetExpansion(url, "anything"), {
+        wrapper,
+      });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(dataExpand).toHaveBeenCalled();
+    });
+
+    it("scopes the cache key by the terminology client's baseUrl, not the data client's", async () => {
+      server.use(
+        http.get(`${TX_BASE}/ValueSet/$expand`, () =>
+          HttpResponse.json({
+            resourceType: "ValueSet",
+            status: "active",
+            url,
+            expansion: {
+              identifier: "x",
+              timestamp: "2024-01-01T00:00:00Z",
+              contains: [],
+            },
+          }),
+        ),
+      );
+      const { wrapper, qc } = mkWrapper({ terminologyBaseUrl: TX_BASE });
+      const { result } = renderHook(() => useValueSetExpansion(url, "x"), {
+        wrapper,
+      });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      const keys = qc.getQueryCache().getAll().map((q) => q.queryKey);
+      const expansionKey = keys.find(
+        (k) =>
+          Array.isArray(k) && k.includes("ValueSet") && k.includes("expand"),
+      );
+      expect(expansionKey).toBeDefined();
+      expect((expansionKey as readonly unknown[])[1]).toBe(TX_BASE);
+      expect((expansionKey as readonly unknown[])[1]).not.toBe(BASE);
     });
   });
 

--- a/packages/react-fhir/src/hooks/queries.ts
+++ b/packages/react-fhir/src/hooks/queries.ts
@@ -18,7 +18,7 @@ import type {
 import type { FhirClient, SearchParams } from "../client/types.js";
 import { coreValueSet } from "../structure/core/valuesets.js";
 import { resolveStructureDefinition } from "../structure/resolve.js";
-import { useFhirClient } from "./FhirClientProvider.js";
+import { useFhirClient, useTerminologyClient } from "./FhirClientProvider.js";
 
 /** Stable query keys so callers can target them with invalidate/refetch. */
 export const fhirQueryKeys = {
@@ -169,7 +169,7 @@ export function useValueSet(
   canonical: string | undefined,
   options?: ReadQueryOpts<ValueSet>,
 ) {
-  const client = useFhirClient();
+  const client = useTerminologyClient();
   return useQuery({
     queryKey: fhirQueryKeys.valueSet(client.baseUrl, canonical ?? ""),
     queryFn: async ({ signal }) => {
@@ -231,7 +231,7 @@ export function useValueSetExpansion(
   filter: string,
   options?: UseValueSetExpansionOptions,
 ) {
-  const client = useFhirClient();
+  const client = useTerminologyClient();
   const trimmed = filter.trim();
   const count = options?.count ?? 20;
   const enabled = (options?.enabled ?? true) && Boolean(canonical) && trimmed.length > 0;


### PR DESCRIPTION
`FhirClientProvider` now takes an optional `terminologyClient`. New
`useTerminologyClient()` hook returns it, falling through to the data
client when omitted so existing single-client setups keep working.

Both `useValueSet` (canonical resolution) and `useValueSetExpansion`
(filtered expansion, added in #164) switch to the terminology client.
Their react-query keys are scoped by the terminology client's `baseUrl`,
so two apps pointed at the same data server but different tx servers
don't share cached entries.

Demo:
- new `VITE_TERMINOLOGY_BASE_URL` env var, defaulting to
  `https://tx.fhir.org/r4` (HL7's community service, browser-CORS-clean,
  collapses to the data URL under MSW so existing mocks keep matching)
- per-user override in localStorage (`fhir-place:terminology-base-url`)
  via load/saveTerminologyBaseUrl
- new "Terminology server" section on the Settings page with a URL
  field, default placeholder, and a SNOMED-licensing note
- `main.tsx` builds and passes a second `FetchFhirClient` to the
  provider, skipping it when the URL collapses to the data URL

Tests:
- 3 new query-hook tests for `useValueSet` (tx routing, fallback, cache
  scope) and 3 mirror tests for `useValueSetExpansion`
- 4 new demo config tests covering default/override/clear/whitespace
  behaviour for the persisted terminology URL

Closes #165