### PR TITLE
feat(resource-list): move + New button into page header

### DIFF
--- a/apps/demo/src/components/CCTopbar.tsx
+++ b/apps/demo/src/components/CCTopbar.tsx
@@ -41,8 +41,6 @@ export function CCTopbar() {
     return ["FHIR Explorer"];
   })();
 
-  const showNew = resourceType && !id && resourceType !== "settings" && resourceType !== "ask";
-
   return (
     <div
       style={{
@@ -123,15 +121,6 @@ export function CCTopbar() {
           </svg>
           Settings
         </Link>
-        {showNew && (
-          <Link
-            to={`/fhir-ui/${resourceType}/new`}
-            style={ccBtn("primary")}
-            data-testid={`create-${resourceType?.toLowerCase()}`}
-          >
-            + New {resourceType}
-          </Link>
-        )}
       </div>
     </div>
   );

--- a/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
@@ -298,6 +298,15 @@ export function ResourceListPage() {
               · Patient/<span style={{ color: "var(--accent-text)" }}>{patientId}</span>
             </span>
           )}
+          {showCreate && (
+            <Link
+              to={`/fhir-ui/${resourceType}/new`}
+              style={{ ...ccBtn("primary"), marginLeft: "auto" }}
+              data-testid={`create-${resourceType.toLowerCase()}`}
+            >
+              + New {resourceType}
+            </Link>
+          )}
         </div>
         {config?.title && (
           <p style={{ fontSize: 13, color: "var(--text-muted)", margin: 0 }}>


### PR DESCRIPTION
## Summary
- Move the primary `+ New {resourceType}` action from the global topbar into the resource list page header, right-aligned on the title row.

## Issue
Closes #

## Changes
- `CCTopbar.tsx`: drop the `showNew` flag and the conditional `+ New` button from the actions cluster.
- `ResourceListPage.tsx`: render the `+ New {resourceType}` link on the same flex row as the heading and `{totalStr}` count, pushed right with `marginLeft: auto`. Wired through the existing `showCreate = !patientId && Boolean(config)` gate, so the button stays hidden in patient-compartment views.
- Preserves the existing `data-testid="create-{resourceType}"` so e2e specs (e.g. `create-patient` in `crud.screenshot.spec.ts`) keep working.

## Test results
- Unable to run `typecheck` / `vitest` / Playwright in this worktree — `node_modules` is not installed and `pnpm` is unavailable here. Change is JSX relocation with no new logic; please rerun the demo app's checks in CI.

## Acceptance / manual QA
- [ ] Acceptance criteria updated (if applicable)
- [ ] `manual-qa` label added when any acceptance item is not fully automated
- [ ] Linked/created manual QA issue(s):

## Screenshots / recordings
Required for UI/UX changes. Add links to externally hosted recordings or assets committed under the relevant app's `docs/`.
- _Pending — verify visually that the `+ New AllergyIntolerance` button now sits in line with "Allergies & intolerances" and the loaded count, right-aligned, and that it still doesn't appear when viewing a resource list scoped to a patient._

## Risks
- The previous topbar button rendered for any resource list path (no `Boolean(config)` check). The new placement uses `ResourceListPage`'s existing `showCreate` gate, which only fires when a `RESOURCE_LIST_CONFIG` entry exists. Resource types without a config entry will no longer show a `+ New` button. If we want parity, relax the gate.

## Follow-ups
- Decide whether to surface `+ New` for resources without a `RESOURCE_LIST_CONFIG` entry; if yes, drop the `Boolean(config)` half of the `showCreate` gate.