### PR TITLE
fix(ReferencePicker): pick on click, not pointerdown

### DIFF
--- a/packages/react-fhir/src/components/ReferencePicker.test.tsx
+++ b/packages/react-fhir/src/components/ReferencePicker.test.tsx
@@ -81,7 +81,11 @@ describe("ReferencePicker", () => {
     });
   });
 
-  it("commits the selection on pointerdown so iOS taps don't get lost to input blur", async () => {
+  it("does not pick on initial touch so a long dropdown remains scrollable", async () => {
+    // Codex review on #202: committing on pointerdown picks the row the
+    // user's finger lands on before they can drag to scroll. Selection now
+    // happens on `click`, which iOS suppresses when a touch resolves into a
+    // scroll gesture.
     server.use(
       http.get(`${BASE}/Patient`, () =>
         HttpResponse.json({
@@ -102,14 +106,40 @@ describe("ReferencePicker", () => {
     await user.type(screen.getByRole("searchbox", { name: /search patient/i }), "L");
     const option = await screen.findByRole("option", { name: /Ada Lovelace/ });
 
-    // Simulate the iOS sequence: pointerdown on the option fires first, BEFORE
-    // any click — emulating the real-world failure mode where the subsequent
-    // tap event was never delivered. pick() must already have run.
+    // pointerdown only — no follow-up click. Mirrors a touch that became a
+    // scroll. `pick()` must NOT run.
     await user.pointer({ keys: "[TouchA>]", target: option });
-    expect(onChange).toHaveBeenCalledWith({
-      reference: "Patient/p1",
-      display: "Ada Lovelace",
-    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("preserves search-input focus when an option is tapped", async () => {
+    // The `mousedown.preventDefault()` keeps focus on the search input so iOS
+    // doesn't dismiss the keyboard between mousedown and click — that reflow
+    // is what made taps land on the wrong row originally.
+    server.use(
+      http.get(`${BASE}/Patient`, () =>
+        HttpResponse.json({
+          resourceType: "Bundle",
+          type: "searchset",
+          entry: patients.map((r) => ({ resource: r })),
+        }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <ReferencePicker targets={["Patient"]} value={undefined} onChange={() => {}} debounceMs={0} />,
+      { wrapper: wrap() },
+    );
+
+    const input = screen.getByRole("searchbox", { name: /search patient/i });
+    await user.type(input, "L");
+    const option = await screen.findByRole("option", { name: /Ada Lovelace/ });
+    expect(input).toHaveFocus();
+
+    // Mousedown on the option should NOT move focus off the input.
+    await user.pointer({ keys: "[MouseLeft>]", target: option });
+    expect(input).toHaveFocus();
   });
 
   it("shows a clear button for an already-selected reference and resets on click", async () => {

--- a/packages/react-fhir/src/components/ReferencePicker.tsx
+++ b/packages/react-fhir/src/components/ReferencePicker.tsx
@@ -174,19 +174,15 @@ export function ReferencePicker(props: ReferencePickerProps) {
                   type="button"
                   role="option"
                   aria-selected={false}
-                  // `onPointerDown` (not `onClick`) so selection commits before
-                  // the search input blurs. iOS Safari reflows the page when
-                  // the keyboard dismisses on blur, which moves the option out
-                  // from under the user's finger and swallows the tap.
-                  onPointerDown={(e) => {
-                    e.preventDefault();
-                    pick(r);
-                  }}
-                  // Keyboard activation (Enter/Space on the focused button)
-                  // never produces a pointerdown — `e.detail === 0` flags it.
-                  onClick={(e) => {
-                    if (e.detail === 0) pick(r);
-                  }}
+                  // `mousedown.preventDefault()` keeps the search input
+                  // focused — without that, the input blurs on tap, iOS
+                  // dismisses the keyboard, the page reflows, and the click
+                  // event lands on whatever ends up under the user's finger.
+                  // The actual selection runs from `onClick` so a touch that
+                  // turns into a scroll/drag (no click event from iOS) doesn't
+                  // accidentally pick the row the finger started on.
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => pick(r)}
                   className="flex w-full items-start justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-slate-50"
                 >
                   <span className="min-w-0 flex-1">


### PR DESCRIPTION
Addresses [codex's P1 review on #202](https://github.com/samsuffolksperoni/fhir-place/pull/202#discussion_r3177240944):

> Calling `pick(r)` inside `onPointerDown` causes every touch contact to select immediately, which breaks normal scrolling behavior on mobile when the result list is long.

## Summary
Selection runs from `onClick` again, which iOS Safari suppresses when a touch resolves into a scroll/drag — so dragging the list no longer accidentally picks. The original tap-doesn't-fire problem (input blurs → keyboard dismisses → page reflows → click misses) is now solved by `mousedown.preventDefault()` on the option button, which keeps focus on the search input across the tap. The keyboard never dismisses, the page never reflows, and the click lands on the row the finger started on.

## Test plan
- [x] Replaced the now-misleading "commits on pointerdown" test with two tests covering the new contract:
  - touch-down on an option *without* a follow-up click (mirrors a tap-turned-scroll) does NOT call `onChange`.
  - mousedown on an option preserves focus on the search input.
- [x] Existing "searches…and picks…on click" test still passes — confirms tap → click → pick still works in the happy path.
- [x] All 9 picker tests pass; typecheck clean.

https://claude.ai/code/session_01YMFr93rL7ZJTnRV6MQZ8T8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMFr93rL7ZJTnRV6MQZ8T8)_