### PR TITLE
docs: add e2e test docs, QA agent playbook, and improved CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,39 @@
 # Claude Code Notes
 
+## General
+
 - Keep context small; read only files relevant to the active issue.
-- Before implementation, summarize a short plan.
+- Before implementation, summarize a short plan (2–4 bullet points).
 - Prefer existing patterns over new abstractions.
 - Treat GitHub issue acceptance criteria as the source of truth.
-- After changes, report files changed, tests run, risks, and follow-ups.
+- After changes, report: files changed, tests run, risks, and follow-ups.
+
+## E2E test maintenance
+
+- Every user-facing change needs a test update in the same PR.
+- New page or route → new spec in `apps/demo/e2e/`.
+- New component on an existing page → add assertions to the relevant spec.
+- Visual/layout change → run `playwright test --update-snapshots`, review
+  the diff, and commit the updated PNGs.
+- Bug fix → add a regression test asserting the broken state no longer occurs.
+- Use `data-testid` selectors; avoid CSS class names and positional selectors.
+- See `apps/demo/e2e/README.md` for the full test map and update rules.
+
+## QA agent
+
+When asked to do a QA pass on the demo app:
+
+1. Ensure the dev server is running: `pnpm --filter @fhir-place/demo dev`.
+2. Run the full e2e suite first: `pnpm --filter @fhir-place/demo e2e`.
+   If any test fails, that is already a filed bug — do not re-file it.
+3. For exploratory coverage beyond the suite, follow `docs/qa-agent.md`.
+4. File each new bug as a GitHub issue using the `agent-work-item` template
+   with concrete reproduction steps, expected vs. actual behavior, and the
+   URL/route where the defect occurs.
+5. Do not fix bugs during the same QA pass — file first, fix in a separate PR.
+
+## Safety rules (see docs/decisions/0003-agent-safety-rules.md)
+
+- Small, issue-scoped changes only.
+- Never delete production data, modify secrets, or force-push `main`.
+- All code changes go through a PR; do not merge without human review.

--- a/apps/demo/e2e/README.md
+++ b/apps/demo/e2e/README.md
@@ -1,0 +1,104 @@
+# End-to-End Tests — fhir-place demo
+
+Playwright 1.56 tests for the demo app. All tests run against the local dev
+server backed by the in-browser MSW mock, so no live FHIR server is needed.
+
+## Suites
+
+| File | What it covers |
+|------|---------------|
+| `smoke.spec.ts` | Patient list renders against HAPI / Medplum / Aidbox backends; backend-specific tests skip gracefully when the target URL isn't set |
+| `patient.screenshot.spec.ts` | Patient list filtering, detail view navigation, mobile viewport |
+| `patient-table.screenshot.spec.ts` | Table layout: column headers, data rows, sort indicators |
+| `patient-row-counts.screenshot.spec.ts` | Row count badge reflects the current search result |
+| `patient-field-picker.spec.ts` | Column picker opens, fields can be toggled, table re-renders |
+| `patient-url-sync.screenshot.spec.ts` | Search state survives a page reload via URL hash |
+| `pagination.screenshot.spec.ts` | Next/prev page controls; last page disables Next |
+| `responsive-table.screenshot.spec.ts` | Table collapses to a card layout on narrow viewports |
+| `compartment.screenshot.spec.ts` | Patient detail shows compartment resource tables |
+| `compartment-links.screenshot.spec.ts` | Compartment chip navigation lands on the right filtered view |
+| `crud.screenshot.spec.ts` | Search → create → edit → delete full lifecycle |
+| `resource-create.screenshot.spec.ts` | ResourceEditor form fields render; submit creates a resource |
+| `delete-error.spec.ts` | Delete failure shows an inline error (not an uncaught exception) |
+| `missing-resource.spec.ts` | Navigating to a missing resource ID shows a not-found state |
+| `allergy-intolerance-patient-filter.spec.ts` | AllergyIntolerance list is filtered to the current patient compartment |
+
+### Live-site monitor (`../e2e-live/`)
+
+A separate suite in `apps/demo/e2e-live/` runs nightly against the deployed
+GitHub Pages demo (real HAPI server). Those tests are intentionally minimal
+and data-shape-tolerant — they assert structure and behavior, not literal
+values. Failures auto-file a GitHub issue; see
+`.github/workflows/live-site-monitor.yml`.
+
+## Running tests
+
+```bash
+# All e2e tests (chromium, no screenshots)
+pnpm --filter @fhir-place/demo e2e
+
+# Screenshot-comparison project only
+pnpm --filter @fhir-place/demo e2e:screenshot
+
+# Single file
+pnpm --filter @fhir-place/demo exec playwright test e2e/smoke.spec.ts
+
+# Headed (see the browser)
+pnpm --filter @fhir-place/demo exec playwright test --headed
+
+# Live-site smoke suite (needs a deployed URL)
+pnpm --filter @fhir-place/demo e2e:live
+```
+
+The dev server starts automatically via `playwright.config.ts` `webServer`.
+You do not need to run `pnpm dev` separately.
+
+## Updating screenshot baselines
+
+Screenshot specs use a fixtures-driven local server. When a visual change is
+intentional:
+
+```bash
+pnpm --filter @fhir-place/demo exec playwright test --project=screenshots --update-snapshots
+```
+
+Commit the updated PNGs in `screenshots/`. Always review the diff before
+committing — a regression looks identical to an intentional change in the
+command output.
+
+## Keeping tests current
+
+**Rule:** every user-facing change that touches a page, component, or data
+flow needs a corresponding test update in the same PR.
+
+| Change type | Action |
+|-------------|--------|
+| New page or route | Add a new spec file; name it after the primary behavior, e.g. `my-feature.spec.ts` |
+| New UI component on existing page | Add assertions to the relevant existing spec |
+| Visual/layout change | Re-run `--update-snapshots`, review, and commit updated PNGs |
+| Behavior removed | Delete the assertions that tested it; keep the file if other tests remain |
+| New backend interop flow | Add a tagged test to `smoke.spec.ts` following the `@medplum` / `@aidbox` pattern |
+| Bug fixed | Add a regression test asserting the broken state no longer appears |
+
+### What makes a good e2e test here
+
+- Assert **behavior and structure**, not exact text values that could change
+  with mock data updates.
+- Use `data-testid` attributes for stable selectors; avoid CSS class names and
+  positional selectors.
+- Keep each test independent — don't rely on state left by a prior test.
+- If a test needs the live network, gate it with a `test.skip` + reachability
+  check (see `smoke.spec.ts` for the pattern).
+
+## Configuration
+
+| File | Purpose |
+|------|---------|
+| `playwright.config.ts` | Local dev-server suite (chromium + screenshots) |
+| `playwright.live.config.ts` | Live-site monitor config (`e2e-live/`) |
+
+Key settings in `playwright.config.ts`:
+- `baseURL`: `http://localhost:5173`
+- Screenshots project: viewport fixed at 1280×800
+- Screenshot output directory: `../../screenshots/`
+- No retries in local runs; CI uses 1 retry

--- a/docs/qa-agent.md
+++ b/docs/qa-agent.md
@@ -1,0 +1,136 @@
+# QA Agent Playbook
+
+A guide for an AI agent (Claude Code) to conduct an exploratory QA pass on
+the fhir-place demo app and file bugs as GitHub issues.
+
+## Prerequisites
+
+1. Dev server running on port 5173:
+   ```bash
+   pnpm --filter @fhir-place/demo dev
+   ```
+2. Run the existing e2e suite first. Any failures there are already known
+   bugs — skip re-filing them:
+   ```bash
+   pnpm --filter @fhir-place/demo e2e
+   ```
+3. Note which tests passed/failed before starting the exploratory pass.
+
+## What to look for
+
+### Signals that indicate a bug
+
+| Signal | How to detect |
+|--------|--------------|
+| Console error or uncaught exception | Monitor browser console; assert `consoleErrors` is empty |
+| Network request fails (4xx/5xx) | Intercept with `page.on("response", ...)` |
+| Page shows an error boundary / "Something went wrong" | `getByText(/something went wrong/i)` |
+| Missing `data-testid` on a component the suite expects | Run existing tests; check which selectors fail |
+| Broken layout at narrow viewport (375 px) | Resize viewport and screenshot |
+| Blank / empty content where data is expected | Assert the relevant element is non-empty |
+| Infinite spinner (loading state that never resolves) | Assert content visible within a reasonable timeout |
+| Text overflows its container | Visual inspection / screenshot comparison |
+| Tab / keyboard navigation broken | Use `page.keyboard.press("Tab")` to walk the UI |
+| Duplicate or stale data after CRUD | Create, read, update, delete and assert after each step |
+
+### Pages to visit
+
+Work through each route systematically. The app uses a hash router
+(`#/ResourceType`).
+
+| Route | What to verify |
+|-------|---------------|
+| `/` | Redirects to `#/Patient`; patient list loads |
+| `#/Patient` | Table renders, search form visible, field picker works, pagination works |
+| `#/Patient/<id>` | Detail view renders; compartment chips visible; no error banners |
+| `#/Patient/<id>/edit` | Edit form pre-populates; save does not 500 |
+| `#/Patient/new` | Create form empty; submit creates and redirects to detail |
+| `#/AllergyIntolerance` | List renders; patient filter chip appears |
+| `#/AllergyIntolerance?patient=<id>` | Filtered to a single patient |
+| `#/Patient/NONEXISTENT` | Not-found state renders cleanly (no exception) |
+| Settings page | Server URL editable; theme toggle works; change persists on reload |
+| CQL Runner | Page loads; editor visible |
+| Ask / AI feature | Input renders; chat state initialises |
+
+### Mobile viewport check
+
+After the desktop pass, repeat the Patient list and detail routes at 375×812
+(iPhone SE). Look for:
+
+- Horizontal overflow (scrollbar on `<body>`)
+- Touch targets smaller than 44×44 px
+- Text truncated in a way that hides key information
+
+## Running a Playwright-based exploratory session
+
+You can use Playwright's `page` API programmatically to walk the app without
+writing a permanent test:
+
+```ts
+// Temporary exploratory script (do NOT commit)
+import { chromium } from "playwright";
+
+const browser = await chromium.launch({ headless: false });
+const page = await browser.newPage();
+
+const errors: string[] = [];
+page.on("console", (m) => { if (m.type() === "error") errors.push(m.text()); });
+page.on("pageerror", (e) => errors.push(`pageerror: ${e.message}`));
+
+await page.goto("http://localhost:5173/#/Patient");
+await page.waitForLoadState("networkidle");
+// ... drive the UI, then inspect `errors`
+
+await browser.close();
+```
+
+Alternatively, run the existing suite with `--headed` and observe:
+```bash
+pnpm --filter @fhir-place/demo exec playwright test --headed --slow-mo=500
+```
+
+## Filing a bug
+
+Use the `agent-work-item` issue template
+(`.github/ISSUE_TEMPLATE/agent-work-item.yml`) with:
+
+- **Title:** `[bug] <short description>` — e.g. `[bug] Delete error banner not visible on mobile`
+- **Problem:** one paragraph describing the defect
+- **User impact:** who is affected and how severely
+- **Desired behavior:** what should happen
+- **Acceptance criteria:** checkboxes, each one testable
+- **Relevant files:** list the likely source files (route, component, hook)
+- **Test plan:** include a Playwright assertion that would catch a regression
+- **Constraints:** note if the fix should not touch unrelated areas
+
+### Minimal bug report template
+
+```
+**Route:** #/Patient/<id>
+**Steps to reproduce:**
+1. Navigate to a patient detail page
+2. Click Delete
+3. Confirm deletion in the dialog
+
+**Expected:** Confirmation dialog closes, list reloads, patient row gone
+**Actual:** Dialog stays open; spinner never resolves
+**Console errors:** [paste any errors]
+**Viewport:** 1280×800 desktop / 375×812 mobile
+```
+
+## Scope and limits
+
+- File bugs only for the demo app (`apps/demo/`). Do not file issues for the
+  react-fhir package unless a component bug is confirmed by a unit test failure.
+- One issue per distinct bug. Do not batch multiple bugs into one issue.
+- Do not fix bugs during the QA pass. Fix in a separate, issue-scoped PR.
+- Do not file issues that duplicate an existing open GitHub issue. Search first.
+- Mark the issue with label `bug` and, if agent-actionable, `agent-ready`.
+
+## After the QA pass
+
+Report a summary:
+- Routes visited
+- Bugs filed (links)
+- Tests that were already catching issues (so credit is given)
+- Any areas with thin coverage that need new specs


### PR DESCRIPTION
- apps/demo/e2e/README.md: full suite map (15 specs), run commands,
  screenshot update workflow, and a rule table for keeping tests current
- docs/qa-agent.md: step-by-step playbook for an agent doing exploratory QA —
  what signals to look for, routes to visit, how to file bugs via the
  agent-work-item template
- CLAUDE.md: add E2E maintenance rules and QA agent instructions; surface
  the safety-rules ADR; preserve all original bullets

https://claude.ai/code/session_01P14Dq73NwiToTPm33cbeZC