### PR TITLE
feat(ResourceSearch): always-visible Type/id input alongside the picker

### DIFF
--- a/apps/demo/e2e/allergy-intolerance-patient-filter.spec.ts
+++ b/apps/demo/e2e/allergy-intolerance-patient-filter.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * AllergyIntolerance.patient is a `Reference` search parameter. The filter
+ * UI exposes both the raw `Type/id` text input and a name-search picker.
+ * These cover the two paths a user can take to populate the same field.
+ */
+test.describe("AllergyIntolerance patient filter", () => {
+  test("name-search pick fills the Type/id text input and applies the filter", async ({
+    page,
+  }) => {
+    await page.goto("/fhir-ui/AllergyIntolerance");
+
+    const search = page.getByTestId("resource-search");
+    const text = search.getByRole("textbox", { name: "patient" });
+    const picker = search.getByRole("searchbox", { name: /search patient/i });
+
+    // Both inputs are present and the text input starts empty.
+    await expect(text).toBeVisible();
+    await expect(picker).toBeVisible();
+    await expect(text).toHaveValue("");
+
+    // Type a name fragment, wait for the suggestion, click it.
+    await picker.fill("Ada");
+    const option = page.getByRole("option", { name: /Ada Lovelace/ });
+    await expect(option).toBeVisible();
+    await option.click();
+
+    // The pick populates the always-visible Type/id text input.
+    await expect(text).toHaveValue("Patient/ada");
+
+    // Submit the search → URL gains `patient=Patient/ada` and the filtered
+    // result (the Penicillin allergy fixture) shows up.
+    await search.getByRole("button", { name: /search/i }).click();
+    await expect(page).toHaveURL(/patient=Patient(\/|%2F)ada/);
+    await expect(page.getByRole("cell", { name: /Penicillin/ })).toBeVisible();
+  });
+
+  test("manually typed Type/id is what gets submitted", async ({ page }) => {
+    await page.goto("/fhir-ui/AllergyIntolerance");
+
+    const search = page.getByTestId("resource-search");
+    const text = search.getByRole("textbox", { name: "patient" });
+
+    await text.fill("Patient/ada");
+    await search.getByRole("button", { name: /search/i }).click();
+
+    await expect(page).toHaveURL(/patient=Patient(\/|%2F)ada/);
+    await expect(page.getByRole("cell", { name: /Penicillin/ })).toBeVisible();
+  });
+});

--- a/apps/demo/src/mocks/handlers.ts
+++ b/apps/demo/src/mocks/handlers.ts
@@ -83,6 +83,18 @@ export const handlers = [
                 { name: "date", type: "date" },
               ],
             },
+            {
+              type: "AllergyIntolerance",
+              interaction: [{ code: "read" }, { code: "search-type" }],
+              searchParam: [
+                {
+                  name: "patient",
+                  type: "reference",
+                  documentation: "Who the sensitivity is for",
+                },
+                { name: "code", type: "token" },
+              ],
+            },
           ],
         },
       ],

--- a/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
@@ -222,12 +222,17 @@ export function ResourceListPage() {
 
   const submitFilters = (next: SearchParams) => {
     const entries: Array<[string, string]> = [];
-    if (patientId) entries.push(["patient", patientId]);
     for (const [k, v] of Object.entries(next)) {
-      if (k === "patient") continue;
+      // In a Patient compartment view the URL owns the `patient` filter;
+      // ignore form-supplied patient values so users can't accidentally
+      // navigate themselves out of the compartment they came in on.
+      if (k === "patient" && patientId) continue;
       if (v === undefined || v === "" || v === null) continue;
       if (Array.isArray(v)) entries.push([k, v.join(",")]);
       else entries.push([k, String(v)]);
+    }
+    if (patientId && !entries.some(([k]) => k === "patient")) {
+      entries.unshift(["patient", patientId]);
     }
     setSearchParams(Object.fromEntries(entries), { replace: true });
   };

--- a/packages/react-fhir/src/components/ResourceSearch.test.tsx
+++ b/packages/react-fhir/src/components/ResourceSearch.test.tsx
@@ -88,9 +88,10 @@ describe("ResourceSearch", () => {
     );
     // name, identifier, birthdate, gender, organization, address-city, phone, _id
     // - birthdate is a date input (no textbox role)
-    // - organization is a reference, rendered via ReferencePicker → searchbox role
-    // → 6 textboxes + 1 searchbox
-    expect(screen.getAllByRole("textbox").length).toBe(6);
+    // - organization is a reference: a Type/id text input + a name-search
+    //   picker (searchbox)
+    // → 7 textboxes + 1 searchbox
+    expect(screen.getAllByRole("textbox").length).toBe(7);
     expect(screen.getByRole("searchbox", { name: /search organization/i })).toBeInTheDocument();
     expect(screen.getByLabelText("birthdate")).toBeInTheDocument();
     expect(screen.getAllByPlaceholderText(/code or system\|code/i).length).toBeGreaterThan(0);
@@ -161,9 +162,9 @@ describe("ResourceSearch", () => {
     );
     expect(screen.getAllByRole("textbox").length).toBe(3);
     await user.click(screen.getByRole("button", { name: /show.*more parameters/i }));
-    // After expand: 6 textboxes (birthdate is a date input; organization is a
-    // reference picker rendered as a searchbox).
-    expect(screen.getAllByRole("textbox").length).toBe(6);
+    // After expand: 7 textboxes (birthdate is a date input; organization
+    // contributes one Type/id textbox plus a separate name-search box).
+    expect(screen.getAllByRole("textbox").length).toBe(7);
     expect(screen.getByRole("searchbox", { name: /search organization/i })).toBeInTheDocument();
   });
 
@@ -230,8 +231,8 @@ beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-describe("ResourceSearch — reference name search", () => {
-  it("searches Patients by name and submits the picked Patient/id", async () => {
+describe("ResourceSearch — reference filter", () => {
+  const stubPatientSearch = () => {
     server.use(
       http.get(`${BASE}/Patient`, ({ request }) => {
         const q = (new URL(request.url).searchParams.get("name") ?? "").toLowerCase();
@@ -249,6 +250,43 @@ describe("ResourceSearch — reference name search", () => {
         });
       }),
     );
+  };
+
+  it("renders both the raw Type/id text input and the name-search picker", () => {
+    wrap(
+      <ResourceSearch
+        resourceType="AllergyIntolerance"
+        capabilityStatement={allergyCap}
+      />,
+    );
+    // Text input (always visible) — `Type/id` placeholder identifies it.
+    expect(screen.getByRole("textbox", { name: /patient/i })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/type\/id/i)).toBeInTheDocument();
+    // Search-by-name picker.
+    expect(screen.getByRole("searchbox", { name: /search patient/i })).toBeInTheDocument();
+  });
+
+  it("submits the value when the user types Type/id directly", async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    wrap(
+      <ResourceSearch
+        resourceType="AllergyIntolerance"
+        capabilityStatement={allergyCap}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.type(
+      screen.getByRole("textbox", { name: /patient/i }),
+      "Patient/manual-id",
+    );
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+    expect(onSubmit).toHaveBeenCalledWith({ patient: "Patient/manual-id" });
+  });
+
+  it("populates the text input from a name-search pick and submits it", async () => {
+    stubPatientSearch();
 
     const onSubmit = vi.fn();
     const user = userEvent.setup();
@@ -260,14 +298,52 @@ describe("ResourceSearch — reference name search", () => {
       />,
     );
 
-    const search = screen.getByRole("searchbox", { name: /search patient/i });
-    await user.type(search, "Lovelace");
+    const text = screen.getByRole("textbox", { name: /patient/i });
+    expect(text).toHaveValue("");
+
+    await user.type(
+      screen.getByRole("searchbox", { name: /search patient/i }),
+      "Lovelace",
+    );
     await waitFor(() =>
       expect(screen.getByRole("option", { name: /Ada Lovelace/ })).toBeInTheDocument(),
     );
     await user.click(screen.getByRole("option", { name: /Ada Lovelace/ }));
+
+    // The pick fills the always-visible Type/id text input.
+    expect(text).toHaveValue("Patient/p1");
+
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+    expect(onSubmit).toHaveBeenCalledWith({ patient: "Patient/p1" });
+  });
+
+  it("lets the user overwrite the picked id by editing the text input afterwards", async () => {
+    stubPatientSearch();
+
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    wrap(
+      <ResourceSearch
+        resourceType="AllergyIntolerance"
+        capabilityStatement={allergyCap}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.type(
+      screen.getByRole("searchbox", { name: /search patient/i }),
+      "Lovelace",
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /Ada Lovelace/ })).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("option", { name: /Ada Lovelace/ }));
+
+    const text = screen.getByRole("textbox", { name: /patient/i });
+    await user.clear(text);
+    await user.type(text, "Patient/different-id");
     await user.click(screen.getByRole("button", { name: /^search$/i }));
 
-    expect(onSubmit).toHaveBeenCalledWith({ patient: "Patient/p1" });
+    expect(onSubmit).toHaveBeenCalledWith({ patient: "Patient/different-id" });
   });
 });

--- a/packages/react-fhir/src/components/ResourceSearch.tsx
+++ b/packages/react-fhir/src/components/ResourceSearch.tsx
@@ -2,7 +2,6 @@ import type {
   CapabilityStatementRestResourceSearchParam,
   CapabilityStatement,
   ElementDefinition,
-  Reference,
 } from "fhir/r4";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import {
@@ -341,17 +340,17 @@ function TokenSearchField({ base, param, value, onChange, profile }: SearchField
 /* ---------- reference ---------- */
 
 /**
- * Reference search field: hands off to the autocomplete `ReferencePicker` so
- * users can find e.g. a Patient by name instead of pasting `Patient/123`. The
- * picker emits a {@link Reference}; we serialise just `Type/id` for the
- * underlying form value (FHIR servers accept both `?patient=Patient/123` and
- * `?patient=123`, but the qualified form survives multi-target params).
+ * Reference search field. Renders the raw `Type/id` text input — always
+ * editable so users who already know the id can paste it directly — and
+ * pairs it with a {@link ReferencePicker} for name-based lookup. Picking a
+ * result populates the text input; the input value is what gets submitted
+ * with the search.
  *
  * Targets come from `SearchParameter.target` when the server exposes them;
  * for the common single-target params used in clinical apps (`patient`,
- * `subject`, `practitioner`, etc.) we fall back to a baked-in mapping so the
- * picker still works against servers that don't surface SearchParameter.
- * When no targets can be derived we render the plain `Type/id` text input.
+ * `practitioner`, etc.) we fall back to a baked-in mapping so the picker
+ * still works against servers that don't surface SearchParameter. When no
+ * targets can be derived we drop the picker and keep just the text input.
  */
 function ReferenceSearchField({ base, param, value, onChange }: SearchFieldProps): ReactNode {
   const { data: spec } = useSearchParameter(base, param.name ?? "");
@@ -362,30 +361,35 @@ function ReferenceSearchField({ base, param, value, onChange }: SearchFieldProps
     return defaultReferenceTargets(param.name ?? "");
   }, [spec, param.name]);
 
+  const textInput = (
+    <input
+      type="text"
+      aria-label={param.name}
+      placeholder={inputPlaceholder(param.type)}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
+    />
+  );
+
   if (targets.length === 0) {
-    return fieldWrapper(
-      <input
-        type="text"
-        aria-label={param.name}
-        placeholder={inputPlaceholder(param.type)}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
-      />,
-      param,
-      base,
-    );
+    return fieldWrapper(textInput, param, base);
   }
 
-  const ref: Reference | undefined = value ? { reference: value } : undefined;
-
   return fieldWrapper(
-    <ReferencePicker
-      targets={targets}
-      value={ref}
-      onChange={(r) => onChange(r?.reference ?? "")}
-      className="relative space-y-2"
-    />,
+    <div className="space-y-1">
+      {textInput}
+      <ReferencePicker
+        targets={targets}
+        // Always undefined so the picker stays in search mode; the raw text
+        // input above is the authoritative value the form submits.
+        value={undefined}
+        onChange={(r) => {
+          if (r?.reference) onChange(r.reference);
+        }}
+        className="relative space-y-2"
+      />
+    </div>,
     param,
     base,
   );


### PR DESCRIPTION
## Summary
The reference search filter now renders the raw `Type/id` text input permanently, not only as a fallback. The name-search picker sits beneath it; picking a result fills the text input above so users can either:
- paste a known `Type/id` directly, or
- search by name and click a result, then optionally edit the result.

Three small supporting changes were needed to make this work end-to-end:

- **Demo CapabilityStatement** now advertises `AllergyIntolerance` with a `patient` reference search param so the filter has something to render against the in-browser MSW mock (mirrors the real-server scenario from the original bug report).

- **`ResourceListPage.submitFilters`** previously stripped `patient` from form submissions unconditionally, which silently dropped any user-entered patient filter on non-compartment routes. It now only protects the `patient` URL param when the page is genuinely scoped to a Patient compartment, so `/fhir-ui/AllergyIntolerance` can filter by patient.

- **New Playwright spec** covers both UX paths against the mock backend: picker selection → text input filled → submit → URL + result, and the manual-id path with the same submit assertions.

## Test plan
- [x] `vitest run` — 18 ResourceSearch tests pass, including 4 new tests covering the always-on text input, the manual-id path, the picker-fill path, and the picker-then-edit path.
- [x] `playwright test e2e/allergy-intolerance-patient-filter.spec.ts` — both e2e paths pass against the MSW mock.
- [x] Typecheck clean.

https://claude.ai/code/session_01YMFr93rL7ZJTnRV6MQZ8T8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMFr93rL7ZJTnRV6MQZ8T8)_