### PR TITLE
fix(demo): drop VITE_FHIR_BASE_URL from Pages build so settings work

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,16 +28,19 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @fhir-place/react-fhir build
       - name: Build demo for GitHub Pages (live HAPI R4)
+        # Intentionally no VITE_FHIR_BASE_URL: pinning it disables the in-app
+        # server picker / settings page (see SETTINGS_ENABLED in config.ts).
+        # HAPI remains the default via BUILTIN_SERVERS[0]; users can switch to
+        # SMART/Firely/etc. from the settings page and have it actually take
+        # effect after the localStorage-driven reload.
         run: pnpm --filter @fhir-place/demo build
         env:
           VITE_USE_MOCK: "false"
-          VITE_FHIR_BASE_URL: "https://hapi.fhir.org/baseR4"
           VITE_BASE_PATH: "/${{ github.event.repository.name }}/"
       - name: Build goals-tasks for GitHub Pages (live HAPI R4)
         run: pnpm --filter @fhir-place/goals-tasks build
         env:
           VITE_USE_MOCK: "false"
-          VITE_FHIR_BASE_URL: "https://hapi.fhir.org/baseR4"
           VITE_BASE_PATH: "/${{ github.event.repository.name }}/goals/"
       - name: Stage goals-tasks under /goals
         run: |


### PR DESCRIPTION
Pinning VITE_FHIR_BASE_URL at build time disables SETTINGS_ENABLED
(config.ts), so the deployed site rendered the read-only ActiveServerStatus
header pill and ignored every "Use this server" click on the settings page —
the SettingsPage's local state moved the ACTIVE badge to the new server, but
ACTIVE_SERVER_CONFIG and the singleton FhirClient stayed pinned to HAPI, so
the header label and resource-list searches kept hitting HAPI.

HAPI remains the default for first-time visitors via BUILTIN_SERVERS[0]; with
the env override gone, returning visitors' localStorage selection is honored
and the in-app server picker becomes interactive again.