### PR TITLE
docs: record discovery results and chosen test patients

### DIFF
--- a/.github/workflows/discover-test-patients.yml
+++ b/.github/workflows/discover-test-patients.yml
@@ -19,6 +19,10 @@ on:
         description: "FHIR server 2 base URL"
         default: "https://hapi.fhir.org/baseR4"
         required: false
+      patient_query:
+        description: "Extra Patient search params (e.g. 'birthdate=gt2010-01-01')"
+        default: ""
+        required: false
 
 jobs:
   discover:
@@ -31,10 +35,11 @@ jobs:
 
       - name: Run discovery script
         env:
-          SERVER1: ${{ inputs.server1 }}
-          SERVER2: ${{ inputs.server2 }}
-          SAMPLE:  ${{ inputs.sample }}
-          TOP:     ${{ inputs.top }}
+          SERVER1:       ${{ inputs.server1 }}
+          SERVER2:       ${{ inputs.server2 }}
+          SAMPLE:        ${{ inputs.sample }}
+          TOP:           ${{ inputs.top }}
+          PATIENT_QUERY: ${{ inputs.patient_query }}
         run: |
           node scripts/discover-test-patients.mjs 2>&1 | tee /tmp/discovery-output.txt
 
@@ -49,6 +54,7 @@ jobs:
           echo "| Server 2 | ${{ inputs.server2 }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Sample size | ${{ inputs.sample }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Top N | ${{ inputs.top }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Patient query | \`${{ inputs.patient_query }}\` |" >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           cat /tmp/discovery-output.txt >> $GITHUB_STEP_SUMMARY

--- a/apps/demo/src/mocks/test-patients.json
+++ b/apps/demo/src/mocks/test-patients.json
@@ -1,0 +1,79 @@
+{
+  "discoveredAt": "2026-05-03",
+  "server": "https://r4.smarthealthit.org",
+  "note": "Chosen by scripts/discover-test-patients.mjs — scored by resource-type breadth × 15 + total volume across 40-patient sample",
+  "patients": [
+    {
+      "id": "5fd069dc-e337-4062-9722-a732c655c17d",
+      "profile": "chronic-complex",
+      "label": "Coleman Ortiz | male | DOB: 1915-07-03",
+      "score": 698,
+      "totals": {
+        "Condition": 21,
+        "Observation": 414,
+        "MedicationRequest": 11,
+        "Encounter": 45,
+        "Procedure": 29,
+        "Immunization": 10,
+        "AllergyIntolerance": 0,
+        "DiagnosticReport": 39,
+        "CarePlan": 9
+      },
+      "notes": "Highest volume (578 resources). Long life history spanning 110 years. Deep observation and diagnostic report series. Use for compartment rendering, pagination, and lab result display tests."
+    },
+    {
+      "id": "c34852c9-ffba-4bda-890a-eef4bc683e42",
+      "profile": "medication-heavy",
+      "label": "Hallie Hoeger | female | DOB: 1926-06-06",
+      "score": 618,
+      "totals": {
+        "Condition": 13,
+        "Observation": 297,
+        "MedicationRequest": 55,
+        "Encounter": 71,
+        "Procedure": 21,
+        "Immunization": 10,
+        "AllergyIntolerance": 0,
+        "DiagnosticReport": 25,
+        "CarePlan": 6
+      },
+      "notes": "55 MedicationRequests — highest of any candidate. 71 encounters. Good for testing medication list pagination, encounter history, and polypharmacy edge cases."
+    },
+    {
+      "id": "9823384d-2120-478e-9ab3-6375c594347d",
+      "profile": "immunization-rich",
+      "label": "Emilee Ritchie | female | DOB: 1924-12-30",
+      "score": 613,
+      "totals": {
+        "Condition": 13,
+        "Observation": 321,
+        "MedicationRequest": 41,
+        "Encounter": 61,
+        "Procedure": 13,
+        "Immunization": 12,
+        "AllergyIntolerance": 0,
+        "DiagnosticReport": 27,
+        "CarePlan": 5
+      },
+      "notes": "High immunization count (12) alongside dense observations and encounters. Good counterpart to Hallie for female-patient tests across conditions, meds, and immunizations."
+    },
+    {
+      "id": "d4f1aab1-73e6-4d51-98eb-e1556406b2a3",
+      "profile": "full-breadth",
+      "label": "Hobert Murazik | male | DOB: 1963-01-06",
+      "score": 537,
+      "totals": {
+        "Condition": 8,
+        "Observation": 297,
+        "MedicationRequest": 18,
+        "Encounter": 33,
+        "Procedure": 6,
+        "Immunization": 12,
+        "AllergyIntolerance": 1,
+        "DiagnosticReport": 25,
+        "CarePlan": 2
+      },
+      "notes": "Only patient in sample with all 9/9 resource types populated, including AllergyIntolerance. Younger profile (63 at discovery). Critical for testing allergy rendering and full-breadth compartment navigation."
+    }
+  ]
+}

--- a/docs/test-patient-strategy.md
+++ b/docs/test-patient-strategy.md
@@ -127,14 +127,29 @@ with clinical data, if the pediatric rendering path becomes important to test.
 - [x] Run discovery against SMART Health IT; pick 4 patient IDs
 - [x] Create `apps/demo/src/mocks/test-patients.json` with chosen patients
 
-### Phase 2 — Second server decision (blocked on open question #1)
+### Phase 1.5 — Targeted searches (next)
 
-Once the server 2 choice is made:
+Two follow-up runs of `discover-test-patients` against SMART Health IT, using the
+new `patient_query` workflow input:
 
-- [ ] **If local HAPI:** write `scripts/seed-test-patients.mjs` using Synthea bundles;
-  add a `docker compose up` post-hook or a dev-setup README step to seed on first run
-- [ ] **If Medplum:** add Medplum patient IDs to `test-patients.json`; document the
-  one-time seeding step in `interop-matrix.md`
+- [ ] **Allergy-rich patient** — `patient_query=_has:AllergyIntolerance:patient:_id:exists=true`
+  finds patients with at least one AllergyIntolerance. Pick the highest-scoring one to
+  replace or supplement the current full-breadth slot (Hobert has only 1 AI record).
+- [ ] **Pediatric patient** — `patient_query=birthdate=gt2010-01-01` finds children.
+  Pick a candidate with growth observations and a vaccine series; add as a 5th profile.
+
+### Phase 2 — Server 2 (Medplum)
+
+Decided: Medplum sandbox is server 2. Project-scoped, seeds survive indefinitely,
+no weekly re-seed. Bearer-token auth is already documented in `interop-matrix.md`.
+
+- [ ] Create a Medplum project + ClientApplication; obtain a long-lived access token
+  scoped to the test-fixtures project
+- [ ] Write `scripts/seed-medplum.mjs` that POSTs Synthea-derived Transaction bundles
+  for each profile and captures the Medplum-assigned IDs into `test-patients.json`
+- [ ] Add the access token as a GitHub repo secret (`MEDPLUM_TEST_TOKEN`); document
+  local-dev setup via `.env.local`
+- [ ] Update `interop-matrix.md` with the seeding step
 
 ### Phase 3 — MSW fixture expansion (1–2 days)
 
@@ -143,15 +158,31 @@ Once the server 2 choice is made:
 - [ ] Lamarr remains sparse (only name + gender) — tests empty-state compartment paths
 - [ ] Turing: add 10+ Observations, 3 Conditions, 2 MedicationRequests, 2 Encounters
 - [ ] Hopper: add 12 Immunizations, 5+ Observations (vitals), 3 Encounters
+- [ ] If pediatric profile is added: extend a synthetic patient (or repurpose one of
+  the existing ones) with growth Observations and an immunization series
 
-### Phase 4 — Test updates (1–2 days)
+### Phase 4 — Live-server test coverage (1–2 days)
 
+The Vitest integration suite (`packages/react-fhir/integration/`) stays focused on
+protocol-drift CRUD roundtrips against HAPI public — its design (random identifiers,
+clean up after, never assert on pre-existing data) is incompatible with asserting on
+known patient IDs. The new live-data assertions live in two new places:
+
+**a) New `LiveRead.integration.test.ts`** (gated on `FHIR_BASE_URL` pointing at SMART):
+- [ ] `describe.skipIf(!url.includes("smarthealthit"))` so the suite no-ops against HAPI
+- [ ] For each chosen patient: `client.read("Patient", id)` returns 200, names match
+- [ ] Compartment search returns >0 for each non-zero type in `test-patients.json.totals`
+  (assert non-empty, not exact counts — Synthea regen could shift counts by ±5%)
+- [ ] Hobert: AllergyIntolerance search returns ≥1
+- [ ] Add an Actions matrix to `integration.yml`: run once with HAPI (existing) and
+  once with `FHIR_BASE_URL=https://r4.smarthealthit.org` (new)
+
+**b) Extend `apps/demo/e2e-live/`** (Playwright against the deployed app):
 - [ ] Add a `getTestPatient(profile)` helper reading `test-patients.json`
-- [ ] Update `compartment.screenshot.spec.ts` to exercise all 4 profiles
-- [ ] Add assertions in `allergy-intolerance-patient-filter.spec.ts` for Hobert (1 allergy)
-  and Ada (0 allergies from live server — empty state)
-- [ ] Add `e2e/patient-profiles.spec.ts`: visit each profile patient, assert correct
-  compartment tabs are present/absent
+- [ ] New `e2e-live/patient-profiles.spec.ts`: navigate to each profile patient on the
+  deployed site (configured to point at SMART), assert the right compartment tabs render
+- [ ] Add Hobert-specific assertion: AllergyIntolerance compartment shows ≥1 row
+- [ ] Tag tests with `@smart` so they skip when the live site points elsewhere
 
 ---
 
@@ -160,18 +191,20 @@ Once the server 2 choice is made:
 | Risk | Likelihood | Mitigation |
 |---|---|---|
 | SMART Health IT corpus resets, changing patient IDs | Low | Re-run `discover-test-patients` workflow; update `test-patients.json` |
-| AllergyIntolerance data too sparse for meaningful tests | Medium | Hobert has 1 AI resource; a targeted search would find richer candidates if needed |
-| Pediatric path untested on live server | Medium | Targeted query for young patients post-discovery; or rely on MSW fixture for that path |
+| AllergyIntolerance data too sparse for meaningful tests | Addressed | Phase 1.5 runs a targeted `_has:AllergyIntolerance` search to replace the full-breadth slot |
+| Pediatric path untested on live server | Addressed | Phase 1.5 runs a targeted `birthdate=gt2010-01-01` search to add a 5th profile |
 | HAPI public rate limits worsen | N/A | HAPI public dropped as server 2 for rich patient data |
 
 ---
 
-## Open questions for human decision
+## Decisions (2026-05-03)
 
-1. **Server 2 choice** — local HAPI Docker (seed once, stable per container) or Medplum
-   sandbox (stable indefinitely, requires bearer token)? HAPI public is confirmed
-   unsuitable for rich patient fixtures.
-2. **AllergyIntolerance coverage** — Hobert has only 1 AI resource. Is that enough, or
-   should we run a targeted discovery search for a patient with 3–5 allergies?
-3. **Pediatric profile** — is it in scope? If yes, a targeted `/Patient?birthdate=gt2010`
-   query on SMART Health IT is the next step.
+1. **Server 2 = Medplum sandbox.** Project-scoped, seeds survive indefinitely. HAPI
+   public dropped for rich-fixture purposes (severe rate limiting + sparse data
+   confirmed in the discovery run). Local HAPI via Docker remains useful for ad-hoc
+   developer testing but isn't part of the canonical fixture set.
+2. **Run a targeted allergy search** — 1 AI record on Hobert is insufficient; a search
+   for a patient with multiple allergies will replace or supplement the full-breadth
+   slot.
+3. **Add a pediatric profile** — bring the total to 5 patients. Targeted search by
+   `birthdate=gt2010-01-01` against SMART Health IT.

--- a/docs/test-patient-strategy.md
+++ b/docs/test-patient-strategy.md
@@ -12,7 +12,7 @@ by default.
 |---|---|---|
 | MSW mock | Ada, Turing, Hopper, Lamarr + 32 synthetic | Only Ada has any (12 resources, 7 types) |
 | HAPI public | Whatever the public bucket has | Unpredictable; resets weekly |
-| SMART Health IT | Pre-loaded Synthea corpus | Unknown — needs investigation |
+| SMART Health IT | Pre-loaded Synthea corpus | 4 candidates chosen — see §Discovery results |
 | Local HAPI (Docker) | Empty on startup | None; must seed manually |
 
 Turing, Hopper, and Lamarr carry only `name`/`gender`/`birthDate`. The 32 synthetic
@@ -24,150 +24,134 @@ dark — untested in CI and unreliable against live servers.
 
 ## Goals
 
-1. **4 patients, 2 live servers** — each patient seeded on both HAPI and SMART Health IT
-   with stable, known IDs so tests can make deterministic assertions.
+1. **4 well-known patients on SMART Health IT** with stable UUIDs and deep clinical data
+   so tests can make deterministic assertions against a live server.
 2. **Wide resource-type coverage** — exercise every compartment type the app renders
    (Condition, Observation, MedicationRequest, AllergyIntolerance, Procedure,
    Encounter, Immunization, DiagnosticReport, CarePlan) plus Patient demographics.
-3. **Field-completeness mix** — one patient with nearly every field populated, one with
-   sparse data, two in between, so edge-case rendering is covered.
-4. **Stability** — IDs must survive server resets. HAPI public resets weekly; the
-   seeding pipeline must run after each reset.
+3. **Distinct clinical profiles** — each patient stresses a different rendering path so
+   failures are easy to localise.
+4. **Matching MSW expansion** — the same 4 profiles reflected in `fixtures.ts` so
+   offline CI tests cover the same paths as live-server smoke tests.
 
 ---
 
 ## Server assessment
 
-### SMART Health IT (`https://r4.smarthealthit.org`)
+### SMART Health IT (`https://r4.smarthealthit.org`) ✓ Chosen as primary live server
 
-SMART Health IT pre-loads a Synthea-generated corpus on every reset. The patients have
-realistic clinical histories spanning years: hundreds of Observations (vitals + labs),
-dozens of Conditions, full Encounter histories, CarePlans, DiagnosticReports, and
-ExplanationOfBenefits. The server is maintained by the SMART Health IT group at Boston
-Children's Hospital and is designed specifically as a stable integration target.
+Discovery run on 2026-05-03 scored 40 sampled patients across 9 resource types.
+Results were excellent: the top 4 candidates have 400–578 resources each, spanning
+8–9/9 compartment types, with realistic multi-decade clinical histories.
 
-**Investigation needed:** Query the server to identify 4 candidates matching the profiles
-below. Synthea patients on this server have UUIDs as their FHIR `id`; once chosen, those
-IDs appear stable across resets (the corpus is reloaded from the same generated dataset).
-A one-time discovery script (see §Implementation) will surface the best candidates.
+Patient IDs are stable across SMART Health IT resets — the corpus is reloaded from the
+same Synthea-generated dataset each time. No ongoing seeding needed.
 
-### HAPI public (`https://hapi.fhir.org/baseR4`)
+### HAPI public (`https://hapi.fhir.org/baseR4`) ✗ Not viable for rich test fixtures
 
-HAPI's public server is a shared sandbox that resets on a rolling weekly schedule. Any
-patient written to it will eventually be wiped. Stable test coverage therefore requires
-a seeding pipeline that writes patients back after each reset, using `PUT` with
-deterministic UUIDs so IDs remain constant across re-seeds.
+The discovery run revealed two fatal problems:
+- **Severe rate limiting** — 429s on 4 of 9 resource-type queries per patient, starting
+  from patient 1. Counts were corrupted for most of the sample.
+- **Sparse data** — the patients that got through were almost entirely junk: 38 of 40
+  scored 0 resources. The "top 4" were all the same person with 2–10 resources total,
+  breadth ≤ 2/9.
 
-**Note on HAPI vs. a private HAPI:** The project's `docker-compose.yml` already ships
-a local HAPI image. A future improvement could promote that to a project-owned hosted
-HAPI (e.g. fly.io or Railway free tier) to eliminate the weekly reset problem entirely.
-This proposal keeps public HAPI as server 2 and handles the reset via automation, with
-a note to revisit if maintenance burden grows.
+HAPI public is useful as an interop target for CRUD and search tests but not as a source
+of rich, stable patient data. A second _stable_ live server with deep patient data
+should be one of:
 
----
+- **Local HAPI via Docker** (`docker-compose.yml` already ships it) — seed it once with
+  Synthea bundles on `docker compose up`; stable for the lifetime of the container.
+- **Medplum sandbox** — project-scoped, seeds survive indefinitely, already documented
+  in `interop-matrix.md`. Requires a bearer token.
 
-## Patient profiles
-
-Four patients with deliberately distinct clinical profiles stress-test different app
-rendering paths.
-
-| # | Persona | Key clinical features | Field-completeness |
-|---|---|---|---|
-| **P1** | **Chronic-complex** | DM2 + HTN + CKD, 5+ years of vitals, 10+ medications, 3+ encounters/year, imaging | Near-complete (name, DOB, MRN, telecom, address, photo, deceased=false) |
-| **P2** | **Acute/surgical** | Single major surgery, short Encounter history, post-op meds, imaging DiagnosticReport | Moderate (name, DOB, gender; no telecom, no MRN) |
-| **P3** | **Pediatric** | Child under 10, well-child encounters, growth Observations (weight/height/BMI), immunization series | Complete demographics, minimal conditions |
-| **P4** | **Sparse/edge-case** | Near-empty record: name + gender only, no conditions, no meds, no encounters | Minimal — tests empty-state UI paths |
+See §Open questions for the decision.
 
 ---
 
-## Approach per server
+## Discovery results — SMART Health IT
 
-### Server 1 — SMART Health IT (discover existing patients)
+Ran `scripts/discover-test-patients.mjs` against `https://r4.smarthealthit.org`
+with `SAMPLE=40 TOP=4`. Full results in `apps/demo/src/mocks/test-patients.json`.
 
-SMART Health IT's corpus is large enough that good candidates for P1–P3 almost certainly
-already exist. The approach:
+| Patient | ID | Score | Resources | Breadth | Distinctive feature |
+|---|---|---|---|---|---|
+| Coleman Ortiz | `5fd069dc-…` | 698 | 578 | 8/9 | 414 Observations, 39 DiagnosticReports — deep lab history |
+| Hallie Hoeger | `c34852c9-…` | 618 | 498 | 8/9 | 55 MedicationRequests, 71 Encounters — polypharmacy |
+| Emilee Ritchie | `9823384d-…` | 613 | 493 | 8/9 | 12 Immunizations, 321 Observations — breadth + immunization series |
+| Hobert Murazik | `d4f1aab1-…` | 537 | 402 | **9/9** | Only patient with AllergyIntolerance — full compartment breadth |
 
-1. Run a one-time **discovery script** (`scripts/discover-test-patients.mjs`) that:
-   - Fetches the first 200 patients from `https://r4.smarthealthit.org/Patient`
-   - For each, issues parallel requests to count their Conditions, Observations,
-     MedicationRequests, Encounters, Immunizations, and Procedures
-   - Scores and ranks patients by resource-type breadth and total count
-   - Prints the top 10 with their IDs and scores
-2. A human reviews the shortlist, picks the 4 that best match the profiles above, and
-   records their IDs in `apps/demo/src/mocks/test-patients.json`.
-3. No ongoing automation needed — SMART's corpus is stable.
+Resource breakdown:
 
-### Server 2 — HAPI public (Synthea seeding, weekly)
+| Patient | Cond | Obs | MedReq | Enc | Proc | Imm | AI | DR | CP |
+|---|---|---|---|---|---|---|---|---|---|
+| Coleman Ortiz | 21 | 414 | 11 | 45 | 29 | 10 | 0 | 39 | 9 |
+| Hallie Hoeger | 13 | 297 | 55 | 71 | 21 | 10 | 0 | 25 | 6 |
+| Emilee Ritchie | 13 | 321 | 41 | 61 | 13 | 12 | 0 | 27 | 5 |
+| Hobert Murazik | 8 | 297 | 18 | 33 | 6 | 12 | **1** | 25 | 2 |
 
-Because HAPI resets weekly, we need a reproducible seeding script and a scheduled job.
+_Cond=Condition, Obs=Observation, MedReq=MedicationRequest, Enc=Encounter,
+Proc=Procedure, Imm=Immunization, AI=AllergyIntolerance, DR=DiagnosticReport, CP=CarePlan_
 
-**Tooling — Synthea:**
-[Synthea](https://github.com/synthetichealth/synthea) is an open-source patient
-generator that produces standards-conformant R4 FHIR Transaction bundles. A single run
-generates a patient with 10–30 resource types, realistic date ranges, and coded values
-from SNOMED, LOINC, and RxNorm. Each generation run is deterministic given a fixed
-`--seed` value, meaning we can reproduce identical patients on every re-seed.
+**Note:** AllergyIntolerance was 0 for 3 of 4 patients. Hobert Murazik is the only
+candidate in the 40-patient sample with a non-zero AI count (1 resource) and is the
+only patient covering all 9 compartment types. A targeted search for patients with
+`AllergyIntolerance?patient=…&_summary=count > 0` would find richer AI coverage if
+needed.
 
-**Seeding script (`scripts/seed-test-patients.mjs`):**
-- Reads `apps/demo/src/mocks/test-patients.json` for the four patient UUIDs
-- Checks whether each patient already exists on HAPI (`GET /Patient/<id>`)
-- If missing, POSTs the corresponding Synthea Transaction bundle, then `PUT`s each
-  resource with its deterministic ID to ensure stable references
-- Exits 0 if all four patients are present; exits 1 if any write fails
+**Note on pediatric coverage:** None of the top-scoring patients are pediatric (DOBs
+range from 1915 to 1963). A separate targeted query
+(`/Patient?birthdate=gt2010-01-01&_count=20`) would be needed to find a child patient
+with clinical data, if the pediatric rendering path becomes important to test.
 
-**Weekly GitHub Actions workflow (`.github/workflows/seed-test-patients.yml`):**
-```
-schedule: cron '0 6 * * 1'   # Monday 06:00 UTC, after HAPI's Sunday reset
-```
-- Installs Node, runs the seed script against HAPI
-- On failure: opens a GitHub issue tagged `test-infrastructure`
-- Caches Synthea JAR between runs to keep the job under 2 minutes
+---
+
+## Patient profiles (mapped to discovered IDs)
+
+| Profile | Patient | Rationale |
+|---|---|---|
+| **Chronic-complex** | Coleman Ortiz (`5fd069dc`) | Highest volume. 110-year history. Deep observation and diagnostic series for compartment pagination tests. |
+| **Medication-heavy** | Hallie Hoeger (`c34852c9`) | 55 medications, 71 encounters. Tests medication list rendering and polypharmacy edge cases. |
+| **Immunization-rich** | Emilee Ritchie (`9823384d`) | 12 immunizations + large observation set. Tests immunization table alongside dense lab data. |
+| **Full-breadth** | Hobert Murazik (`d4f1aab1`) | Only 9/9 resource types including AllergyIntolerance. Critical for allergy rendering and full compartment navigation. |
 
 ---
 
 ## Implementation plan
 
-### Phase 1 — Discovery (1–2 days)
+### Phase 1 — Discovery ✅ Complete
 
-- [ ] Write `scripts/discover-test-patients.mjs` (Node, no extra deps beyond `node-fetch`)
-- [ ] Run it against SMART Health IT; review output; pick 4 patient IDs
-- [ ] Create `apps/demo/src/mocks/test-patients.json`:
-  ```json
-  {
-    "patients": [
-      { "id": "...", "profile": "chronic-complex", "server": "smart" },
-      { "id": "...", "profile": "acute-surgical",  "server": "smart" },
-      { "id": "...", "profile": "pediatric",        "server": "smart" },
-      { "id": "...", "profile": "sparse",           "server": "smart" }
-    ]
-  }
-  ```
+- [x] Write `scripts/discover-test-patients.mjs`
+- [x] Add `scripts/discover-test-patients.mjs` — follows pagination, surfaces 429 errors
+- [x] Add `.github/workflows/discover-test-patients.yml` — `workflow_dispatch` job
+- [x] Run discovery against SMART Health IT; pick 4 patient IDs
+- [x] Create `apps/demo/src/mocks/test-patients.json` with chosen patients
 
-### Phase 2 — HAPI seeding pipeline (2–3 days)
+### Phase 2 — Second server decision (blocked on open question #1)
 
-- [ ] Download Synthea JAR; generate 4 bundles with fixed seeds matching the profiles
-- [ ] Write `scripts/seed-test-patients.mjs` to write bundles to HAPI with deterministic IDs
-- [ ] Add `.github/workflows/seed-test-patients.yml` with the weekly cron + failure issue
-- [ ] Extend `test-patients.json` with the corresponding HAPI patient IDs
+Once the server 2 choice is made:
 
-### Phase 3 — Fixture expansion (1–2 days)
+- [ ] **If local HAPI:** write `scripts/seed-test-patients.mjs` using Synthea bundles;
+  add a `docker compose up` post-hook or a dev-setup README step to seed on first run
+- [ ] **If Medplum:** add Medplum patient IDs to `test-patients.json`; document the
+  one-time seeding step in `interop-matrix.md`
 
-- [ ] Expand `apps/demo/src/mocks/fixtures.ts`: add clinical data for Turing, Hopper, and
-  Lamarr so they map to the acute, pediatric, and sparse profiles respectively
-- [ ] Lamarr (sparse): keep as-is — deliberately empty to test empty-state paths
+### Phase 3 — MSW fixture expansion (1–2 days)
+
+- [ ] Expand `apps/demo/src/mocks/fixtures.ts`: add clinical data for Turing, Hopper, Lamarr
+  mapped to the chronic-complex, medication-heavy, and full-breadth profiles respectively
+- [ ] Lamarr remains sparse (only name + gender) — tests empty-state compartment paths
 - [ ] Turing: add 10+ Observations, 3 Conditions, 2 MedicationRequests, 2 Encounters
-- [ ] Hopper: add growth Observations (height/weight/BMI), 5 Immunizations, 3 Encounters
+- [ ] Hopper: add 12 Immunizations, 5+ Observations (vitals), 3 Encounters
 
 ### Phase 4 — Test updates (1–2 days)
 
-- [ ] Add a `test-patients` helper that reads `test-patients.json` and resolves the correct
-  patient ID for a given profile + server
-- [ ] Update `compartment.screenshot.spec.ts` and `compartment-links.screenshot.spec.ts`
-  to exercise each of the 4 profiles (currently only tests Ada/P1 equivalent)
-- [ ] Add `allergy-intolerance-patient-filter.spec.ts` assertions for P1 (known allergy
-  count) and P4 (empty list)
-- [ ] Add a new `e2e/patient-profiles.spec.ts` spec that visits each of the 4 profile
-  patients and asserts resource-type tabs are present/absent as expected
+- [ ] Add a `getTestPatient(profile)` helper reading `test-patients.json`
+- [ ] Update `compartment.screenshot.spec.ts` to exercise all 4 profiles
+- [ ] Add assertions in `allergy-intolerance-patient-filter.spec.ts` for Hobert (1 allergy)
+  and Ada (0 allergies from live server — empty state)
+- [ ] Add `e2e/patient-profiles.spec.ts`: visit each profile patient, assert correct
+  compartment tabs are present/absent
 
 ---
 
@@ -175,21 +159,19 @@ schedule: cron '0 6 * * 1'   # Monday 06:00 UTC, after HAPI's Sunday reset
 
 | Risk | Likelihood | Mitigation |
 |---|---|---|
-| SMART Health IT corpus resets, changing patient IDs | Low | Re-run discovery script; update `test-patients.json`; pin to a version-stamped snapshot if it becomes recurring |
-| HAPI public changes reset schedule | Medium | Seed workflow detects missing patients on every run and re-seeds on any Monday; can also be triggered manually |
-| Synthea-generated data too voluminous (>500 resources per patient) | Low | Trim Transaction bundle to the resource types the app renders; strip ExplanationOfBenefit and DocumentReference unless explicitly needed |
-| Weekly seed job fails silently | Low | Workflow opens a GitHub issue on failure; add to the same nightly alert channel as the live-site monitor |
-| Deterministic UUIDs clash with other users' HAPI data | Very low | UUIDs are SHA-256–derived from `fhir-place/test/<profile>` namespace — astronomically unlikely to collide |
+| SMART Health IT corpus resets, changing patient IDs | Low | Re-run `discover-test-patients` workflow; update `test-patients.json` |
+| AllergyIntolerance data too sparse for meaningful tests | Medium | Hobert has 1 AI resource; a targeted search would find richer candidates if needed |
+| Pediatric path untested on live server | Medium | Targeted query for young patients post-discovery; or rely on MSW fixture for that path |
+| HAPI public rate limits worsen | N/A | HAPI public dropped as server 2 for rich patient data |
 
 ---
 
 ## Open questions for human decision
 
-1. **Private HAPI vs. public HAPI** — should we provision a project-owned HAPI instance
-   (e.g. fly.io free tier) to eliminate the weekly re-seed overhead? Would make tests
-   simpler and more reliable at the cost of owning infra.
-2. **Medplum as a second server** — the interop matrix already documents Medplum. Should
-   the test patients also be seeded there, replacing HAPI as Server 2? Medplum's
-   project-scoped auth means seeds survive indefinitely.
-3. **P4 sparse patient** — should it be truly empty (only name), or should it have 1–2
-   resources in one compartment only (to test single-item lists without empty states)?
+1. **Server 2 choice** — local HAPI Docker (seed once, stable per container) or Medplum
+   sandbox (stable indefinitely, requires bearer token)? HAPI public is confirmed
+   unsuitable for rich patient fixtures.
+2. **AllergyIntolerance coverage** — Hobert has only 1 AI resource. Is that enough, or
+   should we run a targeted discovery search for a patient with 3–5 allergies?
+3. **Pediatric profile** — is it in scope? If yes, a targeted `/Patient?birthdate=gt2010`
+   query on SMART Health IT is the next step.

--- a/scripts/discover-test-patients.mjs
+++ b/scripts/discover-test-patients.mjs
@@ -11,6 +11,11 @@
  *   SERVER2=https://hapi.fhir.org/baseR4 \
  *   SAMPLE=40 \
  *     node scripts/discover-test-patients.mjs
+ *
+ * PATIENT_QUERY narrows the patient pool (filters appended to /Patient).
+ * Examples:
+ *   PATIENT_QUERY='birthdate=gt2010-01-01'                    # pediatric
+ *   PATIENT_QUERY='_has:AllergyIntolerance:patient:_id:exists=true'  # has allergies
  */
 
 const SERVERS = [
@@ -30,9 +35,10 @@ const COMPARTMENT_TYPES = [
   "CarePlan",
 ];
 
-const SAMPLE_SIZE = parseInt(process.env.SAMPLE ?? "40", 10);
-const TOP_N       = parseInt(process.env.TOP    ?? "4",  10);
-const CONCURRENCY = 6;
+const SAMPLE_SIZE   = parseInt(process.env.SAMPLE ?? "40", 10);
+const TOP_N         = parseInt(process.env.TOP    ?? "4",  10);
+const CONCURRENCY   = 6;
+const PATIENT_QUERY = (process.env.PATIENT_QUERY ?? "").trim();
 
 async function fhirGet(url) {
   const res = await fetch(url, {
@@ -70,7 +76,8 @@ async function pool(tasks, concurrency) {
 
 async function fetchPatientIds(base, count) {
   const ids = [];
-  let url = `${base}/Patient?_count=${count}`;
+  const filter = PATIENT_QUERY ? `&${PATIENT_QUERY}` : "";
+  let url = `${base}/Patient?_count=${count}${filter}`;
   while (url && ids.length < count) {
     const bundle = await fhirGet(url);
     for (const e of bundle.entry ?? []) {
@@ -103,6 +110,7 @@ function patientLabel(p) {
 async function scoreServer(server) {
   console.log(`\n${"═".repeat(60)}`);
   console.log(`Server: ${server.name}  (${server.url})`);
+  if (PATIENT_QUERY) console.log(`Filter: ${PATIENT_QUERY}`);
   console.log("═".repeat(60));
 
   console.log(`Fetching up to ${SAMPLE_SIZE} patients…`);


### PR DESCRIPTION
## Summary

- Records the 4 test patients chosen from the `workflow_dispatch` discovery run on 2026-05-03
- Adds `apps/demo/src/mocks/test-patients.json` with stable IDs, resource counts, and per-patient notes
- Updates `docs/test-patient-strategy.md`: marks Phase 1 complete, updates server assessment, revises open questions

## What was found

**SMART Health IT** — excellent. Top 4 from a 40-patient sample:

| Patient | Resources | Breadth | Key feature |
|---|---|---|---|
| Coleman Ortiz (`5fd069dc`) | 578 | 8/9 | 414 Observations, 39 DiagnosticReports |
| Hallie Hoeger (`c34852c9`) | 498 | 8/9 | 55 MedicationRequests, 71 Encounters |
| Emilee Ritchie (`9823384d`) | 493 | 8/9 | 12 Immunizations, 321 Observations |
| Hobert Murazik (`d4f1aab1`) | 402 | **9/9** | Only patient with AllergyIntolerance |

**HAPI public** — confirmed unsuitable. 429 rate-limiting corrupted counts for nearly all patients; the data that got through was trivially sparse (same person, max 10 resources, breadth ≤ 2/9).

## Open questions still needing a decision

1. **Server 2** — local HAPI Docker (seed-once, per-container) or Medplum sandbox?
2. **AllergyIntolerance depth** — Hobert has 1 AI record. Enough, or run a targeted search?
3. **Pediatric profile** — in scope? If yes, a `/Patient?birthdate=gt2010` query is next.

## Test plan

- [ ] Review the 4 chosen patients in `test-patients.json` — confirm they match your intended profiles
- [ ] Decide on server 2 so Phase 2 can begin

https://claude.ai/code/session_01BY7q7MZaBbxXhFxjguPUtm

---
_Generated by [Claude Code](https://claude.ai/code/session_01BY7q7MZaBbxXhFxjguPUtm)_