### PR TITLE
feat(ResourceSearch): autocomplete reference filters by name

### DIFF
--- a/packages/react-fhir/src/components/ResourceSearch.test.tsx
+++ b/packages/react-fhir/src/components/ResourceSearch.test.tsx
@@ -1,8 +1,10 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { CapabilityStatement } from "fhir/r4";
-import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { FetchFhirClient } from "../client/FetchFhirClient.js";
 import { FhirClientProvider } from "../hooks/FhirClientProvider.js";
 import {
@@ -84,9 +86,11 @@ describe("ResourceSearch", () => {
       />,
     );
     // name, identifier, birthdate, gender, organization, address-city, phone, _id
-    // birthdate is a date input (role is not textbox), so textbox count is 7.
-    const fields = screen.getAllByRole("textbox");
-    expect(fields.length).toBe(7);
+    // - birthdate is a date input (no textbox role)
+    // - organization is a reference, rendered via ReferencePicker → searchbox role
+    // → 6 textboxes + 1 searchbox
+    expect(screen.getAllByRole("textbox").length).toBe(6);
+    expect(screen.getByRole("searchbox", { name: /search organization/i })).toBeInTheDocument();
     expect(screen.getByLabelText("birthdate")).toBeInTheDocument();
     expect(screen.getAllByPlaceholderText(/code or system\|code/i).length).toBeGreaterThan(0);
   });
@@ -156,12 +160,85 @@ describe("ResourceSearch", () => {
     );
     expect(screen.getAllByRole("textbox").length).toBe(3);
     await user.click(screen.getByRole("button", { name: /show.*more parameters/i }));
-    // birthdate is a date input, not a textbox — so 7 textboxes after expand.
-    expect(screen.getAllByRole("textbox").length).toBe(7);
+    // After expand: 6 textboxes (birthdate is a date input; organization is a
+    // reference picker rendered as a searchbox).
+    expect(screen.getAllByRole("textbox").length).toBe(6);
+    expect(screen.getByRole("searchbox", { name: /search organization/i })).toBeInTheDocument();
   });
 
   it("shows a friendly message when no params are advertised", () => {
     wrap(<ResourceSearch resourceType="UnknownType" capabilityStatement={cap} />);
     expect(screen.getByText(/no searchable parameters/i)).toBeInTheDocument();
+  });
+});
+
+const allergyCap: CapabilityStatement = {
+  resourceType: "CapabilityStatement",
+  status: "active",
+  date: "2024-01-01",
+  kind: "instance",
+  fhirVersion: "4.0.1",
+  format: ["json"],
+  rest: [
+    {
+      mode: "server",
+      resource: [
+        {
+          type: "AllergyIntolerance",
+          searchParam: [
+            { name: "patient", type: "reference", documentation: "Who the sensitivity is for" },
+            { name: "code", type: "token" },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const BASE = "https://fhir.example.test/fhir";
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("ResourceSearch — reference name search", () => {
+  it("searches Patients by name and submits the picked Patient/id", async () => {
+    server.use(
+      http.get(`${BASE}/Patient`, ({ request }) => {
+        const q = (new URL(request.url).searchParams.get("name") ?? "").toLowerCase();
+        const all = [
+          { resourceType: "Patient", id: "p1", name: [{ given: ["Ada"], family: "Lovelace" }] },
+          { resourceType: "Patient", id: "p2", name: [{ given: ["Alan"], family: "Turing" }] },
+        ];
+        const matches = all.filter((p) =>
+          (p.name[0]?.family ?? "").toLowerCase().includes(q),
+        );
+        return HttpResponse.json({
+          resourceType: "Bundle",
+          type: "searchset",
+          entry: matches.map((r) => ({ resource: r })),
+        });
+      }),
+    );
+
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    wrap(
+      <ResourceSearch
+        resourceType="AllergyIntolerance"
+        capabilityStatement={allergyCap}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const search = screen.getByRole("searchbox", { name: /search patient/i });
+    await user.type(search, "Lovelace");
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /Ada Lovelace/ })).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("option", { name: /Ada Lovelace/ }));
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({ patient: "Patient/p1" });
   });
 });

--- a/packages/react-fhir/src/components/ResourceSearch.tsx
+++ b/packages/react-fhir/src/components/ResourceSearch.tsx
@@ -1,6 +1,7 @@
 import type {
   CapabilityStatementRestResourceSearchParam,
   CapabilityStatement,
+  Reference,
 } from "fhir/r4";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import {
@@ -14,6 +15,7 @@ import { bindingFor, codesFromValueSet } from "../structure/binding.js";
 import { elementPathForSearchParam } from "../structure/searchBinding.js";
 import { clipSearchParamDoc } from "../structure/searchDoc.js";
 import { findElement } from "../structure/walker.js";
+import { ReferencePicker } from "./ReferencePicker.js";
 
 export interface ResourceSearchProps {
   resourceType: string;
@@ -223,6 +225,11 @@ function SearchField({ base, param, value, onChange }: SearchFieldProps): ReactN
   if (param.type === "date") {
     return <DateSearchField base={base} param={param} value={value} onChange={onChange} />;
   }
+  if (param.type === "reference") {
+    return (
+      <ReferenceSearchField base={base} param={param} value={value} onChange={onChange} />
+    );
+  }
   return fieldWrapper(
     <input
       type={inputType(param.type)}
@@ -302,6 +309,82 @@ function TokenSearchField({ base, param, value, onChange }: SearchFieldProps): R
     param,
     base,
   );
+}
+
+/* ---------- reference ---------- */
+
+/**
+ * Reference search field: hands off to the autocomplete `ReferencePicker` so
+ * users can find e.g. a Patient by name instead of pasting `Patient/123`. The
+ * picker emits a {@link Reference}; we serialise just `Type/id` for the
+ * underlying form value (FHIR servers accept both `?patient=Patient/123` and
+ * `?patient=123`, but the qualified form survives multi-target params).
+ *
+ * Targets come from `SearchParameter.target` when the server exposes them;
+ * for the common single-target params used in clinical apps (`patient`,
+ * `subject`, `practitioner`, etc.) we fall back to a baked-in mapping so the
+ * picker still works against servers that don't surface SearchParameter.
+ * When no targets can be derived we render the plain `Type/id` text input.
+ */
+function ReferenceSearchField({ base, param, value, onChange }: SearchFieldProps): ReactNode {
+  const { data: spec } = useSearchParameter(base, param.name ?? "");
+
+  const targets = useMemo(() => {
+    const fromSpec = (spec?.target ?? []).filter(Boolean);
+    if (fromSpec.length > 0) return fromSpec;
+    return defaultReferenceTargets(param.name ?? "");
+  }, [spec, param.name]);
+
+  if (targets.length === 0) {
+    return fieldWrapper(
+      <input
+        type="text"
+        aria-label={param.name}
+        placeholder={inputPlaceholder(param.type)}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
+      />,
+      param,
+      base,
+    );
+  }
+
+  const ref: Reference | undefined = value ? { reference: value } : undefined;
+
+  return fieldWrapper(
+    <ReferencePicker
+      targets={targets}
+      value={ref}
+      onChange={(r) => onChange(r?.reference ?? "")}
+      className="relative space-y-2"
+    />,
+    param,
+    base,
+  );
+}
+
+/**
+ * Fallback targets for reference search params whose name is conventionally
+ * tied to a single resource type. Keeps the picker useful when the server
+ * doesn't expose `SearchParameter.target`. Conservative on purpose: only
+ * params with one near-universal target are listed.
+ */
+function defaultReferenceTargets(name: string): string[] {
+  switch (name) {
+    case "patient":
+      return ["Patient"];
+    case "practitioner":
+      return ["Practitioner"];
+    case "organization":
+      return ["Organization"];
+    case "location":
+      return ["Location"];
+    case "encounter":
+      return ["Encounter"];
+    default:
+      return [];
+  }
 }
 
 /* ---------- date ---------- */


### PR DESCRIPTION
Reference-typed search params (e.g. AllergyIntolerance.patient) now render
the existing ReferencePicker so users can search by name instead of pasting
`Patient/123`. Targets are sourced from `SearchParameter.target` when the
server exposes it, with a small heuristic for common single-target params
so the picker still works against servers that don't surface SearchParameter.
Falls back to the plain `Type/id` text input when no targets resolve.