### PR TITLE
fix(json-view): ensure results section always has minimum 300px height

### DIFF
--- a/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
@@ -478,7 +478,7 @@ export function ResourceListPage() {
           flex: 1,
           display: "flex",
           flexDirection: "column",
-          minHeight: 0,
+          minHeight: 300,
         }}
       >
         {layout === "json" ? (


### PR DESCRIPTION
When the search form is expanded tall, the results div (flex: 1,
minHeight: 0) could shrink to nearly nothing, leaving the JSON view
barely visible. Setting minHeight: 300 guarantees the results area
always has usable space; the main scroll container handles any overflow.

https://claude.ai/code/session_013UX2frFMJ1bGVbB57JZMQd