### PR TITLE
feat(demo): show resolved FHIR server name + live ACTIVE pill in header

### DIFF
--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -6,9 +6,10 @@ import { ResourceEditPage } from "./routes/fhir-ui/pages/ResourceEditPage.js";
 import { ResourceListPage } from "./routes/fhir-ui/pages/ResourceListPage.js";
 import { SettingsPage } from "./routes/fhir-ui/pages/SettingsPage.js";
 import { CqlRunnerPage } from "./routes/cql-runner/CqlRunnerPage.js";
+import { ActiveServerStatus } from "./components/ActiveServerStatus.js";
 import { FhirUiLayout } from "./components/FhirUiLayout.js";
 import { ServerPicker } from "./components/ServerPicker.js";
-import { ACTIVE_SERVER_CONFIG, SETTINGS_ENABLED } from "./config.js";
+import { SETTINGS_ENABLED } from "./config.js";
 
 export function App() {
   return (
@@ -41,13 +42,7 @@ export function App() {
               </Link>
             </nav>
           </div>
-          {SETTINGS_ENABLED ? (
-            <ServerPicker />
-          ) : (
-            <div className="text-xs text-slate-500" data-testid="base-url">
-              {ACTIVE_SERVER_CONFIG.label}
-            </div>
-          )}
+          {SETTINGS_ENABLED ? <ServerPicker /> : <ActiveServerStatus />}
         </div>
       </header>
       <main className="mx-auto max-w-5xl p-6">

--- a/apps/demo/src/components/ActiveServerStatus.tsx
+++ b/apps/demo/src/components/ActiveServerStatus.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from "react";
+import { ACTIVE_SERVER_CONFIG } from "../config.js";
+import { probeFhirServer, type ProbeResult } from "../serverProbe.js";
+
+type Status =
+  | { kind: "pending" }
+  | { kind: "ok"; software?: string; fhirVersion?: string }
+  | { kind: "error"; message: string };
+
+/**
+ * Header readout used when the env override pins the base URL: shows the
+ * resolved server label plus a green "ACTIVE" pill once a `/metadata` probe
+ * succeeds. Mirrors the SettingsPage's active-pill styling so the deployed
+ * site looks the same as local dev.
+ */
+export function ActiveServerStatus() {
+  const [status, setStatus] = useState<Status>({ kind: "pending" });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const result: ProbeResult = await probeFhirServer(ACTIVE_SERVER_CONFIG);
+      if (cancelled) return;
+      if (result.ok) {
+        setStatus({
+          kind: "ok",
+          ...(result.software ? { software: result.software } : {}),
+          ...(result.fhirVersion ? { fhirVersion: result.fhirVersion } : {}),
+        });
+      } else {
+        setStatus({ kind: "error", message: result.message });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div
+      className="flex items-center gap-2 text-xs text-slate-500"
+      data-testid="base-url"
+    >
+      <span className="text-slate-700">{ACTIVE_SERVER_CONFIG.label}</span>
+      <Pill status={status} />
+    </div>
+  );
+}
+
+function Pill({ status }: { status: Status }) {
+  if (status.kind === "pending") {
+    return (
+      <span
+        className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] uppercase text-slate-500"
+        data-testid="active-server-pill-pending"
+      >
+        Checking…
+      </span>
+    );
+  }
+  if (status.kind === "ok") {
+    const title = [status.software, status.fhirVersion && `FHIR ${status.fhirVersion}`]
+      .filter(Boolean)
+      .join(" · ");
+    return (
+      <span
+        className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] uppercase text-emerald-700"
+        data-testid="active-server-pill-ok"
+        title={title || undefined}
+      >
+        Active
+      </span>
+    );
+  }
+  return (
+    <span
+      className="rounded bg-red-100 px-1.5 py-0.5 text-[10px] uppercase text-red-700"
+      data-testid="active-server-pill-error"
+      title={status.message}
+    >
+      Offline
+    </span>
+  );
+}

--- a/apps/demo/src/config.test.ts
+++ b/apps/demo/src/config.test.ts
@@ -6,6 +6,7 @@ import {
   loadActiveServerId,
   loadServers,
   resolveActiveServer,
+  resolveEnvOverrideServer,
   saveActiveServerId,
   saveServers,
 } from "./config.js";
@@ -234,6 +235,40 @@ describe("resolveActiveServer", () => {
   it("falls back to the first server when active id matches nothing", () => {
     saveActiveServerId("never-existed");
     expect(resolveActiveServer().id).toBe(BUILTIN_SERVERS[0]!.id);
+  });
+});
+
+describe("resolveEnvOverrideServer", () => {
+  it("reuses the built-in label/id when the env URL matches a known server", () => {
+    const server = resolveEnvOverrideServer("https://hapi.fhir.org/baseR4");
+    expect(server.id).toBe("builtin-hapi");
+    expect(server.label).toBe("HAPI Public Test Server");
+    expect(server.baseUrl).toBe("https://hapi.fhir.org/baseR4");
+  });
+
+  it("matches built-ins regardless of trailing slash and case", () => {
+    const server = resolveEnvOverrideServer("HTTPS://Server.Fire.ly/");
+    expect(server.id).toBe("builtin-firely");
+    expect(server.label).toBe("Firely Server (R4)");
+  });
+
+  it("preserves the env-supplied URL verbatim even when it matches a built-in", () => {
+    const server = resolveEnvOverrideServer("https://hapi.fhir.org/baseR4/");
+    expect(server.id).toBe("builtin-hapi");
+    expect(server.baseUrl).toBe("https://hapi.fhir.org/baseR4/");
+  });
+
+  it("falls back to the URL host when no built-in matches", () => {
+    const server = resolveEnvOverrideServer("https://fhir.example.org/r4");
+    expect(server.id).toBe("env-override");
+    expect(server.label).toBe("fhir.example.org");
+    expect(server.baseUrl).toBe("https://fhir.example.org/r4");
+  });
+
+  it("falls back to the raw value when the URL is unparseable", () => {
+    const server = resolveEnvOverrideServer("not a url");
+    expect(server.id).toBe("env-override");
+    expect(server.label).toBe("not a url");
   });
 });
 

--- a/apps/demo/src/config.ts
+++ b/apps/demo/src/config.ts
@@ -188,6 +188,41 @@ export const resolveActiveServer = (): ServerConfig => {
   return servers[0] ?? { ...FALLBACK_SERVER };
 };
 
+const normalizeBaseUrl = (url: string): string =>
+  url.trim().replace(/\/+$/, "").toLowerCase();
+
+const deriveLabelFromUrl = (url: string): string => {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+};
+
+/**
+ * When `VITE_FHIR_BASE_URL` pins the base URL, prefer the matching built-in's
+ * label/id so the header reads "HAPI Public Test Server" instead of a generic
+ * "Env override". Falls back to the URL host so deployments pointing at custom
+ * servers still get a meaningful name.
+ */
+export const resolveEnvOverrideServer = (
+  envBaseUrl: string,
+  builtins: ReadonlyArray<ServerConfig> = BUILTIN_SERVERS,
+): ServerConfig => {
+  const normalized = normalizeBaseUrl(envBaseUrl);
+  const match = builtins.find((s) => normalizeBaseUrl(s.baseUrl) === normalized);
+  if (match) {
+    return { ...match, baseUrl: envBaseUrl };
+  }
+  return {
+    id: "env-override",
+    label: deriveLabelFromUrl(envBaseUrl),
+    baseUrl: envBaseUrl,
+    authMode: "none",
+    builtin: true,
+  };
+};
+
 const ACTIVE_SERVER: ServerConfig = (() => {
   if (USE_MOCK) {
     return {
@@ -199,13 +234,7 @@ const ACTIVE_SERVER: ServerConfig = (() => {
     };
   }
   if (import.meta.env.VITE_FHIR_BASE_URL) {
-    return {
-      id: "env-override",
-      label: "Env override",
-      baseUrl: import.meta.env.VITE_FHIR_BASE_URL,
-      authMode: "none",
-      builtin: true,
-    };
+    return resolveEnvOverrideServer(import.meta.env.VITE_FHIR_BASE_URL);
   }
   return resolveActiveServer();
 })();


### PR DESCRIPTION
When VITE_FHIR_BASE_URL pins the base URL, the header used to read a
generic "Env override". Match the env URL against BUILTIN_SERVERS so it
reuses the known label/id (e.g. "HAPI Public Test Server"), and fall
back to the URL host for unknown servers. Replace the static label div
with an ActiveServerStatus component that runs a /metadata probe on
mount and renders a green ACTIVE pill on success (Checking… while
pending, Offline on error).

https://claude.ai/code/session_01NEFHLw6fCGdLeb3jpGduJa