### PR TITLE
fix: dark mode for table, pickers, resource view, and HTTP preview

### DIFF
--- a/apps/demo/src/components/SearchRequestPreview.tsx
+++ b/apps/demo/src/components/SearchRequestPreview.tsx
@@ -37,57 +37,57 @@ export function SearchRequestPreview({
 
   return (
     <details
-      className="rounded border border-slate-200 bg-white text-sm"
+      className="rounded border border-[var(--border)] bg-[var(--surface)] text-sm"
       open={open}
       onToggle={(e) => setOpen((e.target as HTMLDetailsElement).open)}
       data-testid="request-preview"
     >
-      <summary className="cursor-pointer select-none px-3 py-2 text-slate-600 hover:bg-slate-50">
-        <span className="font-medium text-slate-700">HTTP request</span>
-        <span className="ml-2 text-xs text-slate-400">
+      <summary className="cursor-pointer select-none px-3 py-2 text-[var(--text-muted)] hover:bg-[var(--sunken)]">
+        <span className="font-medium text-[var(--text)]">HTTP request</span>
+        <span className="ml-2 text-xs text-[var(--text-subtle)]">
           GET · {preview.params.length} param
           {preview.params.length === 1 ? "" : "s"}
         </span>
       </summary>
-      <div className="space-y-3 border-t border-slate-200 px-3 py-3">
+      <div className="space-y-3 border-t border-[var(--border)] px-3 py-3">
         <div>
           <div className="mb-1 flex items-center justify-between gap-2">
-            <span className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            <span className="text-xs font-medium uppercase tracking-wide text-[var(--text-muted)]">
               URL
             </span>
             <button
               type="button"
               onClick={copyUrl}
-              className="rounded border border-slate-300 bg-white px-2 py-0.5 text-xs text-slate-600 hover:bg-slate-50"
+              className="rounded border border-[var(--border)] bg-[var(--sunken)] px-2 py-0.5 text-xs text-[var(--text-muted)] hover:bg-[var(--surface)]"
             >
               {copied ? "Copied" : "Copy"}
             </button>
           </div>
           <code
             data-testid="request-preview-url"
-            className="block break-all rounded bg-slate-50 px-2 py-1.5 font-mono text-xs text-slate-800"
+            className="block break-all rounded bg-[var(--sunken)] px-2 py-1.5 font-mono text-xs text-[var(--text)]"
           >
-            <span className="text-slate-500">GET </span>
+            <span className="text-[var(--text-muted)]">GET </span>
             {preview.url}
           </code>
         </div>
 
         <div>
-          <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-slate-500">
+          <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-[var(--text-muted)]">
             Query parameters
           </span>
           {preview.params.length === 0 ? (
-            <p className="text-xs text-slate-500">
+            <p className="text-xs text-[var(--text-muted)]">
               No parameters yet — start typing in the form above.
             </p>
           ) : (
             <table className="w-full table-fixed border-collapse text-xs">
               <thead>
-                <tr className="text-left text-slate-500">
-                  <th className="w-1/3 border-b border-slate-200 py-1 pr-2 font-medium">
+                <tr className="text-left text-[var(--text-muted)]">
+                  <th className="w-1/3 border-b border-[var(--border)] py-1 pr-2 font-medium">
                     Name
                   </th>
-                  <th className="border-b border-slate-200 py-1 font-medium">
+                  <th className="border-b border-[var(--border)] py-1 font-medium">
                     Value
                   </th>
                 </tr>
@@ -95,10 +95,10 @@ export function SearchRequestPreview({
               <tbody className="font-mono">
                 {preview.params.map(([name, value], i) => (
                   <tr key={`${name}-${i}`} className="align-top">
-                    <td className="border-b border-slate-100 py-1 pr-2 text-slate-700">
+                    <td className="border-b border-[var(--border)] py-1 pr-2 text-[var(--text)]">
                       {name}
                     </td>
-                    <td className="break-all border-b border-slate-100 py-1 text-slate-800">
+                    <td className="break-all border-b border-[var(--border)] py-1 text-[var(--text)]">
                       {value}
                     </td>
                   </tr>
@@ -108,7 +108,7 @@ export function SearchRequestPreview({
           )}
         </div>
 
-        <div className="text-[11px] text-slate-400">
+        <div className="text-[11px] text-[var(--text-subtle)]">
           Headers: <span className="font-mono">Accept: application/fhir+json</span>
           {" "}(plus any auth/custom headers configured for the active server)
         </div>

--- a/packages/react-fhir/src/components/ColumnPicker.tsx
+++ b/packages/react-fhir/src/components/ColumnPicker.tsx
@@ -152,7 +152,7 @@ export function ColumnPicker({
         aria-haspopup="true"
         aria-expanded={open}
         aria-controls={panelId}
-        className="inline-flex items-center gap-1 rounded border border-slate-300 bg-white px-2.5 py-1 text-sm text-slate-700 shadow-sm hover:bg-slate-50"
+        className="inline-flex items-center gap-1 rounded border border-[var(--border)] bg-[var(--surface)] px-2.5 py-1 text-sm text-[var(--text)] shadow-sm hover:bg-[var(--sunken)]"
       >
         {buttonLabel}
         <span aria-hidden className="text-[10px]">▾</span>
@@ -164,14 +164,14 @@ export function ColumnPicker({
           role="group"
           aria-label="Choose visible columns"
           onKeyDown={handleListKeyDown}
-          className="absolute right-0 z-10 mt-1 max-h-64 min-w-[12rem] overflow-y-auto rounded border border-slate-200 bg-white p-2 shadow-lg"
+          className="absolute right-0 z-10 mt-1 max-h-64 min-w-[12rem] overflow-y-auto rounded border border-[var(--border)] bg-[var(--surface)] p-2 shadow-lg"
         >
           <ul className="space-y-1">
             {options.map((opt, i) => {
               const checked = current.includes(opt.path);
               return (
                 <li key={opt.path}>
-                  <label className="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-sm hover:bg-slate-50">
+                  <label className="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-sm hover:bg-[var(--sunken)]">
                     <input
                       type="checkbox"
                       ref={(el) => {

--- a/packages/react-fhir/src/components/ResourceTable.tsx
+++ b/packages/react-fhir/src/components/ResourceTable.tsx
@@ -134,7 +134,7 @@ export function ResourceTable<T extends Resource = Resource>({
   };
 
   if (resources.length === 0) {
-    return <>{emptyState ?? <p className="text-sm text-slate-500">No results.</p>}</>;
+    return <>{emptyState ?? <p className="text-sm text-[var(--text-muted)]">No results.</p>}</>;
   }
 
   // Tailwind classes that gate each layout. `auto` renders both DOM trees
@@ -148,7 +148,7 @@ export function ResourceTable<T extends Resource = Resource>({
   const cardsVisibility = layout === "auto" ? "block sm:hidden" : "";
 
   return (
-    <div className={className ?? "rounded border border-slate-200 bg-white"} data-testid="resource-table">
+    <div className={className ?? "rounded border border-[var(--border)] bg-[var(--surface)]"} data-testid="resource-table">
       {/* Desktop / opt-in table layout */}
       {renderTable && (
       <div
@@ -156,19 +156,19 @@ export function ResourceTable<T extends Resource = Resource>({
         data-testid="resource-table-table"
       >
         <table className="w-full text-sm">
-          <thead className="border-b border-slate-200 bg-slate-50 text-left">
+          <thead className="border-b border-[var(--border)] bg-[var(--sunken)] text-left">
             <tr>
               {headers.map((h) => (
                 <th
                   key={h.path}
                   scope="col"
-                  className="px-3 py-2 font-medium text-slate-600"
+                  className="px-3 py-2 font-medium text-[var(--text-muted)]"
                 >
                   {onSortChange ? (
                     <button
                       type="button"
                       onClick={() => toggleSort(h.path)}
-                      className="flex items-center gap-1 hover:text-slate-900"
+                      className="flex items-center gap-1 hover:text-[var(--text)]"
                     >
                       {h.label}
                       {sort?.by === h.path && (
@@ -184,11 +184,11 @@ export function ResourceTable<T extends Resource = Resource>({
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-slate-100">
+          <tbody className="divide-y divide-[var(--border)]">
             {resources.map((r) => (
               <tr
                 key={`${r.resourceType}/${r.id}`}
-                className={onRowClick ? "cursor-pointer hover:bg-slate-50" : undefined}
+                className={onRowClick ? "cursor-pointer hover:bg-[var(--sunken)]" : undefined}
                 onClick={onRowClick ? () => onRowClick(r) : undefined}
                 onKeyDown={
                   onRowClick
@@ -230,7 +230,7 @@ export function ResourceTable<T extends Resource = Resource>({
           and jsdom doesn't apply CSS). */}
       {renderCards && (
       <ul
-        className={`${cardsVisibility} divide-y divide-slate-200`}
+        className={`${cardsVisibility} divide-y divide-[var(--border)]`}
         data-testid="resource-table-cards"
       >
         {resources.map((r) => (
@@ -238,7 +238,7 @@ export function ResourceTable<T extends Resource = Resource>({
             key={`${r.resourceType}/${r.id}`}
             className={
               onRowClick
-                ? "cursor-pointer p-3 hover:bg-slate-50 focus-within:bg-slate-50"
+                ? "cursor-pointer p-3 hover:bg-[var(--sunken)] focus-within:bg-[var(--sunken)]"
                 : "p-3"
             }
             onClick={onRowClick ? () => onRowClick(r) : undefined}
@@ -258,7 +258,7 @@ export function ResourceTable<T extends Resource = Resource>({
             <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
               {headers.map((h) => (
                 <Fragment key={h.path}>
-                  <dt className="text-xs font-medium text-slate-500">
+                  <dt className="text-xs font-medium text-[var(--text-muted)]">
                     {h.label}
                   </dt>
                   <dd className="break-words">
@@ -322,7 +322,7 @@ function renderCell<T extends Resource>({
 
   const value = getByPath(resource, path);
   if (value === undefined || value === null || value === "") {
-    return <span className="text-slate-400">—</span>;
+    return <span className="text-[var(--text-subtle)]">—</span>;
   }
 
   const ctx: RendererContext = {
@@ -339,7 +339,7 @@ function renderCell<T extends Resource>({
     return <span>{String(value)}</span>;
   }
   return (
-    <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">
+    <code className="rounded bg-[var(--sunken)] px-1 py-0.5 text-xs">
       {JSON.stringify(value).slice(0, 60)}
     </code>
   );

--- a/packages/react-fhir/src/components/ResourceView.tsx
+++ b/packages/react-fhir/src/components/ResourceView.tsx
@@ -74,7 +74,7 @@ export function ResourceView(props: ResourceViewProps) {
     }
     return (
       <div className={className} data-testid="resource-view-loading">
-        <p className="text-sm text-slate-500">
+        <p className="text-sm text-[var(--text-muted)]">
           Loading {resource.resourceType} structure…
         </p>
       </div>
@@ -90,16 +90,16 @@ export function ResourceView(props: ResourceViewProps) {
 
   return (
     <section className={className} data-testid="resource-view">
-      <header className="mb-3 flex items-baseline gap-2 border-b border-slate-200 pb-2">
+      <header className="mb-3 flex items-baseline gap-2 border-b border-[var(--border)] pb-2">
         <h2 className="text-lg font-semibold">{resource.resourceType}</h2>
         {resource.id && (
-          <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">{resource.id}</code>
+          <code className="rounded bg-[var(--sunken)] px-1 py-0.5 text-xs">{resource.id}</code>
         )}
       </header>
 
       {!hideNarrative && narrative?.div && (
-        <details className="mb-4 rounded border border-slate-200 bg-white p-3" open>
-          <summary className="cursor-pointer text-sm font-medium text-slate-600">
+        <details className="mb-4 rounded border border-[var(--border)] bg-[var(--surface)] p-3" open>
+          <summary className="cursor-pointer text-sm font-medium text-[var(--text-muted)]">
             Narrative
           </summary>
           <Narrative narrative={narrative} className="prose prose-sm mt-2 max-w-none" />
@@ -109,7 +109,7 @@ export function ResourceView(props: ResourceViewProps) {
       <dl className="grid grid-cols-1 gap-x-4 gap-y-3 text-sm sm:grid-cols-[minmax(8rem,1fr)_3fr] sm:gap-y-2">
         {walked.map((w) => (
           <Fragment key={w.key}>
-            <dt className="font-medium text-slate-600 sm:pt-0" title={w.path}>
+            <dt className="font-medium text-[var(--text-muted)] sm:pt-0" title={w.path}>
               {w.label}
             </dt>
             <dd className="-mt-2 sm:mt-0">
@@ -137,7 +137,7 @@ interface ElementValueProps {
 function ElementValue({ walked, sd, renderers, onReferenceClick }: ElementValueProps) {
   const { value, isArray } = walked;
   if (isArray && Array.isArray(value)) {
-    if (value.length === 0) return <span className="text-slate-400">—</span>;
+    if (value.length === 0) return <span className="text-[var(--text-subtle)]">—</span>;
     return (
       <ul className="space-y-1">
         {value.map((item, i) => (
@@ -207,7 +207,7 @@ function RenderByType({
   }
 
   return (
-    <pre className="overflow-x-auto rounded bg-slate-50 p-2 text-xs text-slate-700">
+    <pre className="overflow-x-auto rounded bg-[var(--sunken)] p-2 text-xs text-[var(--text)]">
       {JSON.stringify(value, null, 2)}
     </pre>
   );
@@ -231,16 +231,16 @@ function BackboneView({
   const children = walkObject(sd, parentPath, value);
   if (children.length === 0) {
     return (
-      <pre className="overflow-x-auto rounded bg-slate-50 p-2 text-xs text-slate-700">
+      <pre className="overflow-x-auto rounded bg-[var(--sunken)] p-2 text-xs text-[var(--text)]">
         {JSON.stringify(value, null, 2)}
       </pre>
     );
   }
   return (
-    <dl className="grid grid-cols-1 gap-x-3 gap-y-1 border-l-2 border-slate-200 pl-3 sm:grid-cols-[minmax(6rem,1fr)_3fr]">
+    <dl className="grid grid-cols-1 gap-x-3 gap-y-1 border-l-2 border-[var(--border)] pl-3 sm:grid-cols-[minmax(6rem,1fr)_3fr]">
       {children.map((c) => (
         <Fragment key={c.key}>
-          <dt className="text-xs font-medium text-slate-500" title={c.path}>
+          <dt className="text-xs font-medium text-[var(--text-muted)]" title={c.path}>
             {c.label}
           </dt>
           <dd className="text-sm">

--- a/packages/react-fhir/src/components/SortPicker.tsx
+++ b/packages/react-fhir/src/components/SortPicker.tsx
@@ -111,7 +111,7 @@ export function SortPicker({
         className={`inline-flex items-center gap-1.5 rounded border px-3 py-1.5 text-sm shadow-sm ${
           activeField
             ? "border-blue-300 bg-blue-50 text-blue-700"
-            : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50"
+            : "border-[var(--border)] bg-[var(--surface)] text-[var(--text)] hover:bg-[var(--sunken)]"
         }`}
       >
         <span>
@@ -140,12 +140,12 @@ export function SortPicker({
           id={panelId}
           role="group"
           aria-label="Choose sort field"
-          className="absolute left-0 z-10 mt-1 w-72 rounded border border-slate-200 bg-white p-2 shadow-md"
+          className="absolute left-0 z-10 mt-1 w-72 rounded border border-[var(--border)] bg-[var(--surface)] p-2 shadow-md"
         >
           <div
             role="group"
             aria-label="Sort direction"
-            className="mb-2 inline-flex w-full rounded border border-slate-200 text-sm"
+            className="mb-2 inline-flex w-full rounded border border-[var(--border)] text-sm"
           >
             <button
               type="button"
@@ -155,7 +155,7 @@ export function SortPicker({
               className={`flex-1 rounded-l px-2 py-1 ${
                 activeDir === "asc" && activeField
                   ? "bg-blue-600 text-white"
-                  : "bg-white text-slate-700 hover:bg-slate-50 disabled:text-slate-400"
+                  : "bg-[var(--surface)] text-[var(--text)] hover:bg-[var(--sunken)] disabled:text-[var(--text-subtle)]"
               }`}
             >
               Ascending ↑
@@ -165,10 +165,10 @@ export function SortPicker({
               onClick={() => commit(activeField, "desc")}
               aria-pressed={activeDir === "desc"}
               disabled={!activeField}
-              className={`flex-1 rounded-r border-l border-slate-200 px-2 py-1 ${
+              className={`flex-1 rounded-r border-l border-[var(--border)] px-2 py-1 ${
                 activeDir === "desc" && activeField
                   ? "bg-blue-600 text-white"
-                  : "bg-white text-slate-700 hover:bg-slate-50 disabled:text-slate-400"
+                  : "bg-[var(--surface)] text-[var(--text)] hover:bg-[var(--sunken)] disabled:text-[var(--text-subtle)]"
               }`}
             >
               Descending ↓
@@ -188,13 +188,13 @@ export function SortPicker({
                     className={`flex w-full items-center justify-between rounded px-2 py-1 text-left text-sm ${
                       selected
                         ? "bg-blue-600 text-white"
-                        : "text-slate-700 hover:bg-slate-100"
+                        : "text-[var(--text)] hover:bg-[var(--sunken)]"
                     }`}
                   >
                     <span>{labelFor(name)}</span>
                     <span
                       className={`text-[10px] uppercase ${
-                        selected ? "text-blue-100" : "text-slate-400"
+                        selected ? "text-blue-100" : "text-[var(--text-subtle)]"
                       }`}
                     >
                       {p.type}
@@ -212,7 +212,7 @@ export function SortPicker({
                 commit(undefined, "asc");
                 setOpen(false);
               }}
-              className="mt-2 w-full rounded border border-slate-200 px-2 py-1 text-xs text-slate-500 hover:bg-slate-50"
+              className="mt-2 w-full rounded border border-[var(--border)] px-2 py-1 text-xs text-[var(--text-muted)] hover:bg-[var(--sunken)]"
             >
               Clear sort
             </button>


### PR DESCRIPTION
## Summary

- Replace hardcoded Tailwind slate/white colors in `ResourceTable`, `SortPicker`, `ColumnPicker`, `ResourceView`, and `SearchRequestPreview` with CSS variable references so all components adapt to the `.dark` class toggle
- Fixes the white "HTTP request" panel, table header row, Sort/Columns button backgrounds, row hover states, borders, code chips, and muted text labels

## Files changed

- `packages/react-fhir/src/components/ResourceTable.tsx` — container, header row, dividers, hover states, empty dash, code chip fallback
- `packages/react-fhir/src/components/SortPicker.tsx` — trigger button, dropdown panel, asc/desc toggles, field list, "Clear sort" button
- `packages/react-fhir/src/components/ColumnPicker.tsx` — trigger button, dropdown panel, checkbox row hover
- `packages/react-fhir/src/components/ResourceView.tsx` — header border, ID chip, Narrative panel, field labels, JSON fallback pre, backbone border
- `apps/demo/src/components/SearchRequestPreview.tsx` — entire HTTP request panel (container, URL block, param table, copy button, footer)

## Test plan

- [ ] Toggle dark mode and verify the resource table, sort/column pickers, and HTTP request panel all render with dark backgrounds and appropriate text contrast
- [ ] Confirm light mode appearance is unchanged

https://claude.ai/code/session_01TrSMAUgXTEPbbydxfYha3d

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrSMAUgXTEPbbydxfYha3d)_