### PR TITLE
Add AI-powered natural language search for FHIR resources

### DIFF
--- a/apps/demo/src/components/CCSidebar.tsx
+++ b/apps/demo/src/components/CCSidebar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { ACTIVE_SERVER_CONFIG, loadActiveServerId, loadServers, saveActiveServerId } from "../config.js";
 import { TOP_RESOURCE_TYPES } from "../resourceListConfig.js";
+import { JumpDialog } from "./JumpDialog.js";
 import { CC_MONO } from "./ccStyles.js";
 
 export function CCSidebar() {
@@ -9,6 +10,18 @@ export function CCSidebar() {
   const navigate = useNavigate();
   const [pickerOpen, setPickerOpen] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
+  const [jumpOpen, setJumpOpen] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setJumpOpen(true);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   const activeType = (() => {
     const m = location.pathname.match(/^\/fhir-ui\/([^/]+)/);
@@ -181,9 +194,13 @@ export function CCSidebar() {
         )}
       </div>
 
-      {/* Search */}
+      {/* Search / Jump */}
       <div style={{ padding: "10px 12px", borderBottom: "1px solid var(--border)" }}>
         <div
+          role="button"
+          tabIndex={0}
+          onClick={() => setJumpOpen(true)}
+          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setJumpOpen(true); }}
           style={{
             display: "flex",
             alignItems: "center",
@@ -192,14 +209,14 @@ export function CCSidebar() {
             border: "1px solid var(--border)",
             borderRadius: 6,
             background: "var(--bg)",
-            cursor: "text",
+            cursor: "pointer",
           }}
         >
           <svg width="13" height="13" viewBox="0 0 14 14" fill="none" stroke="var(--text-subtle)" strokeWidth="1.5">
             <circle cx="6" cy="6" r="4.5" />
             <path d="M9.5 9.5L13 13" />
           </svg>
-          <span style={{ fontSize: 12, color: "var(--text-subtle)", flex: 1 }}>Jump to…</span>
+          <span style={{ fontSize: 12, color: "var(--text-subtle)", flex: 1 }}>Search in plain English…</span>
           <span
             style={{
               fontSize: 10,
@@ -214,6 +231,8 @@ export function CCSidebar() {
           </span>
         </div>
       </div>
+
+      <JumpDialog open={jumpOpen} onClose={() => setJumpOpen(false)} />
 
       {/* Resources */}
       <div style={{ padding: "12px 8px", overflowY: "auto", flex: 1 }}>

--- a/apps/demo/src/components/JumpDialog.tsx
+++ b/apps/demo/src/components/JumpDialog.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { naturalLanguageToFhirQuery } from "../ask/anthropicQuery.js";
+import { loadAnthropicApiKey } from "../config.js";
+import { CC_MONO } from "./ccStyles.js";
+
+interface JumpDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function JumpDialog({ open, onClose }: JumpDialogProps) {
+  const navigate = useNavigate();
+  const [question, setQuestion] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setQuestion("");
+      setError(null);
+      setTimeout(() => inputRef.current?.focus(), 30);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  const submit = async () => {
+    if (!question.trim() || loading) return;
+    const apiKey = loadAnthropicApiKey();
+    if (!apiKey) {
+      setError("No Anthropic API key — add one in Settings first.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const plan = await naturalLanguageToFhirQuery(question, apiKey);
+      const qs = new URLSearchParams();
+      for (const [k, v] of Object.entries(plan.params)) {
+        if (v) qs.append(k, v);
+      }
+      const search = qs.toString();
+      navigate(`/fhir-ui/${plan.resourceType}${search ? `?${search}` : ""}`);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 1000,
+        display: "flex",
+        alignItems: "flex-start",
+        justifyContent: "center",
+        paddingTop: 120,
+        background: "rgba(0,0,0,0.4)",
+      }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        style={{
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          borderRadius: 12,
+          boxShadow: "0 24px 60px rgba(0,0,0,0.25)",
+          width: "100%",
+          maxWidth: 560,
+          overflow: "hidden",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Input row */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "14px 16px",
+            borderBottom: error ? "1px solid var(--border)" : undefined,
+          }}
+        >
+          {loading ? (
+            <svg
+              width="16" height="16" viewBox="0 0 16 16"
+              fill="none" stroke="var(--accent)" strokeWidth="1.5"
+              style={{ flexShrink: 0, animation: "spin 1s linear infinite" }}
+            >
+              <circle cx="8" cy="8" r="6" strokeOpacity="0.25" />
+              <path d="M8 2a6 6 0 016 6" />
+            </svg>
+          ) : (
+            <svg
+              width="16" height="16" viewBox="0 0 16 16"
+              fill="none" stroke="var(--text-subtle)" strokeWidth="1.5"
+              style={{ flexShrink: 0 }}
+            >
+              <circle cx="7" cy="7" r="5" />
+              <path d="M11 11l3.5 3.5" />
+            </svg>
+          )}
+          <input
+            ref={inputRef}
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") submit(); }}
+            placeholder="Search in plain English… e.g. patients with diabetes over 65"
+            style={{
+              flex: 1,
+              border: "none",
+              outline: "none",
+              background: "transparent",
+              fontSize: 15,
+              color: "var(--text)",
+              fontFamily: "inherit",
+            }}
+          />
+          <span
+            style={{
+              fontSize: 10,
+              color: "var(--text-subtle)",
+              fontFamily: CC_MONO,
+              padding: "2px 6px",
+              border: "1px solid var(--border)",
+              borderRadius: 4,
+              flexShrink: 0,
+            }}
+          >
+            ⏎ search
+          </span>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div style={{ padding: "10px 16px", fontSize: 12, color: "var(--error, #dc2626)" }}>
+            {error}
+          </div>
+        )}
+
+        {/* Footer hint */}
+        {!error && (
+          <div
+            style={{
+              padding: "8px 16px",
+              fontSize: 11,
+              color: "var(--text-subtle)",
+              borderTop: "1px solid var(--border)",
+            }}
+          >
+            Claude translates your question into a FHIR search and opens it as a new tab
+          </div>
+        )}
+      </div>
+
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+}

--- a/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
@@ -8,12 +8,14 @@ import {
   useStructureDefinition,
 } from "@fhir-place/react-fhir";
 import type { Reference, Resource } from "fhir/r4";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import type { SearchParams } from "@fhir-place/react-fhir";
+import { naturalLanguageToFhirQuery } from "../../../ask/anthropicQuery.js";
 import { PatientRowCounts } from "../../../components/PatientRowCounts.js";
 import { SearchRequestPreview } from "../../../components/SearchRequestPreview.js";
 import { CC_FONT, CC_MONO, ccBtn } from "../../../components/ccStyles.js";
+import { loadAnthropicApiKey } from "../../../config.js";
 import {
   RESOURCE_LIST_CONFIG,
   isTopResourceType,
@@ -215,6 +217,23 @@ export function ResourceListPage() {
     });
   }, [tableColumns, defaultVisibleColumns]);
 
+  const askAI = useCallback(
+    async (question: string): Promise<Record<string, string> | null> => {
+      const apiKey = loadAnthropicApiKey();
+      if (!apiKey) throw new Error("No Anthropic API key — add one in Settings first.");
+      const plan = await naturalLanguageToFhirQuery(question, apiKey);
+      const { _count, ...rest } = plan.params;
+      void _count;
+      if (plan.resourceType !== resourceType) {
+        const qs = new URLSearchParams(rest);
+        navigate(`/fhir-ui/${plan.resourceType}${qs.toString() ? `?${qs}` : ""}`);
+        return null;
+      }
+      return rest;
+    },
+    [resourceType, navigate],
+  );
+
   const submitFilters = (next: SearchParams) => {
     const entries: Array<[string, string]> = [];
     for (const [k, v] of Object.entries(next)) {
@@ -355,6 +374,7 @@ export function ResourceListPage() {
               })
             }
             onSubmit={submitFilters}
+            onAskAI={askAI}
           />
 
           {/* Request preview */}

--- a/packages/react-fhir/src/components/ResourceSearch.tsx
+++ b/packages/react-fhir/src/components/ResourceSearch.tsx
@@ -3,7 +3,7 @@ import type {
   CapabilityStatement,
   ElementDefinition,
 } from "fhir/r4";
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   useCapabilities,
   useSearchParameter,
@@ -32,6 +32,13 @@ export interface ResourceSearchProps {
   priorityParams?: string[];
   className?: string;
   profile?: string;
+  /**
+   * When provided, an "Ask AI" button appears in the form header. The callback
+   * receives the user's natural-language question and should return a map of
+   * FHIR search params to fill into the form, or null to handle navigation
+   * externally (e.g. when the AI suggests a different resource type).
+   */
+  onAskAI?: (question: string) => Promise<Record<string, string> | null>;
 }
 
 type SpecType = CapabilityStatementRestResourceSearchParam["type"];
@@ -101,6 +108,7 @@ export function ResourceSearch(props: ResourceSearchProps) {
     priorityParams = ["_id", "identifier", "name", "family", "given", "status", "code", "subject", "patient", "date"],
     className,
     profile,
+    onAskAI,
   } = props;
 
   const capQuery = useCapabilities({ enabled: !capabilityStatement });
@@ -113,6 +121,37 @@ export function ResourceSearch(props: ResourceSearchProps) {
 
   const [values, setValues] = useState<Record<string, string>>(initialParams ?? {});
   const [showAll, setShowAll] = useState(false);
+
+  const [askOpen, setAskOpen] = useState(false);
+  const [askQuestion, setAskQuestion] = useState("");
+  const [askLoading, setAskLoading] = useState(false);
+  const [askError, setAskError] = useState<string | null>(null);
+  const askInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (askOpen) setTimeout(() => askInputRef.current?.focus(), 20);
+  }, [askOpen]);
+
+  const handleAsk = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!askQuestion.trim() || !onAskAI || askLoading) return;
+    setAskLoading(true);
+    setAskError(null);
+    try {
+      const result = await onAskAI(askQuestion);
+      if (result) {
+        setValues(result);
+        onSubmit?.(buildSearchParams(result));
+        setShowAll(true);
+      }
+      setAskOpen(false);
+      setAskQuestion("");
+    } catch (err) {
+      setAskError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setAskLoading(false);
+    }
+  };
 
   useEffect(() => {
     onChange?.(buildSearchParams(values));
@@ -156,10 +195,61 @@ export function ResourceSearch(props: ResourceSearchProps) {
         <h3 className="text-sm font-semibold text-[var(--text)]">
           Search {resourceType}
         </h3>
-        <span className="text-xs text-[var(--text-subtle)]">
-          {params.length} parameters available
-        </span>
+        <div className="flex items-center gap-2">
+          {onAskAI && (
+            <button
+              type="button"
+              onClick={() => { setAskOpen((v) => !v); setAskError(null); }}
+              className="flex items-center gap-1 rounded border border-[var(--border)] bg-[var(--surface)] px-2 py-0.5 text-xs text-[var(--text-muted)] hover:bg-[var(--sunken)]"
+              title="Ask AI to fill search filters"
+            >
+              <svg width="11" height="11" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M6 1v2M6 9v2M1 6h2M9 6h2M2.5 2.5l1.5 1.5M8 8l1.5 1.5M9.5 2.5L8 4M4 8l-1.5 1.5" />
+              </svg>
+              Ask AI
+            </button>
+          )}
+          <span className="text-xs text-[var(--text-subtle)]">
+            {params.length} parameters available
+          </span>
+        </div>
       </div>
+
+      {/* Inline Ask AI panel */}
+      {askOpen && onAskAI && (
+        <div className="rounded border border-blue-200 bg-blue-50 p-2 space-y-1.5">
+          <div className="flex gap-2">
+            <input
+              ref={askInputRef}
+              type="text"
+              value={askQuestion}
+              onChange={(e) => setAskQuestion(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void handleAsk(e); } if (e.key === "Escape") { setAskOpen(false); setAskError(null); } }}
+              placeholder={`Describe what you're looking for in plain English…`}
+              disabled={askLoading}
+              className="flex-1 rounded border border-blue-300 bg-[var(--sunken)] px-2 py-1 text-sm text-[var(--text)] focus:border-blue-500 focus:outline-none disabled:opacity-60"
+            />
+            <button
+              type="button"
+              onClick={(e) => { void handleAsk(e); }}
+              disabled={askLoading || !askQuestion.trim()}
+              className="rounded bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+            >
+              {askLoading ? "…" : "Fill"}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setAskOpen(false); setAskError(null); }}
+              className="rounded border border-[var(--border)] bg-[var(--surface)] px-2 py-1 text-sm text-[var(--text-muted)] hover:bg-[var(--sunken)]"
+            >
+              ✕
+            </button>
+          </div>
+          {askError && (
+            <p className="text-xs text-red-600">{askError}</p>
+          )}
+        </div>
+      )}
 
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {visible.map((p) => (


### PR DESCRIPTION
## Summary
Adds AI-powered search capabilities using Claude to translate natural language queries into FHIR search parameters. Users can now search for resources by describing what they're looking for in plain English, with the AI automatically filling in the appropriate search filters or navigating to the correct resource type.

## Changes
- **New `JumpDialog` component** (`apps/demo/src/components/JumpDialog.tsx`): A modal dialog that accepts natural language questions and uses Claude to convert them into FHIR queries. Supports keyboard shortcuts (Cmd/Ctrl+K to open, Escape to close, Enter to search).

- **Enhanced `ResourceSearch` component** (`packages/react-fhir/src/components/ResourceSearch.tsx`):
  - Added `onAskAI` callback prop that receives natural language questions and returns search parameters
  - Added inline "Ask AI" panel with input field and submit button
  - Integrates AI results directly into the search form

- **Updated `CCSidebar`** (`apps/demo/src/components/CCSidebar.tsx`):
  - Converted search box to a clickable button that opens `JumpDialog`
  - Added Cmd/Ctrl+K keyboard shortcut to open the jump dialog
  - Updated placeholder text to "Search in plain English…"

- **Enhanced `ResourceListPage`** (`apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx`):
  - Implemented `askAI` callback that handles AI-generated search parameters
  - Automatically navigates to different resource types if the AI suggests them
  - Passes callback to `ResourceSearch` component to enable inline AI assistance

## Test results
No automated tests added. The changes integrate with existing Claude API infrastructure and UI components. Manual testing should verify:
- Keyboard shortcuts (Cmd/Ctrl+K opens dialog, Escape closes it)
- Natural language queries are correctly converted to FHIR search parameters
- Navigation to different resource types when AI suggests them
- Error handling when API key is missing or API calls fail

## Acceptance / manual QA
- [ ] Test opening jump dialog with Cmd/Ctrl+K shortcut
- [ ] Test natural language search with various query types (e.g., "patients over 65", "recent lab results")
- [ ] Test cross-resource navigation when AI suggests a different resource type
- [ ] Test error messages when API key is not configured
- [ ] Test inline "Ask AI" button in resource search form

## Risks
- Depends on Anthropic API availability and rate limits
- Natural language interpretation may not always produce expected FHIR queries
- Users must have API key configured for feature to work

## Follow-ups
- Consider adding query history or suggestions
- Add analytics to track which natural language queries are most common
- Expand AI capabilities to handle more complex multi-step searches

https://claude.ai/code/session_01AWeUgGmPFcmzxzT4WUooof