### PR TITLE
fix(ReferencePicker): drop raw id from dropdown rows

### DIFF
--- a/packages/react-fhir/src/components/ReferencePicker.test.tsx
+++ b/packages/react-fhir/src/components/ReferencePicker.test.tsx
@@ -74,7 +74,11 @@ describe("ReferencePicker", () => {
     );
     // DOB + gender render as the secondary disambiguator beneath the name.
     expect(screen.getByText(/DOB 1815-12-10 · female/)).toBeInTheDocument();
-    await user.click(screen.getByRole("option", { name: /Ada Lovelace/ }));
+    // Raw id is intentionally not surfaced — name + DOB are enough to
+    // disambiguate, and the id is noise for clinical users.
+    const option = screen.getByRole("option", { name: /Ada Lovelace/ });
+    expect(option).not.toHaveTextContent("p1");
+    await user.click(option);
     expect(onChange).toHaveBeenCalledWith({
       reference: "Patient/p1",
       display: "Ada Lovelace",

--- a/packages/react-fhir/src/components/ReferencePicker.tsx
+++ b/packages/react-fhir/src/components/ReferencePicker.tsx
@@ -183,17 +183,14 @@ export function ReferencePicker(props: ReferencePickerProps) {
                   // accidentally pick the row the finger started on.
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => pick(r)}
-                  className="flex w-full items-start justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-slate-50"
+                  className="flex w-full flex-col gap-0.5 px-3 py-2 text-left text-sm hover:bg-slate-50"
                 >
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate">{formatReferenceLabel(r)}</span>
-                    {secondary && (
-                      <span className="block truncate text-xs text-slate-500">
-                        {secondary}
-                      </span>
-                    )}
-                  </span>
-                  <code className="shrink-0 text-xs text-slate-500">{r.id}</code>
+                  <span className="block truncate">{formatReferenceLabel(r)}</span>
+                  {secondary && (
+                    <span className="block truncate text-xs text-slate-500">
+                      {secondary}
+                    </span>
+                  )}
                 </button>
               </li>
             );


### PR DESCRIPTION
## Summary
Clinical users disambiguate by name + DOB, not by the technical resource id. Removing the trailing `<code>{r.id}</code>` per row keeps the rows focused on what's actually useful and gives the secondary DOB/gender line the full row width.

Layout switches from horizontal name + id to a vertical stack:
```
Sam Fhirman
DOB 1990-04-23 · male
```

## Test plan
- [x] Existing ReferencePicker test extended to assert the option's accessible text no longer contains the id (`p1`).
- [x] All 8 picker tests pass; typecheck clean.

https://claude.ai/code/session_01YMFr93rL7ZJTnRV6MQZ8T8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMFr93rL7ZJTnRV6MQZ8T8)_