### PR TITLE
fix(ReferencePicker): commit picks on pointerdown + show DOB in results

### DIFF
--- a/packages/react-fhir/src/components/ReferencePicker.test.tsx
+++ b/packages/react-fhir/src/components/ReferencePicker.test.tsx
@@ -30,8 +30,20 @@ const wrap = () => {
 
 describe("ReferencePicker", () => {
   const patients = [
-    { resourceType: "Patient", id: "p1", name: [{ given: ["Ada"], family: "Lovelace" }] },
-    { resourceType: "Patient", id: "p2", name: [{ given: ["Alan"], family: "Turing" }] },
+    {
+      resourceType: "Patient",
+      id: "p1",
+      name: [{ given: ["Ada"], family: "Lovelace" }],
+      birthDate: "1815-12-10",
+      gender: "female",
+    },
+    {
+      resourceType: "Patient",
+      id: "p2",
+      name: [{ given: ["Alan"], family: "Turing" }],
+      birthDate: "1912-06-23",
+      gender: "male",
+    },
   ];
 
   it("searches when the user types and picks a resource on click", async () => {
@@ -60,7 +72,40 @@ describe("ReferencePicker", () => {
     await waitFor(() =>
       expect(screen.getByRole("option", { name: /Ada Lovelace/ })).toBeInTheDocument(),
     );
+    // DOB + gender render as the secondary disambiguator beneath the name.
+    expect(screen.getByText(/DOB 1815-12-10 · female/)).toBeInTheDocument();
     await user.click(screen.getByRole("option", { name: /Ada Lovelace/ }));
+    expect(onChange).toHaveBeenCalledWith({
+      reference: "Patient/p1",
+      display: "Ada Lovelace",
+    });
+  });
+
+  it("commits the selection on pointerdown so iOS taps don't get lost to input blur", async () => {
+    server.use(
+      http.get(`${BASE}/Patient`, () =>
+        HttpResponse.json({
+          resourceType: "Bundle",
+          type: "searchset",
+          entry: patients.map((r) => ({ resource: r })),
+        }),
+      ),
+    );
+
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ReferencePicker targets={["Patient"]} value={undefined} onChange={onChange} debounceMs={0} />,
+      { wrapper: wrap() },
+    );
+
+    await user.type(screen.getByRole("searchbox", { name: /search patient/i }), "L");
+    const option = await screen.findByRole("option", { name: /Ada Lovelace/ });
+
+    // Simulate the iOS sequence: pointerdown on the option fires first, BEFORE
+    // any click — emulating the real-world failure mode where the subsequent
+    // tap event was never delivered. pick() must already have run.
+    await user.pointer({ keys: "[TouchA>]", target: option });
     expect(onChange).toHaveBeenCalledWith({
       reference: "Patient/p1",
       display: "Ada Lovelace",

--- a/packages/react-fhir/src/components/ReferencePicker.tsx
+++ b/packages/react-fhir/src/components/ReferencePicker.tsx
@@ -129,6 +129,13 @@ export function ReferencePicker(props: ReferencePickerProps) {
               setIsOpen(true);
             }}
             onFocus={() => setIsOpen(true)}
+            // iOS Safari otherwise overlays its "AutoFill Contact" bar on top of
+            // our results dropdown, swallowing taps on the actual options.
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            name="reference-picker-search"
             className="min-w-[12rem] flex-1 rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
           />
           {supportsBirthdate && (
@@ -159,20 +166,42 @@ export function ReferencePicker(props: ReferencePickerProps) {
           {!isFetching && results.length === 0 && (
             <li className="px-3 py-2 text-xs text-slate-500">No matches</li>
           )}
-          {results.map((r) => (
-            <li key={`${r.resourceType}/${r.id}`}>
-              <button
-                type="button"
-                role="option"
-                aria-selected={false}
-                onClick={() => pick(r)}
-                className="flex w-full items-baseline justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-slate-50"
-              >
-                <span className="truncate">{formatReferenceLabel(r)}</span>
-                <code className="shrink-0 text-xs text-slate-500">{r.id}</code>
-              </button>
-            </li>
-          ))}
+          {results.map((r) => {
+            const secondary = secondaryLabel(r);
+            return (
+              <li key={`${r.resourceType}/${r.id}`}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={false}
+                  // `onPointerDown` (not `onClick`) so selection commits before
+                  // the search input blurs. iOS Safari reflows the page when
+                  // the keyboard dismisses on blur, which moves the option out
+                  // from under the user's finger and swallows the tap.
+                  onPointerDown={(e) => {
+                    e.preventDefault();
+                    pick(r);
+                  }}
+                  // Keyboard activation (Enter/Space on the focused button)
+                  // never produces a pointerdown — `e.detail === 0` flags it.
+                  onClick={(e) => {
+                    if (e.detail === 0) pick(r);
+                  }}
+                  className="flex w-full items-start justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-slate-50"
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate">{formatReferenceLabel(r)}</span>
+                    {secondary && (
+                      <span className="block truncate text-xs text-slate-500">
+                        {secondary}
+                      </span>
+                    )}
+                  </span>
+                  <code className="shrink-0 text-xs text-slate-500">{r.id}</code>
+                </button>
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>
@@ -190,6 +219,21 @@ const namedTypes = new Set([
   "Location",
   "Device",
 ]);
+
+/**
+ * Disambiguator shown beneath the primary label in dropdown items. For
+ * person-shaped resources we surface DOB + gender so two patients with the
+ * same name (very common) can be told apart without leaving the picker.
+ */
+function secondaryLabel(resource: Resource): string {
+  const r = resource as unknown as Record<string, unknown>;
+  if (birthdateTypes.has(resource.resourceType)) {
+    const dob = typeof r.birthDate === "string" ? r.birthDate : undefined;
+    const gender = typeof r.gender === "string" ? r.gender : undefined;
+    return [dob && `DOB ${dob}`, gender].filter(Boolean).join(" · ");
+  }
+  return "";
+}
 
 function defaultSearchParamFor(type: string): string {
   if (namedTypes.has(type)) return "name";


### PR DESCRIPTION
Follow-up to #197.

## Summary
Two fixes for the AllergyIntolerance patient filter on iOS Safari:

- **Tap-to-pick was being lost.** Two compounding causes:
  1. iOS Safari's "AutoFill Contact" bar overlays the suggestion list once the search input gains focus, swallowing taps on the option below it. Adding `autoComplete="off"` (plus the related iOS hints) suppresses the AutoFill bar.
  2. The option button used `onClick`, which fires *after* the input blurs. The blur dismisses the keyboard, reflows the page, and the option moves out from under the user's finger. Switched to `onPointerDown` with `preventDefault()` so the pick commits before blur. Keyboard activation (Enter/Space) is preserved via an `onClick` fallback gated on `e.detail === 0`.

- **DOB + gender in dropdown rows.** Two patients with the same name is the norm. Person-shaped resource rows (Patient / Practitioner / RelatedPerson / Person) now show DOB and gender beneath the name when present, so users can disambiguate without leaving the picker.

## Test plan
- [x] All 8 ReferencePicker unit tests pass, including a new test that simulates an iOS-style touch-down on an option (no click event) and asserts the selection still commits.
- [x] Existing test extended to assert the DOB/gender secondary line renders.
- [x] Typecheck clean.
- [ ] Manual: re-open Allergies & Intolerances filter on iOS Safari, type "Sam", confirm tapping a suggestion populates the field and submits the search.

https://claude.ai/code/session_01YMFr93rL7ZJTnRV6MQZ8T8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMFr93rL7ZJTnRV6MQZ8T8)_