### PR TITLE
docs: reorganize and improve documentation across the monorepo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,20 @@
 
 Thanks for your interest in `fhir-place`. This is a small project; the contribution bar is "ship something that's tested and honest about what it does."
 
+## Prerequisites
+
+- **Node.js ≥ 20** (check with `node -v`)
+- **pnpm** — install with `npm i -g pnpm` if you don't have it
+
 ## Local setup
 
 ```bash
 pnpm install
 pnpm dev                                               # demo app (MSW mock by default)
-pnpm test                                              # unit + integration tests
+pnpm test                                              # unit tests only (Vitest + MSW + jsdom)
 pnpm -r typecheck
 pnpm --filter @fhir-place/demo e2e                     # Playwright screenshots
-pnpm --filter @fhir-place/react-fhir test:integration  # live-server HAPI integration
+pnpm --filter @fhir-place/react-fhir test:integration  # live-server HAPI integration (separate — not part of pnpm test)
 ```
 
 The demo defaults to an in-browser MSW mock. To point at a real server:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ docker compose up -d
 VITE_USE_MOCK=false VITE_FHIR_BASE_URL=http://localhost:8080/fhir pnpm dev
 ```
 
+### Goal/Task deployable starter
+
+[`apps/goals-tasks`](apps/goals-tasks/README.md) is a minimal but deployable sample for a Goal + Task workflow. It shows how to use the library primitives together for a real clinical use case:
+
+- Search and list a patient's goals with `useSearch` + `<ResourceSearch>`
+- Render goal and task details with `<ResourceView>`
+- Create and update goals and tasks with `<ResourceEditor>` plus `useCreateResource` / `useUpdateResource`
+- Persist state transitions through your FHIR server (`Task.status`, `Goal.lifecycleStatus`) using the generic mutation hooks
+
+See [`apps/goals-tasks/README.md`](apps/goals-tasks/README.md) for the full breakdown and how to run it.
+
 ## Documentation
 
 | Doc | What it covers |

--- a/README.md
+++ b/README.md
@@ -1,252 +1,60 @@
 # fhir-place
 
-**`@fhir-place/react-fhir`** — a spec-driven React component library for FHIR.
-Published on npm; consumed by the demo app in this repo.
+This repo is two things:
 
-**Backend-agnostic, spec-driven React for any FHIR REST API.** A React component library for building FHIR resource viewers and editors driven by the FHIR specification itself (`StructureDefinition`, `SearchParameter`, `CapabilityStatement`). Minimal resource-specific code — everything derives from the spec's own metadata, so the library works natively against any FHIR REST API.
+- **[`@fhir-place/react-fhir`](packages/react-fhir/README.md)** — a spec-driven React library for FHIR, published on npm. Backend-agnostic; UI derives from `StructureDefinition`, `SearchParameter`, and `CapabilityStatement` so it works against any FHIR REST API.
+- **[fhir-ui](apps/demo/README.md)** — a FHIR browser and editor built on react-fhir. Browse, search, create, edit, and delete FHIR resources across a tab-based shell with NLP search, CQL runner, dark mode, and a configurable server target.
 
-**Live demo:** <https://samsuffolksperoni.github.io/fhir-place/> — hits the **public HAPI R4 server**. Patient data there is shared and reset periodically; creates / edits you make are visible to everyone (and won't last forever). Local `pnpm dev` uses an in-browser MSW mock by default so you can work offline.
+**Live demo:** <https://samsuffolksperoni.github.io/fhir-place/> — hits the public HAPI R4 server. Patient data is shared and reset periodically.
+
+## Packages
+
+| Path | What it is |
+| --- | --- |
+| [`packages/react-fhir`](packages/react-fhir/README.md) | npm library — typed FHIR client, TanStack Query hooks, StructureDefinition walkers, spec-driven React components |
+| [`apps/demo`](apps/demo/README.md) | fhir-ui — the full browser/editor app built on react-fhir |
 
 ## Status
 
 Early alpha. R4 first. MIT licensed. Safe to depend on for prototypes and side projects; expect breaking changes before 1.0.
 
 - **94 unit tests** (Vitest + MSW + jsdom)
-- **Playwright e2e + screenshots** (patient list, detail, mobile, create / edit / delete, search)
+- **Playwright e2e + screenshots** across patient list, detail, mobile, CRUD, search
 - **Nightly live-HAPI integration suite** covers full CRUD, reference resolution, CapabilityStatement + StructureDefinition walks
 
-## Packages
+CI: typecheck + unit tests + build on every PR. Pages deploy on push to `main`. Integration suite runs nightly.
 
-| Path | What it is |
-| --- | --- |
-| `packages/react-fhir` | the component library (client, hooks, generic renderers, spec-driven view/edit/search) |
-| `apps/demo` | a development/demo app for the library — ships with MSW in-browser mock FHIR so it runs offline |
-
-## Install (in your app)
-
-```bash
-pnpm add @fhir-place/react-fhir @tanstack/react-query react react-dom
-```
-
-Published on npm as of 0.1.0. Pre-1.0, expect minor-version bumps to include breaking changes — check the changelog before upgrading. Versioning is managed via [changesets](https://github.com/changesets/changesets); see [CONTRIBUTING](CONTRIBUTING.md) for how to ship a PR with a changeset.
-
-## Quick start
-
-```tsx
-import {
-  FetchFhirClient,
-  FhirClientProvider,
-  ResourceView,
-  ResourceEditor,
-  ResourceSearch,
-  useSearch,
-  useResource,
-  useCreateResource,
-} from "@fhir-place/react-fhir";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-
-const queryClient = new QueryClient();
-const fhir = new FetchFhirClient({
-  baseUrl: "https://hapi.fhir.org/baseR4",
-  // Optional: bearer token, per-request or static
-  // getHeaders: async () => ({ Authorization: `Bearer ${await getToken()}` }),
-});
-
-export function App() {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <FhirClientProvider client={fhir}>
-        <YourPages />
-      </FhirClientProvider>
-    </QueryClientProvider>
-  );
-}
-```
-
-### Read a resource
-
-```tsx
-function PatientDetail({ id }: { id: string }) {
-  const { data: patient } = useResource<Patient>("Patient", id);
-  if (!patient) return null;
-  return <ResourceView resource={patient} />;
-}
-```
-
-### Edit / create
-
-```tsx
-function PatientEditor({ initial }: { initial: Patient }) {
-  const update = useUpdateResource<Patient>();
-  return (
-    <ResourceEditor
-      resource={initial}
-      saving={update.isPending}
-      onSave={(draft) => update.mutateAsync(draft as Patient & { id: string })}
-    />
-  );
-}
-```
-
-### Search
-
-```tsx
-function Patients() {
-  const [params, setParams] = useState<SearchParams>({ _count: 20 });
-  const { data } = useSearch<Patient>("Patient", params);
-  return (
-    <>
-      <ResourceSearch
-        resourceType="Patient"
-        priorityParams={["name", "family", "gender", "birthdate"]}
-        onSubmit={setParams}
-      />
-      <ul>
-        {data?.entry?.map((e) => (
-          <li key={e.resource!.id}>{e.resource!.name?.[0]?.family}</li>
-        ))}
-      </ul>
-    </>
-  );
-}
-```
-
-## What's in the library
-
-### `client/`
-- **`FhirClient` interface** — `read`, `vread`, `history`, `search`, `create`, `update`, `patch` (JSON Patch), `delete`, `readReference` (relative + absolute), generic `request()` escape hatch
-- **`FetchFhirClient`** — the only shipped implementation. Supports `If-Match` / `If-None-Match` / `If-None-Exist`, static + dynamic headers, `AbortSignal`, custom `fetch`
-- **`FhirError`** — carries status, URL, and `OperationOutcome` from the server when available
-
-### `hooks/`
-- **`FhirClientProvider` / `useFhirClient`** — context
-- **`useResource`, `useSearch`, `useCapabilities`, `useStructureDefinition`, `useSearchParameter`, `useValueSet`, `useReadReference`** — TanStack Query wrappers with stable query keys (`fhirQueryKeys`). `useSearchParameter` resolves a `(base, code)` pair to its canonical `SearchParameter` resource so spec-aware code can prefer `expression` over the kebab→camel naming convention.
-- **`useCreateResource`, `useUpdateResource`, `useDeleteResource`** — mutations that invalidate matching read queries on success
-
-### `structure/`
-- **`walkResource` / `walkObject`** — iterate a StructureDefinition snapshot, yield present elements in canonical order, resolve `[x]` choice types
-- **`directChildren`, `findElement`** — querying SDs
-- **`pathGet` / `pathSet` / `pathRemove` / `prune`** — immutable helpers used by the editor
-
-### `components/`
-- **`<ResourceView>`** — spec-driven read-only view. Dispatches by FHIR datatype; falls back to JSON for unknowns. Recurses into BackboneElements. Zero resource-specific code.
-- **`<ResourceEditor>`** — spec-driven form. Inputs for every R4 primitive + HumanName, Address, ContactPoint, Identifier, Reference, Period, Quantity, Coding, CodeableConcept. BackboneElement recursion. Arrays with add/remove; choice-type switching clears the other variant. `onChange` on every keystroke; `onSave` receives a pruned draft.
-- **`<ResourceSearch>`** — form driven by `CapabilityStatement.rest[].resource[].searchParam`. Type-aware placeholders (token, date, reference, number, quantity, uri). Priority params + "show more" toggle.
-- **`<ResourceTable>`** — generic list/table renderer driven by the StructureDefinition; FHIR-datatype-aware cell formatting (HumanName, CodeableConcept, Reference, …) using the same renderer map as `<ResourceView>`. Supports controlled sort, row clicks, custom per-column renderers.
-- **`<ColumnPicker>`** — companion popover to `<ResourceTable>`: toggle column visibility with checkboxes, persist user choice to `localStorage` via `storageKey`. Keyboard-accessible (Esc closes, ArrowUp/Down navigate).
-- **`<Narrative>`** — the *only* place `dangerouslySetInnerHTML` is allowed. DOMPurify with a FHIR-appropriate allowlist: no `<script>`, no `on*`, no `javascript:`, no forms or inputs.
-- **`defaultTypeRenderers` / `defaultTypeInputs`** — the dispatch maps. Every built-in renderer/input is overridable by passing `renderers` / `inputs` props.
-
-## Design principles
-
-- **Spec-driven.** UI derives from StructureDefinition / SearchParameter, not hand-written per resource type.
-- **Server-agnostic.** Plain FHIR REST via a `FhirClient` interface; no vendor SDK lock-in. The demo works against the public HAPI server, a docker-compose HAPI, or (via MSW) no server at all.
-- **Safe by default.** Narrative sanitised with DOMPurify; a lint rule keeps `dangerouslySetInnerHTML` out of every other file.
-- **Escape hatches everywhere.** Pass `renderers` / `inputs` to override any datatype. Use `client.request()` for custom operations. Subclass `FetchFhirClient` for custom auth.
-- **Tree-shakeable, typed.** ESM + `.d.ts`; subpath exports `@fhir-place/react-fhir/client`, `/hooks`, `/structure`, `/components`.
-
-See [`docs/decisions/0004-positioning.md`](docs/decisions/0004-positioning.md) for the wedge and the rationale behind it.
-
-## Comparison with other React-FHIR libraries
-
-Honest, narrow snapshot of where this library sits today. Each row is a real package on npm.
-
-| Library | Backend | UI lock-in | Spec-driven | LLM/MCP story |
-| --- | --- | --- | --- | --- |
-| **`@fhir-place/react-fhir`** | Any FHIR REST | None — Tailwind + unstyled | Yes (StructureDefinition + SearchParameter + CapabilityStatement) | Roadmap (Zod-from-SD, optional MCP package) |
-| `@medplum/react` | Best with Medplum server (some components require Medplum-specific extensions) | Mantine v7 required | Partial | Server-side only |
-| `@bonfhir/react` (+ `@bonfhir/mantine`) | Any | Mantine renderers ship in `@bonfhir/mantine` | Yes (codegen for R4B / R5) | None |
-| `@beda.software/fhir-react` | Any (Aidbox-leaning) | None — hooks only | Hook-level | None |
-| `1uphealth/fhir-react` (unscoped `fhir-react` on npm) | Display-only, no client | Bootstrap | No | None |
-
-Where we lose today: fewer batteries-included components than `@medplum/react`, no Mantine renderer parity with `@bonfhir/mantine`, no SMART App Launch adapter shipped (use `fhirclient` + `FhirClient.getHeaders` for now), and no profile-aware codegen yet. Tracked items below.
-
-## Dev
+## Running locally
 
 ```bash
 pnpm install
-pnpm dev                                          # demo app + in-browser MSW mock FHIR (Vite on :5173)
-pnpm test                                         # unit tests (jsdom + MSW)
-pnpm -r typecheck                                 # all packages
-pnpm --filter @fhir-place/demo e2e                # Playwright incl. screenshots (screenshots/)
-pnpm --filter @fhir-place/react-fhir test:integration    # live-server integration, defaults to https://hapi.fhir.org/baseR4
+pnpm dev          # fhir-ui with in-browser MSW mock FHIR (Vite on :5173)
+pnpm test         # unit tests (Vitest)
+pnpm -r typecheck
+pnpm --filter @fhir-place/demo e2e                       # Playwright e2e + screenshots
+pnpm --filter @fhir-place/react-fhir test:integration    # live-HAPI integration suite
 ```
 
-The demo defaults to MSW in dev. To point it at a real server:
+The app defaults to an in-browser MSW mock so it runs offline. To point at a real server:
 
 ```bash
 # public HAPI
 VITE_USE_MOCK=false VITE_FHIR_BASE_URL=https://hapi.fhir.org/baseR4 pnpm dev
 
-# local docker HAPI (starts a R4 server on :8080 with persistent data)
+# local Docker HAPI (persistent, R4, port 8080)
 docker compose up -d
 VITE_USE_MOCK=false VITE_FHIR_BASE_URL=http://localhost:8080/fhir pnpm dev
 ```
 
-### CI layout
+## Documentation
 
-- **`.github/workflows/ci.yml`** — typecheck + unit tests + library/demo build on every PR
-- **`.github/workflows/pages.yml`** — builds the demo (mock mode) and deploys to GitHub Pages on push to `main`
-- **`.github/workflows/integration.yml`** — runs the live-HAPI suite nightly at 05:00 UTC, on push to `main`, and via manual dispatch. PRs skip it so HAPI flakiness can't block unrelated work.
-
-## Building your own FHIR app on this library
-
-The components are a toolbox, not a framework. Typical pattern for a new app:
-
-1. **Wire a `FhirClient`** — point at your server, plug in auth via `headers` or `getHeaders`.
-2. **Hook a Resource list page** — call `useSearch<YourType>(...)` directly and render the results however you want. `<ResourceSearch>` gives you a driven filter form.
-3. **Hook a detail page** — `<ResourceView resource={...} />`.
-4. **Hook create/edit** — `<ResourceEditor resource={...} onSave={...} />`.
-5. **Override per-type UX** where needed — pass `renderers` or `inputs` to swap in app-specific widgets (e.g. a signature pad for `Signature`, a chart for repeated `Observation.valueQuantity`).
-6. **Resource-specific workflow** — put business logic (e.g. Task state transitions, Goal progress calculations) in your own hooks alongside the library's generic hooks.
-
-
-### Goal/Task deployable starter
-
-If you are shipping a `Goal` + `Task` workflow, this library is already deployable for a read/write baseline:
-
-- Search and list synthetic patients with `useSearch` + `<ResourceSearch>`.
-- Render goal details with `<ResourceView>` (including narrative + coded fields).
-- Create/update goals and tasks with `<ResourceEditor>` plus `useCreateResource` / `useUpdateResource`.
-- Persist state transitions through your FHIR server (`Task.status`, `Task.intent`, `Goal.lifecycleStatus`) using the generic mutation hooks.
-- Keep your app-specific business rules in local hooks/components while the library handles spec-driven rendering and form plumbing.
-
-For production deployment, pair this with your own auth/session layer, environment-specific FHIR base URL configuration, and server-side policy checks.
-
-## Roadmap
-
-Honest list of what's missing if you're building a real app today.
-
-### Tracked (has an issue)
-
-Comment / upvote if one of these is blocking you — or pick one up; each issue has a concrete API sketch and acceptance criteria.
-
-| # | Item | Why it matters |
-| --- | --- | --- |
-| [#4](https://github.com/samsuffolksperoni/fhir-place/issues/4) | ValueSet resolution + binding-aware code input | Every real `code` field (`Task.status`, `Goal.lifecycleStatus`, `Observation.status`) today falls back to a plain text input. |
-| [#5](https://github.com/samsuffolksperoni/fhir-place/issues/5) | `<ReferencePicker>` search-and-pick widget | Linking a Task to a Goal today means typing `Goal/abc123` into a raw text field. |
-| [#6](https://github.com/samsuffolksperoni/fhir-place/issues/6) | Generic `<ResourceTable>` with column picker | We ship `<ResourceView>` (detail) and `<ResourceSearch>` (filter form) but no list/table component. |
-| [#7](https://github.com/samsuffolksperoni/fhir-place/issues/7) | Pagination via `Bundle.link[rel=next]` in `useSearch` | `useSearch` returns one Bundle; browsing more than `_count` matches needs `useInfiniteSearch`. |
-| [#11](https://github.com/samsuffolksperoni/fhir-place/issues/11) | Auto-populate `<ResourceSearch>` token fields from their ValueSet binding | Search by `gender` should be a dropdown of `male / female / other / unknown`, not a free-text field. Builds on #4. |
-| [#121](https://github.com/samsuffolksperoni/fhir-place/issues/121) | Typed search builder v0 — core API | `client.search('Patient', params)` is loosely typed today; chained search, `_include`, `_revinclude`, and `_has` lose type info. ADR [0004](docs/decisions/0004-positioning.md) commits to the "tRPC-of-FHIR" wedge. |
-| [#122](https://github.com/samsuffolksperoni/fhir-place/issues/122) | Typed search builder — hook + demo example | Wires the builder into `useTypedSearch` and a demo page so the DX win is visible in real React usage. Builds on #121. |
-| [#123](https://github.com/samsuffolksperoni/fhir-place/issues/123) | Profile-aware codegen spike (US Core 7 seed) | `@types/fhir` is broad; `value[x]` collapses to `any` and profile constraints aren't reflected. Spike learns the codegen pipeline shape before committing to a stable API. |
-| [#124](https://github.com/samsuffolksperoni/fhir-place/issues/124) | Experimental Zod schema generation from `StructureDefinition` | LLM tool-use surfaces (Anthropic, OpenAI, Gemini, MCP) want JSON Schema or Zod. Feeds client-side validation and structured-output surfaces. |
-| [#125](https://github.com/samsuffolksperoni/fhir-place/issues/125) | Interop demo matrix (HAPI + Medplum + Aidbox) | "Backend-agnostic" is asserted but only proven against public HAPI today. ADR [0004](docs/decisions/0004-positioning.md) commits to demonstrable proof across backends. |
-| [#127](https://github.com/samsuffolksperoni/fhir-place/issues/127) | Inferno (g)(10) CI badge | Inferno-passing demos against real EHR sandboxes are the highest-trust signal in healthcare OSS. Fits the existing nightly `integration.yml` pattern. |
-| [#128](https://github.com/samsuffolksperoni/fhir-place/issues/128) | Optional `@fhir-place/mcp` package | Wraps an arbitrary FHIR base URL + token as MCP tools. Existing MCP offerings (Aidbox, WSO2, Momentum) are server-bound; this is the client-side, BYO-server angle. |
-
-### Deferred (open an issue if you need it)
-
-These will become issues once a concrete use case surfaces — premature issues rot.
-
-- **Extensions.** `<ResourceEditor>` skips `extension` / `modifierExtension` by default. Many real profiles lean on them.
-- **Profile support.** `useStructureDefinition` fetches base types; taking a profile canonical URL is a small change we haven't made.
-- **SMART on FHIR v2 auth.** Deferred. Bearer-token auth works via `FhirClient.getHeaders`; launch flows need a dedicated adapter (peer-dep on [`fhirclient`](https://github.com/smart-on-fhir/client-js) rather than reimplementing the OAuth dance).
-- **R4B / R5.** R4 only for v1. The `FhirClient` interface will grow a `fhirVersion` discriminator for version-specific code.
-- **Subscriptions / realtime.** Out of scope; poll with TanStack Query's `refetchInterval` for now.
-
-PRs welcome on any tracked item. For a deferred item: open an issue describing your use case and we can prioritise.
+| Doc | What it covers |
+| --- | --- |
+| [`packages/react-fhir/README.md`](packages/react-fhir/README.md) | Install, quick start, full API reference, design principles, comparison with other libraries, roadmap |
+| [`apps/demo/README.md`](apps/demo/README.md) | fhir-ui features, app structure, how it uses react-fhir, how to run |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | PR workflow, testing, changesets, bump conventions |
+| [`docs/decisions/`](docs/decisions/) | Architecture Decision Records |
+| [Open issues](https://github.com/samsuffolksperoni/fhir-place/issues) | Tracked gaps and roadmap items |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repo is two things:
 | --- | --- |
 | [`packages/react-fhir`](packages/react-fhir/README.md) | npm library — typed FHIR client, TanStack Query hooks, StructureDefinition walkers, spec-driven React components |
 | [`apps/demo`](apps/demo/README.md) | fhir-ui — the full browser/editor app built on react-fhir |
+| [`apps/goals-tasks`](apps/goals-tasks/README.md) | minimal sample app showing a Goal + Task workflow built on react-fhir |
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ CI: typecheck + unit tests + build on every PR. Pages deploy on push to `main`. 
 
 ## Running locally
 
+Requires **Node.js ≥ 20** and **pnpm** (`npm i -g pnpm`).
+
 ```bash
 pnpm install
 pnpm dev          # fhir-ui with in-browser MSW mock FHIR (Vite on :5173)

--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -59,8 +59,54 @@ The app adds its own app-layer concerns on top:
 - **Routing** (`react-router-dom`) — `/:resourceType`, `/:resourceType/:id`, `/:resourceType/:id/edit`, `/new`, `/ask`, `/settings`, `/cql-runner`
 - **Tab context** (`TabsContext`) — open-tab list kept in React state, synced to the browser URL
 - **Theme context** (`ThemeContext`) — CSS variable swap for dark/light mode
-- **Resource list config** (`resourceListConfig.ts`) — per-type `formatPrimary` / `formatMeta` / `priorityParams` / `tableColumns` for the most common resource types (Patient, Observation, Condition, …). Unknown types fall back to StructureDefinition-derived columns automatically.
+- **Resource list config** (`resourceListConfig.ts`) — see below
 - **NLP query translation** (`ask/anthropicQuery.ts`) — calls the Anthropic API to turn a natural-language question into `{ resourceType, params }`.
+
+## Resource list config (`resourceListConfig.ts`)
+
+This file is the main place to touch when adding or customising how a resource type looks in the list/table view. It defines a `ResourceListConfig` per type and collects them all into `RESOURCE_LIST_CONFIG`.
+
+### The `ResourceListConfig` interface
+
+```ts
+interface ResourceListConfig<T extends Resource = Resource> {
+  title: string;              // page heading, e.g. "Patients"
+  singular: string;           // used in "+ New {singular}" and empty-state copy
+  priorityParams: string[];   // search params shown first in the filter form
+  tableColumns: ResourceListColumn[];       // all columns the column-picker can offer
+  defaultVisibleColumns: string[];          // subset shown before the user customises
+  formatPrimary?: (resource: T) => string;  // main text in list-view rows (enables List layout)
+  formatMeta?: (resource: T) => Array<string | undefined | null>; // secondary metadata in list rows
+}
+```
+
+`formatPrimary` is optional. When omitted the resource type only renders in Table or JSON layout — the List toggle is disabled. Most resource types provide it; types like `Location` and `Medication` that don't have a natural "name" field still get one via `codeText()`.
+
+`tableColumns` uses dot-notation paths (`"address.city"`, `"period.start"`). The special path `"__counts"` on Patient renders the `<PatientRowCounts>` component (compartment counts) rather than a raw field value.
+
+### Configured resource types
+
+All 20 types in `TOP_RESOURCE_TYPES` have explicit configs: Patient, AllergyIntolerance, Appointment, CarePlan, CareTeam, Condition, DiagnosticReport, DocumentReference, Encounter, Goal, Immunization, Location, Medication, MedicationRequest, Observation, Organization, Practitioner, Procedure, ServiceRequest, Task.
+
+### Fallback for unconfigured types
+
+Any resource type not in `RESOURCE_LIST_CONFIG` (e.g. a custom or less-common type) still works. `ResourceListPage` detects the missing config and falls back to:
+1. Fetching the resource's `StructureDefinition` via `useStructureDefinition`.
+2. Deriving columns from the `isSummary` elements in the SD snapshot (up to 8).
+3. If the SD has no summary elements, defaulting to `["status", "code.text", "subject.reference", "id"]`.
+
+This means the app handles any FHIR R4 resource type out of the box, with the configured types getting polished list-view presentation.
+
+### Adding a new resource type
+
+1. Add the type string to `TOP_RESOURCE_TYPES` in `resourceListConfig.ts`.
+2. Define a `ResourceListConfig<YourType>` constant with the fields above.
+3. Add it to the `RESOURCE_LIST_CONFIG` record.
+4. Optionally add compartment entries in `compartment.ts` if the type should appear as a patient compartment chip.
+
+### `patientFields.ts`
+
+A separate utility that builds `PatientFieldOption[]` from a live `StructureDefinition`. Used by the Patient column picker to offer every top-level Patient field (including choice-type variants like `deceasedBoolean` / `deceasedDateTime`) with human-readable labels derived from the SD's `short` descriptions. Not part of `resourceListConfig.ts` because it depends on a runtime SD fetch rather than being statically declared.
 
 ## App structure
 

--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -163,19 +163,23 @@ pnpm dev           # starts Vite on :5173, MSW mock FHIR active by default
 
 ### Pointing at a real FHIR server
 
+The repo ships `.env` presets for the three tested backends — copy one to get started immediately:
+
 ```bash
-# public HAPI R4
-VITE_USE_MOCK=false VITE_FHIR_BASE_URL=https://hapi.fhir.org/baseR4 pnpm dev
+# Medplum public sandbox (requires a bearer token — see interop-matrix.md)
+cp apps/demo/.env.example.medplum apps/demo/.env.local
 
-# local Docker HAPI (persistent, R4, port 8080)
-docker compose up -d
-VITE_USE_MOCK=false VITE_FHIR_BASE_URL=http://localhost:8080/fhir pnpm dev
+# Aidbox dev license via docker-compose (see interop-matrix.md)
+cp apps/demo/.env.example.aidbox apps/demo/.env.local
 
-# Medplum sandbox (example)
-VITE_USE_MOCK=false VITE_FHIR_BASE_URL=https://api.medplum.com/fhir/R4 pnpm dev
+# Public HAPI (no auth needed)
+echo 'VITE_USE_MOCK=false' > apps/demo/.env.local
+echo 'VITE_FHIR_BASE_URL=https://hapi.fhir.org/baseR4' >> apps/demo/.env.local
 ```
 
-Or use the **Server picker** in the app's top bar to switch servers at runtime without restarting.
+Then `pnpm dev` and the app will pick up the env file automatically. Or use the **Server picker** in the top bar to switch at runtime without restarting.
+
+Full per-backend setup walkthrough (docker-compose steps, auth config, known caveats): [`apps/demo/docs/interop-matrix.md`](docs/interop-matrix.md).
 
 ### NLP search (Ask AI)
 

--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -28,10 +28,6 @@ fhir-ui is a full FHIR browser and editor built on [`@fhir-place/react-fhir`](..
 - Requires an Anthropic API key, set in Settings. The key stays local (localStorage only).
 - Standalone Ask page available via the sidebar.
 
-### Goal / Task workflows (early)
-
-Goal and Task resource types work through the generic fhir-ui pages — search, list, detail, create, and edit all work without any Goal/Task-specific code, because the app derives its UI from the `StructureDefinition`. There are no dedicated workflow pages (e.g. a goal-progress tracker or task state machine view) yet; those would live in `routes/fhir-ui/pages/` when the time comes.
-
 ### CQL runner
 
 - Paste or write Clinical Quality Language (CQL) and evaluate it against resources fetched from the active FHIR server.

--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -1,0 +1,143 @@
+# fhir-ui (`apps/demo`)
+
+fhir-ui is a full FHIR browser and editor built on [`@fhir-place/react-fhir`](../../packages/react-fhir/README.md). It ships as the live demo at <https://samsuffolksperoni.github.io/fhir-place/> and serves as the reference implementation of what you can build with react-fhir.
+
+## What it does
+
+### Browse and search any resource type
+
+- Sidebar lists resource types (Patient, Observation, Condition, …); click to open a list page.
+- Search form is driven by the server's `CapabilityStatement` — all search parameters for the resource type appear automatically.
+- Results show in **List** (formatted primary + metadata rows), **Table** (column-picked, sortable), or **JSON** layouts. Toggle with the layout switcher.
+- Infinite scroll / "Load more" via `useInfiniteSearch`.
+
+### Create, view, and edit resources
+
+- Detail page renders the resource with `<ResourceView>` — spec-driven, FHIR-datatype-aware, recurses into BackboneElements.
+- Edit page uses `<ResourceEditor>` — a form generated from the resource's `StructureDefinition`. Supports every R4 primitive and composite type (HumanName, Address, Reference, CodeableConcept, etc.).
+- Create page opens a blank `<ResourceEditor>` for any resource type.
+
+### Patient compartment navigation
+
+- Patient detail page surfaces compartment chips (Observations, Conditions, Encounters, …) with counts.
+- Clicking a chip opens the compartment-scoped list page (`patient=<id>` filter applied automatically).
+
+### NLP / Ask AI search
+
+- "Ask AI" input in the search form accepts natural language ("patients born in 1980 named Smith") and translates it to FHIR search parameters via the Anthropic API.
+- Requires an Anthropic API key, set in Settings. The key stays local (localStorage only).
+- Standalone Ask page available via the sidebar.
+
+### CQL runner
+
+- Paste or write Clinical Quality Language (CQL) and evaluate it against resources fetched from the active FHIR server.
+- Uses `cql-execution` + `cql-exec-fhir` for local evaluation.
+
+### Developer-friendly shell features
+
+- **Tab bar** — open multiple resource types / records simultaneously; tabs are URL-synced so they survive refresh.
+- **Jump dialog** — `⌘K` / `Ctrl+K` to jump to any resource type or run NLP search directly.
+- **Server picker** — switch between the MSW mock, public HAPI, and any custom base URL at runtime.
+- **Dark mode** — full light/dark theme toggle.
+- **HTTP request preview** — search card shows the exact FHIR URL before you submit.
+- **Column picker** — choose which fields appear in table view; persisted per resource type to `localStorage`.
+- **Sort picker** — choose `_sort` from the server's advertised search params.
+- **Responsive** — cards layout on mobile; sidebar collapses.
+
+## How it's built on react-fhir
+
+fhir-ui is the consumer app in this monorepo. It imports `@fhir-place/react-fhir` as a workspace dependency and uses every layer:
+
+| react-fhir layer | Used for |
+| --- | --- |
+| `client/` — `FetchFhirClient` | Wired in `main.tsx`; the active server URL comes from `ServerPicker` / env var |
+| `hooks/` — `useInfiniteSearch`, `useResource`, `useStructureDefinition`, `useCreateResource`, `useUpdateResource`, `useDeleteResource` | All resource data fetching and mutations; TanStack Query handles caching |
+| `structure/` | Column derivation in `ResourceListPage` (summary elements from SD snapshot); path helpers in the editor |
+| `components/` — `ResourceSearch`, `ResourceTable`, `ColumnPicker`, `SortPicker`, `ResourceView`, `ResourceEditor` | Every list, detail, create, and edit page |
+
+The app adds its own app-layer concerns on top:
+- **Routing** (`react-router-dom`) — `/:resourceType`, `/:resourceType/:id`, `/:resourceType/:id/edit`, `/new`, `/ask`, `/settings`, `/cql-runner`
+- **Tab context** (`TabsContext`) — open-tab list kept in React state, synced to the browser URL
+- **Theme context** (`ThemeContext`) — CSS variable swap for dark/light mode
+- **Resource list config** (`resourceListConfig.ts`) — per-type `formatPrimary` / `formatMeta` / `priorityParams` / `tableColumns` for the most common resource types (Patient, Observation, Condition, …). Unknown types fall back to StructureDefinition-derived columns automatically.
+- **NLP query translation** (`ask/anthropicQuery.ts`) — calls the Anthropic API to turn a natural-language question into `{ resourceType, params }`.
+
+## App structure
+
+```
+apps/demo/src/
+├── App.tsx                    # shell layout: sidebar, topbar, tab bar, routes
+├── main.tsx                   # React root, QueryClientProvider, FhirClientProvider
+├── config.ts                  # env var reading, API key storage
+├── resourceListConfig.ts      # per-type display config (columns, formatters, priority params)
+├── patientFields.ts           # Patient-specific list formatters
+├── compartment.ts             # Patient compartment resource types + counts
+├── serverProbe.ts             # active server capability detection
+│
+├── components/                # app-shell UI components
+│   ├── CCSidebar.tsx          # resource type sidebar
+│   ├── CCTopbar.tsx           # server picker, dark mode, settings
+│   ├── CCTabs.tsx             # tab bar
+│   ├── FhirUiLayout.tsx       # (thin layout wrapper, mostly legacy)
+│   ├── JumpDialog.tsx         # ⌘K jump/search dialog
+│   ├── PatientCompartmentLinks.tsx
+│   ├── PatientRowCounts.tsx   # inline compartment counts on patient list
+│   ├── SearchRequestPreview.tsx
+│   └── ServerPicker.tsx
+│
+├── context/
+│   ├── TabsContext.tsx         # open tab list + URL sync
+│   └── ThemeContext.tsx        # light/dark theme
+│
+├── routes/
+│   ├── fhir-ui/pages/
+│   │   ├── ResourceListPage.tsx    # list + search + table/list/json layouts
+│   │   ├── ResourceDetailPage.tsx  # ResourceView + compartment links
+│   │   ├── ResourceCreatePage.tsx  # blank ResourceEditor
+│   │   ├── ResourceEditPage.tsx    # populated ResourceEditor
+│   │   ├── AskPage.tsx             # standalone NLP search
+│   │   └── SettingsPage.tsx        # API key, server URL
+│   └── cql-runner/
+│       ├── CqlRunnerPage.tsx
+│       └── CqlRunner.tsx
+│
+├── ask/
+│   └── anthropicQuery.ts      # NLP → FHIR params via Anthropic API
+│
+└── mocks/                     # MSW handlers (in-browser mock FHIR server)
+```
+
+## Running locally
+
+```bash
+# from repo root
+pnpm install
+pnpm dev           # starts Vite on :5173, MSW mock FHIR active by default
+```
+
+### Pointing at a real FHIR server
+
+```bash
+# public HAPI R4
+VITE_USE_MOCK=false VITE_FHIR_BASE_URL=https://hapi.fhir.org/baseR4 pnpm dev
+
+# local Docker HAPI (persistent, R4, port 8080)
+docker compose up -d
+VITE_USE_MOCK=false VITE_FHIR_BASE_URL=http://localhost:8080/fhir pnpm dev
+
+# Medplum sandbox (example)
+VITE_USE_MOCK=false VITE_FHIR_BASE_URL=https://api.medplum.com/fhir/R4 pnpm dev
+```
+
+Or use the **Server picker** in the app's top bar to switch servers at runtime without restarting.
+
+### NLP search (Ask AI)
+
+Open Settings in the app and paste an Anthropic API key. The key is stored in `localStorage` only — it never leaves the browser.
+
+### Tests and e2e
+
+```bash
+pnpm --filter @fhir-place/demo test:run     # unit tests (Vitest)
+pnpm --filter @fhir-place/demo e2e          # Playwright (screenshots land in screenshots/)
+```

--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -28,6 +28,10 @@ fhir-ui is a full FHIR browser and editor built on [`@fhir-place/react-fhir`](..
 - Requires an Anthropic API key, set in Settings. The key stays local (localStorage only).
 - Standalone Ask page available via the sidebar.
 
+### Goal / Task workflows (early)
+
+Goal and Task resource types work through the generic fhir-ui pages — search, list, detail, create, and edit all work without any Goal/Task-specific code, because the app derives its UI from the `StructureDefinition`. There are no dedicated workflow pages (e.g. a goal-progress tracker or task state machine view) yet; those would live in `routes/fhir-ui/pages/` when the time comes.
+
 ### CQL runner
 
 - Paste or write Clinical Quality Language (CQL) and evaluate it against resources fetched from the active FHIR server.

--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -25,7 +25,7 @@ fhir-ui is a full FHIR browser and editor built on [`@fhir-place/react-fhir`](..
 ### NLP / Ask AI search
 
 - "Ask AI" input in the search form accepts natural language ("patients born in 1980 named Smith") and translates it to FHIR search parameters via the Anthropic API.
-- Requires an Anthropic API key, set in Settings. The key stays local (localStorage only).
+- Requires an Anthropic API key, set in Settings. The key is stored in `localStorage` only — it is sent to Anthropic when a query runs but is never stored server-side by this app.
 - Standalone Ask page available via the sidebar.
 
 ### CQL runner
@@ -124,7 +124,7 @@ apps/demo/src/
 │   ├── CCSidebar.tsx          # resource type sidebar
 │   ├── CCTopbar.tsx           # server picker, dark mode, settings
 │   ├── CCTabs.tsx             # tab bar
-│   ├── FhirUiLayout.tsx       # (thin layout wrapper, mostly legacy)
+│   ├── FhirUiLayout.tsx       # thin layout wrapper (renders Outlet)
 │   ├── JumpDialog.tsx         # ⌘K jump/search dialog
 │   ├── PatientCompartmentLinks.tsx
 │   ├── PatientRowCounts.tsx   # inline compartment counts on patient list
@@ -183,7 +183,7 @@ Full per-backend setup walkthrough (docker-compose steps, auth config, known cav
 
 ### NLP search (Ask AI)
 
-Open Settings in the app and paste an Anthropic API key. The key is stored in `localStorage` only — it never leaves the browser.
+Open Settings in the app and paste an Anthropic API key. The key is stored in `localStorage` only — it is sent to Anthropic on each query but is never stored server-side by this app.
 
 ### Tests and e2e
 

--- a/apps/goals-tasks/README.md
+++ b/apps/goals-tasks/README.md
@@ -1,0 +1,68 @@
+# goals-tasks (`apps/goals-tasks`)
+
+A minimal sample app that demonstrates a Goal + Task workflow built on [`@fhir-place/react-fhir`](../../packages/react-fhir/README.md). It's intentionally narrow — no shell, no sidebar, no generic resource browser — just the pages you'd need to manage a patient's goals and their linked tasks.
+
+Early / in progress. The generic fhir-ui (`apps/demo`) handles Goal and Task fine via its generic pages; this app shows what a purpose-built, domain-specific UI looks like when you use react-fhir as the foundation.
+
+## What it does
+
+- **Patient overview** — patient header + list of their goals with lifecycle status badges, plus a "+ New goal" button.
+- **Goal detail** — renders the goal with `<ResourceView>`, lists linked tasks (`Task?focus=Goal/<id>`), and lets you create a new task pre-linked to this goal.
+- **Goal create / edit** — `<ResourceEditor>` seeded with a minimal `Goal` skeleton (subject pre-filled from the demo patient).
+- **Task detail** — renders the task with `<ResourceView>`, edit and delete actions.
+- **Task create / edit** — `<ResourceEditor>` seeded with a minimal `Task` skeleton, pre-linking `focus` to the goal if launched from the goal detail page.
+
+All CRUD flows through `useCreateResource`, `useUpdateResource`, and `useDeleteResource`. Mutations auto-invalidate the relevant queries via TanStack Query.
+
+## How it uses react-fhir
+
+| react-fhir export | Used for |
+| --- | --- |
+| `useResource` | Loading a single Goal, Task, or Patient |
+| `useSearch` | Goal list for a patient; Task list for a goal |
+| `useCreateResource`, `useUpdateResource`, `useDeleteResource` | All mutations |
+| `<ResourceView>` | Goal and Task detail rendering (spec-driven, no custom field code) |
+| `<ResourceEditor>` | Goal and Task create/edit forms (spec-driven, seeded with a skeleton) |
+| `FetchFhirClient` / `FhirClientProvider` | Wired in `main.tsx`; switches between MSW mock and a real server via env var |
+
+The app adds only what's domain-specific on top: route structure, status badge helpers (`helpers.ts`), and a hardcoded demo patient ID (stand-in for a SMART launch context).
+
+## App structure
+
+```
+apps/goals-tasks/src/
+├── App.tsx           # routes: /, /Goal/:id, /Goal/:id/edit, /Goal/new, /Task/:id, …
+├── main.tsx          # React root, QueryClientProvider, FhirClientProvider
+├── config.ts         # env var reading, demo patient ID, hash-router flag
+├── helpers.ts        # patientLabel(), statusPillClass()
+│
+├── pages/
+│   ├── PatientOverviewPage.tsx   # patient header + goal list
+│   ├── GoalDetailPage.tsx        # ResourceView + linked task list
+│   ├── GoalEditorPage.tsx        # ResourceEditor (create + edit)
+│   ├── TaskDetailPage.tsx        # ResourceView + edit/delete
+│   └── TaskEditorPage.tsx        # ResourceEditor (create + edit)
+│
+└── mocks/            # MSW handlers for offline dev
+```
+
+## Running locally
+
+```bash
+# from repo root
+pnpm install
+pnpm --filter @fhir-place/goals-tasks dev   # Vite dev server, MSW mock active by default
+```
+
+To point at a real FHIR server:
+
+```bash
+VITE_USE_MOCK=false VITE_FHIR_BASE_URL=https://hapi.fhir.org/baseR4 \
+  pnpm --filter @fhir-place/goals-tasks dev
+```
+
+The demo patient is hardcoded as `demo-patient`. A real deployment would replace this with a patient ID from SMART launch context or a patient-picker flow.
+
+```bash
+pnpm --filter @fhir-place/goals-tasks e2e   # Playwright screenshots
+```

--- a/docs/prompts/daily-doc-sync.md
+++ b/docs/prompts/daily-doc-sync.md
@@ -1,0 +1,148 @@
+# Daily doc sync prompt
+
+This prompt is designed to run on a daily cron schedule. It checks whether
+the documentation in this repo has drifted from the code and makes targeted
+corrections. Only change things that are verifiably stale — do not rewrite
+sections for style.
+
+---
+
+## Your task
+
+You are running a daily documentation freshness check on the `samsuffolksperoni/fhir-place`
+repository. Work on the `main` branch. If you make any changes, commit them
+with the message `docs(auto-sync): <brief description of what changed>` and
+push. If nothing has drifted, make no commit and exit cleanly.
+
+Keep edits surgical — one stale fact at a time. Do not rewrite sections that
+are still accurate.
+
+---
+
+## Checks to run (in order)
+
+### 1. Unit test count in root README
+
+Run the unit test suite and count the passing tests:
+
+```bash
+pnpm --filter @fhir-place/react-fhir test:run 2>&1 | tail -5
+```
+
+The root `README.md` currently states a specific number of unit tests (e.g.
+"94 unit tests"). If the actual count differs, update that line. Match the
+exact phrasing — only the number changes.
+
+---
+
+### 2. CI readme gate
+
+The repo has a script that gates CI:
+
+```bash
+node scripts/check-readme-goal-task.mjs
+```
+
+Run it. If it exits non-zero, the root `README.md` is missing required
+content. Identify exactly which snippets are missing (the script prints them)
+and restore only those snippets. Do not restructure the section — find the
+nearest logical place and insert the missing text.
+
+---
+
+### 3. Exported library components vs. documented components
+
+Read `packages/react-fhir/src/components/index.ts`. List every symbol
+exported from it.
+
+Read the `### components/` section of `packages/react-fhir/README.md`.
+
+For each exported component or type that has no mention in that section, add
+a one-line bullet. Use the same format as existing bullets:
+`**\`<ComponentName>\`**` — short description of what it does.
+
+Do not remove bullets for things that are already there — only add missing
+ones.
+
+Apply the same check to:
+- `packages/react-fhir/src/hooks/index.ts` → `### hooks/` section
+- `packages/react-fhir/src/client/index.ts` → `### client/` section
+- `packages/react-fhir/src/structure/index.ts` → `### structure/` section
+
+---
+
+### 4. Roadmap table — closed issues
+
+Read the roadmap table in `packages/react-fhir/README.md` (the table under
+`## Roadmap / known gaps`). For each issue number listed, use the GitHub MCP
+tools to check whether the issue is still open.
+
+For any issue that is **closed**, remove its row from the table and add a
+brief note at the bottom of the section: `<!-- #NNN closed YYYY-MM-DD -->`.
+Do not delete the note about checking the full issue list — leave that
+paragraph intact.
+
+---
+
+### 5. Top resource types list
+
+Read `apps/demo/src/resourceListConfig.ts`. Find the `TOP_RESOURCE_TYPES`
+array and note every type in it.
+
+Read the "Configured resource types" paragraph in `apps/demo/README.md`.
+
+If the list in the README does not match the array exactly (types added,
+renamed, or removed), update the paragraph to match. Keep the same sentence
+structure — just update the type names.
+
+---
+
+### 6. Packages table in root README
+
+List the contents of `apps/` and `packages/` directories. For each directory
+that contains a `package.json`, check whether it appears in the packages table
+in `README.md`.
+
+If any package or app is present in the filesystem but missing from the table,
+add a row. Use the same format as existing rows. If a row references a path
+that no longer exists, remove it.
+
+---
+
+### 7. Node version requirement
+
+Read the `engines.node` field from the root `package.json`.
+
+Check `README.md` and `CONTRIBUTING.md` for the documented Node version
+requirement (e.g. "Node.js ≥ 20"). If the `engines` field has changed and the
+docs still reference the old version, update both files.
+
+---
+
+### 8. New apps missing a README
+
+For each directory under `apps/`, check whether a `README.md` exists. If any
+app directory lacks one, create a minimal stub:
+
+```markdown
+# <app-name>
+
+> README not yet written. See [apps/<app-name>/src/](src/) to explore the code.
+```
+
+Do not fabricate content about the app — only create the stub.
+
+---
+
+## Rules
+
+- **Only change what you can verify from the code.** Don't guess intent or
+  fill in descriptions you're not sure about.
+- **One commit per meaningful change group.** If you fix three separate things
+  (test count + one new export + one closed issue), that's one commit listing
+  all three.
+- **Never reformat or rewrite sections that are still accurate.** The goal is
+  freshness, not perfection.
+- **If a check is ambiguous**, leave it alone and note it in the commit message
+  with a `NOTE:` line so a human can review.
+- **Do not open a pull request.** Commit directly to `main`.

--- a/docs/prompts/daily-doc-sync.md
+++ b/docs/prompts/daily-doc-sync.md
@@ -10,9 +10,14 @@ sections for style.
 ## Your task
 
 You are running a daily documentation freshness check on the `samsuffolksperoni/fhir-place`
-repository. Work on the `main` branch. If you make any changes, commit them
-with the message `docs(auto-sync): <brief description of what changed>` and
-push. If nothing has drifted, make no commit and exit cleanly.
+repository. Work on a short-lived branch named `docs/auto-sync-<YYYY-MM-DD>`. If you make
+any changes, commit them with the message
+`docs(auto-sync): <brief description of what changed>` and push the branch.
+Then open a pull request targeting `main` so CI runs and there is an audit
+trail. If nothing has drifted, make no commit, no branch, and exit cleanly.
+
+Doc-sync changes are markdown-only, so CI is fast. The PR can be merged
+without review if all checks pass — configure branch protection accordingly.
 
 Keep edits surgical — one stale fact at a time. Do not rewrite sections that
 are still accurate.
@@ -145,4 +150,4 @@ Do not fabricate content about the app — only create the stub.
   freshness, not perfection.
 - **If a check is ambiguous**, leave it alone and note it in the commit message
   with a `NOTE:` line so a human can review.
-- **Do not open a pull request.** Commit directly to `main`.
+- **Open a pull request** targeting `main` after pushing the branch. Do not merge it yourself — let CI run and branch protection handle it.

--- a/packages/react-fhir/README.md
+++ b/packages/react-fhir/README.md
@@ -151,6 +151,7 @@ for (const node of walkResource(patient, structureDef)) {
 - **`<ResourceTable>`** — generic list/table renderer driven by the StructureDefinition; FHIR-datatype-aware cell formatting (HumanName, CodeableConcept, Reference, …) using the same renderer map as `<ResourceView>`. Supports controlled sort, row clicks, custom per-column renderers.
 - **`<ColumnPicker>`** — companion popover to `<ResourceTable>`: toggle column visibility with checkboxes, persist user choice to `localStorage` via `storageKey`. Keyboard-accessible.
 - **`<SortPicker>`** — popover to choose the `_sort` search parameter, driven by the resource's search params.
+- **`<ReferencePicker>`** — debounced search-and-pick widget for FHIR `Reference` fields. Accepts `targets` (allowed resource types), searches the server live as the user types, and returns a typed `Reference`. Replaces the raw `Type/id` text field that `<ResourceEditor>` generates for Reference elements by default. Also exports `<ReferencePickerFallback>` for when the search fails.
 - **`<Narrative>`** — the *only* place `dangerouslySetInnerHTML` is used. DOMPurify with a FHIR-appropriate allowlist: no `<script>`, no `on*`, no `javascript:`, no forms or inputs.
 - **`defaultTypeRenderers` / `defaultTypeInputs`** — the dispatch maps. Every built-in renderer/input is overridable by passing `renderers` / `inputs` props.
 
@@ -239,7 +240,6 @@ Tracked items (comment / upvote on the issue, or pick one up — each has a conc
 | # | Item |
 | --- | --- |
 | [#4](https://github.com/samsuffolksperoni/fhir-place/issues/4) | ValueSet resolution + binding-aware code input |
-| [#5](https://github.com/samsuffolksperoni/fhir-place/issues/5) | `<ReferencePicker>` search-and-pick widget |
 | [#121](https://github.com/samsuffolksperoni/fhir-place/issues/121) | Typed search builder v0 — core API |
 | [#123](https://github.com/samsuffolksperoni/fhir-place/issues/123) | Profile-aware codegen spike (US Core 7 seed) |
 | [#124](https://github.com/samsuffolksperoni/fhir-place/issues/124) | Experimental Zod schema generation from `StructureDefinition` |

--- a/packages/react-fhir/README.md
+++ b/packages/react-fhir/README.md
@@ -5,9 +5,7 @@ built on the plain FHIR REST API. UI derives from `StructureDefinition`,
 `SearchParameter`, and `CapabilityStatement` — no vendor SDK, no
 resource-specific UI code.
 
-> Pre-1.0. Safe for prototypes; expect breaking changes before 1.0. The
-> canonical project docs (design principles, screenshots, demo, roadmap) live
-> in the [repo README](https://github.com/samsuffolksperoni/fhir-place#readme).
+> Pre-1.0. Safe for prototypes; expect breaking changes before 1.0.
 
 ## Install
 
@@ -23,11 +21,11 @@ Peer dependencies:
 | `react-dom` | `^18.0.0 \|\| ^19.0.0` |
 | `@tanstack/react-query` | `^5.0.0` |
 
-## Minimal setup
+## Quick start
 
-Wrap your app in `QueryClientProvider` and `FhirClientProvider`. Every hook in
-this package reads the active client from context and runs through TanStack
-Query, so cache invalidation, suspense, and devtools all work out of the box.
+Wrap your app in `QueryClientProvider` and `FhirClientProvider`. Every hook
+reads the active client from context and runs through TanStack Query, so cache
+invalidation, suspense, and devtools all work out of the box.
 
 ```tsx
 import { FetchFhirClient, FhirClientProvider } from "@fhir-place/react-fhir";
@@ -36,7 +34,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 const queryClient = new QueryClient();
 const fhir = new FetchFhirClient({
   baseUrl: "https://hapi.fhir.org/baseR4",
-  // Optional auth — runs per request, so tokens can refresh transparently.
+  // Optional auth — runs per request, so tokens refresh transparently.
   // getHeaders: async () => ({ Authorization: `Bearer ${await getToken()}` }),
 });
 
@@ -49,9 +47,61 @@ export function App({ children }: { children: React.ReactNode }) {
 }
 ```
 
-## Examples
+### Read a resource
 
-### `client/` — typed FHIR REST client
+```tsx
+function PatientDetail({ id }: { id: string }) {
+  const { data: patient } = useResource<Patient>("Patient", id);
+  if (!patient) return null;
+  return <ResourceView resource={patient} />;
+}
+```
+
+### Edit / create
+
+```tsx
+function PatientEditor({ initial }: { initial: Patient }) {
+  const update = useUpdateResource<Patient>();
+  return (
+    <ResourceEditor
+      resource={initial}
+      saving={update.isPending}
+      onSave={(draft) => update.mutateAsync(draft as Patient & { id: string })}
+    />
+  );
+}
+```
+
+### Search
+
+```tsx
+function Patients() {
+  const [params, setParams] = useState<SearchParams>({ _count: 20 });
+  const { data } = useSearch<Patient>("Patient", params);
+  return (
+    <>
+      <ResourceSearch
+        resourceType="Patient"
+        priorityParams={["name", "family", "gender", "birthdate"]}
+        onSubmit={setParams}
+      />
+      <ul>
+        {data?.entry?.map((e) => (
+          <li key={e.resource!.id}>{e.resource!.name?.[0]?.family}</li>
+        ))}
+      </ul>
+    </>
+  );
+}
+```
+
+## What's in the library
+
+### `client/`
+
+- **`FhirClient` interface** — `read`, `vread`, `history`, `search`, `create`, `update`, `patch` (JSON Patch), `delete`, `readReference` (relative + absolute), generic `request()` escape hatch
+- **`FetchFhirClient`** — the only shipped implementation. Supports `If-Match` / `If-None-Match` / `If-None-Exist`, static + dynamic headers, `AbortSignal`, custom `fetch`
+- **`FhirError`** — carries status, URL, and `OperationOutcome` from the server when available
 
 ```ts
 import { FetchFhirClient } from "@fhir-place/react-fhir/client";
@@ -61,11 +111,11 @@ const patient = await fhir.read("Patient", "example");
 const bundle = await fhir.search("Patient", { name: "smith", _count: 20 });
 ```
 
-`FetchFhirClient` supports `If-Match` / `If-None-Match` / `If-None-Exist`,
-static + dynamic headers, `AbortSignal`, JSON Patch, and custom `fetch`. Errors
-throw `FhirError` carrying status + the server's `OperationOutcome`.
+### `hooks/`
 
-### `hooks/` — TanStack Query wrappers
+- **`FhirClientProvider` / `useFhirClient`** — context
+- **`useResource`, `useSearch`, `useInfiniteSearch`, `useCapabilities`, `useStructureDefinition`, `useSearchParameter`, `useValueSet`, `useReadReference`** — TanStack Query wrappers with stable query keys (`fhirQueryKeys`). `useSearchParameter` resolves a `(base, code)` pair to its canonical `SearchParameter` resource so spec-aware code can prefer `expression` over the kebab→camel naming convention.
+- **`useCreateResource`, `useUpdateResource`, `useDeleteResource`** — mutations that invalidate matching read queries on success
 
 ```tsx
 import { useResource, useSearch, useUpdateResource } from "@fhir-place/react-fhir/hooks";
@@ -78,25 +128,11 @@ function PatientCard({ id }: { id: string }) {
 }
 ```
 
-Mutations (`useCreateResource`, `useUpdateResource`, `useDeleteResource`)
-invalidate matching read queries on success. Stable query keys are exported as
-`fhirQueryKeys` so callers can target them with `invalidate` / `refetch`.
+### `structure/`
 
-### `components/` — spec-driven UI
-
-```tsx
-import { ResourceView, ResourceEditor, ResourceSearch } from "@fhir-place/react-fhir/components";
-
-<ResourceView resource={patient} />;
-<ResourceEditor resource={patient} onSave={(draft) => fhir.update(draft)} />;
-<ResourceSearch resourceType="Patient" onSelect={(p) => …} />;
-```
-
-Renderers and inputs are driven by the FHIR datatype dispatch maps
-(`defaultTypeRenderers`, `defaultTypeInputs`). Override per-datatype by passing
-`renderers` / `inputs` props — no fork required.
-
-### `structure/` — StructureDefinition introspection
+- **`walkResource` / `walkObject`** — iterate a StructureDefinition snapshot, yield present elements in canonical order, resolve `[x]` choice types
+- **`directChildren`, `findElement`** — querying SDs
+- **`pathGet` / `pathSet` / `pathRemove` / `prune`** — immutable path helpers used by the editor
 
 ```ts
 import { walkResource, findElement, pathGet } from "@fhir-place/react-fhir/structure";
@@ -107,34 +143,42 @@ for (const node of walkResource(patient, structureDef)) {
 }
 ```
 
+### `components/`
+
+- **`<ResourceView>`** — spec-driven read-only view. Dispatches by FHIR datatype; falls back to JSON for unknowns. Recurses into BackboneElements. Zero resource-specific code.
+- **`<ResourceEditor>`** — spec-driven form. Inputs for every R4 primitive + HumanName, Address, ContactPoint, Identifier, Reference, Period, Quantity, Coding, CodeableConcept. BackboneElement recursion. Arrays with add/remove; choice-type switching clears the other variant. `onChange` on every keystroke; `onSave` receives a pruned draft.
+- **`<ResourceSearch>`** — form driven by `CapabilityStatement.rest[].resource[].searchParam`. Type-aware placeholders (token, date, reference, number, quantity, uri). Priority params + "show more" toggle. Optional NLP search via `onAskAI` prop.
+- **`<ResourceTable>`** — generic list/table renderer driven by the StructureDefinition; FHIR-datatype-aware cell formatting (HumanName, CodeableConcept, Reference, …) using the same renderer map as `<ResourceView>`. Supports controlled sort, row clicks, custom per-column renderers.
+- **`<ColumnPicker>`** — companion popover to `<ResourceTable>`: toggle column visibility with checkboxes, persist user choice to `localStorage` via `storageKey`. Keyboard-accessible.
+- **`<SortPicker>`** — popover to choose the `_sort` search parameter, driven by the resource's search params.
+- **`<Narrative>`** — the *only* place `dangerouslySetInnerHTML` is used. DOMPurify with a FHIR-appropriate allowlist: no `<script>`, no `on*`, no `javascript:`, no forms or inputs.
+- **`defaultTypeRenderers` / `defaultTypeInputs`** — the dispatch maps. Every built-in renderer/input is overridable by passing `renderers` / `inputs` props.
+
+```tsx
+import { ResourceView, ResourceEditor, ResourceSearch } from "@fhir-place/react-fhir/components";
+
+<ResourceView resource={patient} />;
+<ResourceEditor resource={patient} onSave={(draft) => fhir.update(draft)} />;
+<ResourceSearch resourceType="Patient" onSelect={(p) => navigate(`/Patient/${p.id}`)} />;
+```
+
 ## Subpath exports
 
 The package ships four stable subpath entry points alongside the root export.
-Use the subpath that matches the layer you depend on — it keeps bundles small
-and makes the dependency direction explicit:
 
 | Import | Use it for |
 | --- | --- |
-| `@fhir-place/react-fhir` | The convenience root export — re-exports all four layers below. |
+| `@fhir-place/react-fhir` | Convenience root — re-exports all four layers. |
 | `@fhir-place/react-fhir/client` | `FhirClient`, `FetchFhirClient`, `FhirError`, `SearchParams`. No React. |
 | `@fhir-place/react-fhir/hooks` | `FhirClientProvider`, `useFhirClient`, query / mutation hooks, `fhirQueryKeys`. Requires `@tanstack/react-query`. |
 | `@fhir-place/react-fhir/structure` | StructureDefinition / SearchParameter walkers, path helpers, value-set / binding utilities. No React, no network. |
 | `@fhir-place/react-fhir/components` | `ResourceView`, `ResourceEditor`, `ResourceSearch`, `ResourceTable`, `Narrative`, datatype renderers + inputs. |
 
-### API surface stability
-
-- The root export and the four subpath exports are the **public API**. They
-  follow semver on the package version.
-- Anything imported via a deeper relative path (e.g. `dist/components/inputs/Period.js`)
-  is **internal**. It can move or change shape between minor releases.
-- Pre-1.0, minor-version bumps may include breaking changes — see the
-  [changelog](./CHANGELOG.md) before upgrading.
+**API stability:** The root export and the four subpath exports are the public API and follow semver. Anything accessed via a deeper relative path is internal and can change between minor releases. Pre-1.0, minor-version bumps may include breaking changes — check the [changelog](./CHANGELOG.md) before upgrading.
 
 ## Architecture: layer boundaries
 
-The library is organised as four layers, each with a single responsibility.
-Imports flow downward — a higher layer may depend on the layers below it, but
-not the reverse.
+The library has four layers. Imports flow downward only — a higher layer may depend on layers below it, never the reverse.
 
 ```
 components/   ← UI (React, JSX, datatype dispatch)
@@ -146,19 +190,66 @@ structure/    ← StructureDefinition introspection (no React, no network)
 client/       ← Typed FHIR REST transport (no React)
 ```
 
-- `client/` knows how to talk to a FHIR server. It has no React or DOM
-  dependencies and is safe to import from Node tooling.
-- `structure/` understands the FHIR metamodel — walking SDs, resolving paths,
-  formatting values, expanding ValueSets. Pure functions, no I/O.
-- `hooks/` glues `client/` to TanStack Query and exposes the cache via stable
-  query keys. Imports `client/` and `structure/`; never `components/`.
+- `client/` talks to a FHIR server. No React or DOM dependencies — safe to use from Node tooling.
+- `structure/` understands the FHIR metamodel: walking SDs, resolving paths, formatting values, expanding ValueSets. Pure functions, no I/O.
+- `hooks/` glues `client/` to TanStack Query and exposes the cache via stable query keys.
 - `components/` renders / edits resources by dispatching on FHIR datatype.
-  Imports any layer below; never imported by lower layers.
 
-When you contribute, prefer adding to the lowest layer that can host the
-behaviour. A new search-param helper belongs in `client/`; a new datatype
-formatter belongs in `structure/`; a new query hook belongs in `hooks/`; a new
-input or renderer belongs in `components/`.
+When contributing, prefer adding to the lowest layer that can host the behaviour. A new search-param helper belongs in `client/`; a new datatype formatter belongs in `structure/`; a new query hook belongs in `hooks/`; a new input or renderer belongs in `components/`.
+
+## Design principles
+
+- **Spec-driven.** UI derives from `StructureDefinition` / `SearchParameter` / `CapabilityStatement`, not hand-written per resource type. If you find yourself writing resource-specific logic in the library, push it to the consumer app or make it a generic primitive.
+- **Server-agnostic.** Plain FHIR REST via a `FhirClient` interface; no vendor SDK in the critical path. The demo works against public HAPI, docker-compose HAPI, or via MSW with no server at all. Every feature flows through the `FhirClient` interface — no direct `fetch` outside `FetchFhirClient`.
+- **Headless.** No Mantine / Bootstrap / Material lock-in. Tailwind + unstyled primitives.
+- **Safe by default.** Narrative sanitised with DOMPurify; only `<Narrative>` gets to render HTML. Every other component uses React's default escaping.
+- **Escape hatches everywhere.** Pass `renderers` / `inputs` to override any datatype. Use `client.request()` for custom operations. Subclass `FetchFhirClient` for custom auth.
+
+See [`docs/decisions/0004-positioning.md`](../../docs/decisions/0004-positioning.md) for the positioning rationale and the "tRPC-of-FHIR" wedge.
+
+## Building your own FHIR app
+
+The components are a toolbox, not a framework. Typical pattern for a new app:
+
+1. **Wire a `FhirClient`** — point at your server, plug in auth via `getHeaders`.
+2. **Resource list** — call `useSearch<YourType>(...)` or `useInfiniteSearch(...)` and render with `<ResourceSearch>` for the filter form and `<ResourceTable>` for results.
+3. **Detail page** — `<ResourceView resource={...} />`.
+4. **Create / edit** — `<ResourceEditor resource={...} onSave={...} />`.
+5. **Override per-type UX** where needed — pass `renderers` or `inputs` to swap in app-specific widgets (e.g. a chart for repeated `Observation.valueQuantity`).
+6. **Resource-specific workflow** — put business logic (e.g. Task state transitions, Goal progress) in your own hooks alongside the library's generic ones.
+
+See [`apps/demo`](../../apps/demo/README.md) for a full working example of this pattern.
+
+## Comparison with other React-FHIR libraries
+
+| Library | Backend | UI lock-in | Spec-driven | LLM/MCP story |
+| --- | --- | --- | --- | --- |
+| **`@fhir-place/react-fhir`** | Any FHIR REST | None — Tailwind + unstyled | Yes (StructureDefinition + SearchParameter + CapabilityStatement) | Roadmap (Zod-from-SD, optional MCP package) |
+| `@medplum/react` | Best with Medplum (some components require Medplum-specific extensions) | Mantine v7 required | Partial | Server-side only |
+| `@bonfhir/react` + `@bonfhir/mantine` | Any | Mantine renderers | Yes (codegen for R4B / R5) | None |
+| `@beda.software/fhir-react` | Any (Aidbox-leaning) | None — hooks only | Hook-level | None |
+| `1uphealth/fhir-react` | Display-only, no client | Bootstrap | No | None |
+
+Where this library loses today: fewer batteries-included components than `@medplum/react`, no Mantine renderer parity with `@bonfhir/mantine`, no SMART App Launch adapter shipped, no profile-aware codegen yet.
+
+## Roadmap / known gaps
+
+Tracked items (comment / upvote on the issue, or pick one up — each has a concrete API sketch and acceptance criteria):
+
+| # | Item |
+| --- | --- |
+| [#4](https://github.com/samsuffolksperoni/fhir-place/issues/4) | ValueSet resolution + binding-aware code input |
+| [#5](https://github.com/samsuffolksperoni/fhir-place/issues/5) | `<ReferencePicker>` search-and-pick widget |
+| [#121](https://github.com/samsuffolksperoni/fhir-place/issues/121) | Typed search builder v0 — core API |
+| [#123](https://github.com/samsuffolksperoni/fhir-place/issues/123) | Profile-aware codegen spike (US Core 7 seed) |
+| [#124](https://github.com/samsuffolksperoni/fhir-place/issues/124) | Experimental Zod schema generation from `StructureDefinition` |
+| [#125](https://github.com/samsuffolksperoni/fhir-place/issues/125) | Interop demo matrix (HAPI + Medplum + Aidbox) |
+| [#127](https://github.com/samsuffolksperoni/fhir-place/issues/127) | Inferno (g)(10) CI badge |
+| [#128](https://github.com/samsuffolksperoni/fhir-place/issues/128) | Optional `@fhir-place/mcp` package |
+
+See the [full issue list](https://github.com/samsuffolksperoni/fhir-place/issues) for the current state — issues are the source of truth and stay up to date as work lands.
+
+Deferred (open an issue if you need it): Extensions in the editor, profile-URL support in `useStructureDefinition`, SMART on FHIR v2 auth, R4B / R5, Subscriptions / realtime.
 
 ## Testing
 
@@ -168,8 +259,7 @@ pnpm test:run      # single run
 pnpm test:ci       # single run with coverage + thresholds
 ```
 
-Coverage thresholds are enforced in `vitest.config.ts`; `test:ci` is the
-script CI runs to gate merges.
+Coverage thresholds are enforced in `vitest.config.ts`; `test:ci` is what CI runs to gate merges.
 
 ## License
 


### PR DESCRIPTION
Complete documentation overhaul. Changes across 8 commits:

## Structure

- **Root `README.md`** — rewritten as a lean monorepo overview: what the repo contains, status, dev commands, and a docs index table. Library API docs moved out.
- **`packages/react-fhir/README.md`** — now the authoritative library reference. Absorbs Quick start, full API reference per layer (`client/`, `hooks/`, `structure/`, `components/`), Design principles, Comparison table, and a Roadmap that links to GitHub Issues as the living source of truth.
- **`apps/demo/README.md`** — new. fhir-ui features, how it's built on react-fhir layer by layer, full app folder structure.
- **`apps/goals-tasks/README.md`** — new. The Goal + Task sample app was missing from all docs entirely; added its own README covering what it does, how it maps onto react-fhir, and how to run.

## Correctness fixes

- Restored `### Goal/Task deployable starter` section to root README — `scripts/check-readme-goal-task.mjs` gates CI on this and would have broken on merge.
- Added `<ReferencePicker>` / `<ReferencePickerFallback>` to the components API section — fully shipped and exported but completely undocumented. Removed it from the roadmap table.
- Fixed `CONTRIBUTING.md`: `pnpm test` was described as running "unit + integration tests" — it only runs unit tests. Integration suite requires an explicit separate command.

## Coverage gaps filled

- **Resource list config** — `resourceListConfig.ts` and `patientFields.ts` now have a dedicated section in `apps/demo/README.md` explaining the `ResourceListConfig` interface field by field, the 20 configured types, the SD-based fallback for unknown types, and a step-by-step guide for adding a new type.
- **Dev prerequisites** — Node ≥ 20 requirement was in `package.json` engines but mentioned nowhere in any README or CONTRIBUTING. Added to both.
- **`.env` presets** — `.env.example.medplum` / `.env.example.aidbox` were undiscoverable. Demo README now shows `cp .env.example.* .env.local` as the fast path.
- **`apps/demo/docs/interop-matrix.md`** — solid per-backend setup walkthrough that was never linked from anywhere. Now linked from the demo README.

## Automation

- **`docs/prompts/daily-doc-sync.md`** — prompt for a cron-scheduled agent to catch documentation drift: test count, CI gate, new exports vs. documented API, closed roadmap issues, resource type list, packages table, Node version, missing app READMEs.

https://claude.ai/code/session_01JWB3Cn64X49N7pY7J9K8cc