### PR TITLE
feat(topbar): add labeled Settings button next to History

### DIFF
--- a/apps/demo/src/components/CCTopbar.tsx
+++ b/apps/demo/src/components/CCTopbar.tsx
@@ -22,6 +22,7 @@ function MoonIcon() {
 export function CCTopbar() {
   const location = useLocation();
   const { theme, toggle } = useTheme();
+  const isSettings = location.pathname === "/fhir-ui/settings";
 
   // useParams() returns {} when rendered outside <Routes>, so parse from pathname directly.
   const p = location.pathname;
@@ -106,6 +107,22 @@ export function CCTopbar() {
           </svg>
           History
         </button>
+        <Link
+          to="/fhir-ui/settings"
+          style={{
+            ...ccBtn("ghost"),
+            color: isSettings ? "var(--accent-text)" : "var(--text-muted)",
+            background: isSettings ? "var(--accent-soft)" : "transparent",
+            textDecoration: "none",
+          }}
+          data-testid="topbar-settings"
+        >
+          <svg width="13" height="13" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+            <circle cx="7" cy="7" r="2" />
+            <path d="M7 1v1.5M7 11.5V13M1 7h1.5M11.5 7H13M2.6 2.6l1 1M10.4 10.4l1 1M11.4 2.6l-1 1M3.6 10.4l-1 1" />
+          </svg>
+          Settings
+        </Link>
         {showNew && (
           <Link
             to={`/fhir-ui/${resourceType}/new`}


### PR DESCRIPTION
## Summary
- Adds a labeled **Settings** button (gear icon + text) to the topbar action bar so the Settings page is reachable from anywhere in the app without hunting for the small footer gear icon.

## Issue
Closes #

## Changes
- `apps/demo/src/components/CCTopbar.tsx`: new `<Link>` to `/fhir-ui/settings` rendered after the existing **History** button. Uses `ccBtn("ghost")` styling and highlights with `--accent-soft` / `--accent-text` when on the Settings route. Adds `data-testid="topbar-settings"` for tests.

## Test results
- Manual: clicked the new button on a non-settings page; navigates to `/fhir-ui/settings` and shows the active highlight.
- The pre-existing sidebar gear icon is unchanged and still works.
- `npx tsc --noEmit -p apps/demo` shows only the pre-existing unrelated `vite/client` types error; no new TS errors from this change.

## Acceptance / manual QA
- [ ] Acceptance criteria updated (if applicable)
- [ ] `manual-qa` label added when any acceptance item is not fully automated
- [ ] Linked/created manual QA issue(s):

## Screenshots / recordings
Required for UI/UX changes. Add links to externally hosted recordings or assets committed under the relevant app's `docs/`.
- _Pending — visible as a "Settings" ghost button between **History** and the contextual **+ New …** button in the topbar._

## Risks
- Cosmetic only. Duplicates an existing entry point (sidebar footer gear) so there's no functional regression risk; worst case is a tiny bit of visual redundancy until we decide whether to keep both.

## Follow-ups
- Consider whether the small footer gear in `CCSidebar` is still needed once the topbar entry is in place.