### PR TITLE
fix(ReferencePicker): label DOB filter, separate ref from picker

### DIFF
--- a/packages/react-fhir/src/components/ReferencePicker.test.tsx
+++ b/packages/react-fhir/src/components/ReferencePicker.test.tsx
@@ -201,6 +201,18 @@ describe("ReferencePicker", () => {
     expect(screen.queryByLabelText(/birth date/i)).not.toBeInTheDocument();
   });
 
+  it("labels the DOB input visibly so the empty box reads as an optional filter", () => {
+    render(
+      <ReferencePicker targets={["Patient"]} value={undefined} onChange={() => {}} />,
+      { wrapper: wrap() },
+    );
+    // The visible "DOB" prefix is what tells the user the otherwise-blank
+    // type=date input is a date-of-birth filter.
+    const dob = screen.getByLabelText(/birth date/i);
+    expect(dob).toBeInTheDocument();
+    expect(dob.closest("label")).toHaveTextContent(/^DOB/);
+  });
+
   it("searches by birthdate alone (no free-text query) for Patient", async () => {
     const seen: string[] = [];
     server.use(

--- a/packages/react-fhir/src/components/ReferencePicker.tsx
+++ b/packages/react-fhir/src/components/ReferencePicker.tsx
@@ -139,18 +139,26 @@ export function ReferencePicker(props: ReferencePickerProps) {
             className="min-w-[12rem] flex-1 rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
           />
           {supportsBirthdate && (
-            <input
-              type="date"
-              aria-label="Birth date"
+            // Visible "DOB" prefix because empty `type="date"` inputs render
+            // as a blank box on iOS, and an unlabeled empty box next to the
+            // search field reads as broken UI rather than an optional filter.
+            <label
+              className="flex items-center gap-1.5 rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-500 shadow-sm focus-within:border-blue-500"
               title="Filter by date of birth (optional)"
-              value={birthdate}
-              onChange={(e) => {
-                setBirthdate(e.target.value);
-                setIsOpen(true);
-              }}
-              onFocus={() => setIsOpen(true)}
-              className="rounded border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm focus:border-blue-500 focus:outline-none"
-            />
+            >
+              <span>DOB</span>
+              <input
+                type="date"
+                aria-label="Birth date"
+                value={birthdate}
+                onChange={(e) => {
+                  setBirthdate(e.target.value);
+                  setIsOpen(true);
+                }}
+                onFocus={() => setIsOpen(true)}
+                className="border-0 bg-transparent p-0 text-sm text-slate-700 focus:outline-none"
+              />
+            </label>
           )}
         </div>
       )}

--- a/packages/react-fhir/src/components/ResourceSearch.tsx
+++ b/packages/react-fhir/src/components/ResourceSearch.tsx
@@ -377,8 +377,13 @@ function ReferenceSearchField({ base, param, value, onChange }: SearchFieldProps
   }
 
   return fieldWrapper(
-    <div className="space-y-1">
+    <div className="space-y-1.5">
       {textInput}
+      <div className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-slate-400">
+        <span className="h-px flex-1 bg-slate-200" />
+        <span>or look up</span>
+        <span className="h-px flex-1 bg-slate-200" />
+      </div>
       <ReferencePicker
         targets={targets}
         // Always undefined so the picker stays in search mode; the raw text


### PR DESCRIPTION
## Summary
Cleans up the reference search field so the layout reads clearly. Two issues from the screenshot:

1. **Empty DOB box.** The `type="date"` filter renders as a blank box on iOS until the user taps it, with no visible label. Wrapped it in a label with a visible "DOB" prefix so the field's purpose is obvious at a glance.

2. **Loose stack of inputs.** The Type/id text input and the picker were stacked with no visual relationship. Added a quiet "or look up" rule between them in `ReferenceSearchField` so it reads as: *here's the value being submitted, here's how to look it up*.

Before:
```
[ Type/id                                    ]
[ Search Patient by name…    ] [        ]   ← what is this???
```

After:
```
[ Type/id                                    ]
─────── or look up ───────
[ Search Patient by name…    ] [ DOB ____ ]
```

## Test plan
- [x] New unit test asserts the visible "DOB" prefix on the date input's label.
- [x] All 28 ReferencePicker + ResourceSearch unit tests pass.
- [x] AllergyIntolerance Playwright spec still green.
- [x] Typecheck clean.

https://claude.ai/code/session_01YMFr93rL7ZJTnRV6MQZ8T8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMFr93rL7ZJTnRV6MQZ8T8)_