### PR TITLE
Make FHIR reference fields clickable links with resolved display names

### DIFF
--- a/apps/demo/src/routes/fhir-ui/pages/ResourceDetailPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceDetailPage.tsx
@@ -58,12 +58,8 @@ export function ResourceDetailPage() {
   const onReferenceClick = (ref: Reference) => {
     const r = ref.reference;
     if (!r) return;
-    if (/^https?:\/\//i.test(r)) {
-      window.open(r, "_blank", "noopener,noreferrer");
-      return;
-    }
-    const [type, refId] = r.split("/");
-    if (type && refId) navigate(`/fhir-ui/${type}/${refId}`);
+    const match = r.match(/([A-Za-z]+)\/([^/]+)$/);
+    if (match) navigate(`/fhir-ui/${match[1]}/${match[2]}`);
   };
 
   const handleDelete = async () => {

--- a/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
@@ -7,7 +7,7 @@ import {
   useInfiniteSearch,
   useStructureDefinition,
 } from "@fhir-place/react-fhir";
-import type { Resource } from "fhir/r4";
+import type { Reference, Resource } from "fhir/r4";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import type { SearchParams } from "@fhir-place/react-fhir";
@@ -112,6 +112,13 @@ export function ResourceListPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const client = useFhirClient();
+
+  const onReferenceClick = (ref: Reference) => {
+    const r = ref.reference;
+    if (!r) return;
+    const match = r.match(/([A-Za-z]+)\/([^/]+)$/);
+    if (match) navigate(`/fhir-ui/${match[1]}/${match[2]}`);
+  };
   const patientId = searchParams.get("patient") ?? undefined;
 
   const config: ResourceListConfig | undefined = isTopResourceType(resourceType)
@@ -543,6 +550,7 @@ export function ResourceListPage() {
                     }
                   : undefined
               }
+              onReferenceClick={onReferenceClick}
               onRowClick={(r) => r.id && navigate(`/fhir-ui/${r.resourceType}/${r.id}`)}
               emptyState={
                 <p

--- a/packages/react-fhir/src/components/renderers.tsx
+++ b/packages/react-fhir/src/components/renderers.tsx
@@ -14,13 +14,16 @@ import type {
   Range,
   Ratio,
   Reference,
+  Resource,
 } from "fhir/r4";
 import type { ReactNode } from "react";
 import { Fragment, useState } from "react";
 import {
   formatAddress,
   formatHumanName,
+  formatReferenceLabel,
 } from "../structure/format.js";
+import { useReadReference } from "../hooks/queries.js";
 
 /** Context passed to every renderer. */
 export interface RendererContext {
@@ -377,20 +380,34 @@ const IdentifierRenderer: FhirTypeRenderer = (value) => {
   );
 };
 
+function ReferenceCellLink({
+  reference,
+  onClick,
+}: {
+  reference: Reference;
+  onClick: (ref: Reference) => void;
+}) {
+  const { data } = useReadReference<Resource>(reference, { staleTime: 5 * 60_000 });
+  const label = data
+    ? formatReferenceLabel(data)
+    : (reference.display ?? reference.reference ?? "—");
+  return (
+    <button
+      type="button"
+      className="text-blue-700 underline"
+      onClick={() => onClick(reference)}
+    >
+      {label}
+    </button>
+  );
+}
+
 const ReferenceRenderer: FhirTypeRenderer = (value, ctx) => {
   const r = value as Reference;
-  const label = r.display ?? r.reference ?? "—";
   if (ctx.onReferenceClick && r.reference) {
-    return (
-      <button
-        type="button"
-        className="text-blue-700 underline"
-        onClick={() => ctx.onReferenceClick?.(r)}
-      >
-        {label}
-      </button>
-    );
+    return <ReferenceCellLink reference={r} onClick={ctx.onReferenceClick} />;
   }
+  const label = r.display ?? r.reference ?? "—";
   return <span>{label}</span>;
 };
 


### PR DESCRIPTION
Reference cells in table/detail views now fetch the referenced resource
and display a human-readable name (patient name, org name, etc.) via
formatReferenceLabel. Both absolute URLs and relative references resolve
to the local /fhir-ui/{type}/{id} show page instead of opening a new tab.

https://claude.ai/code/session_01JxSxbKSPQThskVEqLHr9uS