### PR TITLE
fix: Load more button appearing mid-list instead of below results

### DIFF
--- a/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
@@ -576,24 +576,25 @@ export function ResourceListPage() {
           )
         )}
 
-        {/* Load more */}
-        {hasNextPage && (
-          <div style={{ display: "flex", justifyContent: "center", marginTop: 12 }}>
-            <button
-              onClick={() => fetchNextPage()}
-              disabled={isFetchingNextPage}
-              data-testid="load-more"
-              style={{
-                ...ccBtn("secondary"),
-                fontSize: 12,
-                opacity: isFetchingNextPage ? 0.6 : 1,
-              }}
-            >
-              {isFetchingNextPage ? "Loading…" : "Load more"}
-            </button>
-          </div>
-        )}
       </div>
+
+      {/* Load more */}
+      {hasNextPage && (
+        <div style={{ display: "flex", justifyContent: "center", padding: "12px 24px" }}>
+          <button
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+            data-testid="load-more"
+            style={{
+              ...ccBtn("secondary"),
+              fontSize: 12,
+              opacity: isFetchingNextPage ? 0.6 : 1,
+            }}
+          >
+            {isFetchingNextPage ? "Loading…" : "Load more"}
+          </button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- The "Load more" button was rendered inside the results flex container as a sibling to the content (`ResourceList`, table, or JSON view)
- In the list layout, `ResourceList` has no `flex: 1`, so the button could end up visually overlapping with list items rather than appearing below them
- Moved the button outside the results `<div>` so it is always a sibling of the results block, guaranteeing it renders at the bottom of the page after all rows

## Test plan

- [ ] Open Patient list in **List** layout — Load more should appear below all cards, not overlapping any row
- [ ] Open Patient list in **Table** layout — Load more should appear below the table
- [ ] Open Patient list in **JSON** layout — Load more should appear below the JSON block
- [ ] Click Load more — next page appends correctly and button hides when no further pages exist

https://claude.ai/code/session_01RVtodsXwp6rpkKkb5tpczq

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVtodsXwp6rpkKkb5tpczq)_