### PR TITLE
fix(demo): always show Settings link in header nav

### DIFF
--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -29,15 +29,13 @@ export function App() {
               <Link to="/fhir-ui/ask" className="text-slate-600 underline">
                 Ask
               </Link>
-              {SETTINGS_ENABLED && (
-                <Link
-                  to="/fhir-ui/settings"
-                  className="text-slate-600 underline"
-                  data-testid="nav-settings-link"
-                >
-                  Settings
-                </Link>
-              )}
+              <Link
+                to="/fhir-ui/settings"
+                className="text-slate-600 underline"
+                data-testid="nav-settings-link"
+              >
+                Settings
+              </Link>
             </nav>
           </div>
           {SETTINGS_ENABLED ? (

--- a/apps/demo/src/routes/fhir-ui/pages/SettingsPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/SettingsPage.tsx
@@ -338,13 +338,28 @@ function ServerForm({
             </button>
           </div>
         ))}
-        <button
-          type="button"
-          onClick={() => updateHeaders([...headers, { key: "", value: "" }])}
-          className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 hover:bg-slate-50"
-        >
-          + Add header
-        </button>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => updateHeaders([...headers, { key: "", value: "" }])}
+            className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 hover:bg-slate-50"
+          >
+            + Add header
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              updateHeaders([
+                ...headers,
+                { key: "Authorization", value: "Bearer " },
+              ])
+            }
+            className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 hover:bg-slate-50"
+            data-testid="add-bearer-header"
+          >
+            + Add bearer
+          </button>
+        </div>
       </fieldset>
 
       <TestResult state={testState} />


### PR DESCRIPTION
Previously the Settings nav link was gated on SETTINGS_ENABLED, which is
false when VITE_FHIR_BASE_URL is set (the GitHub Pages deploy). That
hid the link entirely on the live site even though the Settings page
is still useful there for managing the Anthropic API key, custom
headers, and bookmarking server configs for local use.

The page is reachable unconditionally (route is always registered), so
the nav entry should be too.

https://claude.ai/code/session_013T8kQEn74gZtGaPkvjmy7D