### PR TITLE
ci: workflow_dispatch to discover rich test patients on live FHIR servers

### DIFF
--- a/.github/workflows/discover-test-patients.yml
+++ b/.github/workflows/discover-test-patients.yml
@@ -1,0 +1,63 @@
+name: Discover test patients
+
+on:
+  workflow_dispatch:
+    inputs:
+      sample:
+        description: "Number of patients to sample per server"
+        default: "40"
+        required: false
+      top:
+        description: "Number of top candidates to report"
+        default: "4"
+        required: false
+      server1:
+        description: "FHIR server 1 base URL"
+        default: "https://r4.smarthealthit.org"
+        required: false
+      server2:
+        description: "FHIR server 2 base URL"
+        default: "https://hapi.fhir.org/baseR4"
+        required: false
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run discovery script
+        env:
+          SERVER1: ${{ inputs.server1 }}
+          SERVER2: ${{ inputs.server2 }}
+          SAMPLE:  ${{ inputs.sample }}
+          TOP:     ${{ inputs.top }}
+        run: |
+          node scripts/discover-test-patients.mjs 2>&1 | tee /tmp/discovery-output.txt
+
+      - name: Write job summary
+        if: always()
+        run: |
+          echo '## Test patient discovery results' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '| Input | Value |' >> $GITHUB_STEP_SUMMARY
+          echo '|---|---|' >> $GITHUB_STEP_SUMMARY
+          echo "| Server 1 | ${{ inputs.server1 }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Server 2 | ${{ inputs.server2 }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Sample size | ${{ inputs.sample }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Top N | ${{ inputs.top }} |" >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat /tmp/discovery-output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload full output as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: discovery-output
+          path: /tmp/discovery-output.txt
+          retention-days: 14


### PR DESCRIPTION
## Summary

Adds a manually-triggered GitHub Actions workflow that runs `scripts/discover-test-patients.mjs` on a GitHub runner (which has unrestricted internet access to the FHIR servers).

## How to trigger

1. Go to **Actions → Discover test patients → Run workflow**
2. Optionally override the inputs (servers, sample size, top-N)
3. Click **Run workflow**
4. Results appear in the job summary and as a downloadable artifact

## Inputs

| Input | Default | Description |
|---|---|---|
| `server1` | `https://r4.smarthealthit.org` | First FHIR server |
| `server2` | `https://hapi.fhir.org/baseR4` | Second FHIR server |
| `sample` | `40` | Patients to score per server |
| `top` | `4` | Candidates to report |

## Output

- **Job summary**: scored patient table printed inline on the Actions run page
- **Artifact** (`discovery-output`): full stdout, retained 14 days

## Test plan

- [ ] Trigger the workflow from the Actions tab and confirm results appear in the job summary

https://claude.ai/code/session_01BY7q7MZaBbxXhFxjguPUtm

---
_Generated by [Claude Code](https://claude.ai/code/session_01BY7q7MZaBbxXhFxjguPUtm)_