### PR TITLE
test: default integration suite to SMART Health IT instead of HAPI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,8 +1,8 @@
-name: Integration tests (live HAPI)
+name: Integration tests (live FHIR)
 
 on:
   schedule:
-    # 05:00 UTC nightly — catches HAPI protocol drift without blocking daytime merges.
+    # 05:00 UTC nightly — catches protocol drift without blocking daytime merges.
     - cron: "0 5 * * *"
   push:
     branches:
@@ -12,7 +12,7 @@ on:
       fhir_base_url:
         description: "FHIR server base URL to target"
         required: false
-        default: "https://hapi.fhir.org/baseR4"
+        default: "https://r4.smarthealthit.org"
 
 permissions:
   contents: read
@@ -25,10 +25,11 @@ concurrency:
 jobs:
   integration:
     runs-on: ubuntu-latest
-    # Public HAPI can be flaky. The job should surface failures clearly in the
-    # Actions tab without forcing anyone to babysit it. continue-on-error is
-    # NOT set because we *do* want a red square when HAPI is genuinely broken
-    # — the nightly schedule means it's not blocking human work.
+    # The public live server can be flaky. The job should surface failures
+    # clearly in the Actions tab without forcing anyone to babysit it.
+    # continue-on-error is NOT set because we *do* want a red square when the
+    # server is genuinely broken — the nightly schedule means it's not
+    # blocking human work.
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -41,7 +42,7 @@ jobs:
       - name: Run integration suite against live FHIR server
         id: integration
         env:
-          FHIR_BASE_URL: ${{ inputs.fhir_base_url || 'https://hapi.fhir.org/baseR4' }}
+          FHIR_BASE_URL: ${{ inputs.fhir_base_url || 'https://r4.smarthealthit.org' }}
           SKIP_IF_UNREACHABLE: "1"
         run: pnpm --filter @fhir-place/react-fhir exec vitest run --config vitest.integration.config.ts --reporter=default --reporter=json --outputFile=test-results/integration-results.json
         continue-on-error: true

--- a/packages/react-fhir/integration/FhirClient.integration.test.ts
+++ b/packages/react-fhir/integration/FhirClient.integration.test.ts
@@ -27,7 +27,7 @@ describe.skipIf(!reachable)(`integration: FhirClient @ ${FHIR_BASE_URL}`, () => 
   const cleanup: Array<{ type: string; id: string }> = [];
 
   afterAll(async () => {
-    // Best-effort cleanup; HAPI may have wiped them already.
+    // Best-effort cleanup; the server may have wiped them already.
     await Promise.allSettled(
       cleanup.map(({ type, id }) => client.delete(type, id).catch(() => {})),
     );
@@ -120,7 +120,7 @@ describe.skipIf(!reachable)(`integration: FhirClient @ ${FHIR_BASE_URL}`, () => 
       await client.delete("Patient", created.id!);
       cleanup.pop(); // already removed
 
-      // read after delete — HAPI returns 404 or 410; either is acceptable
+      // read after delete — FHIR servers return 404 or 410; either is acceptable
       const err = await client
         .read<Patient>("Patient", created.id!)
         .catch((e) => e);
@@ -260,8 +260,8 @@ describe.skipIf(!reachable)(`integration: FhirClient @ ${FHIR_BASE_URL}`, () => 
   test(
     "ValueSet/$expand on administrative-gender returns codes including 'female' (#29)",
     async () => {
-      // useValueSet's first-step lookup. Real HAPI exposes $expand for the
-      // core R4 ValueSets — if this regresses we want to know.
+      // useValueSet's first-step lookup. Public test servers expose $expand
+      // for the core R4 ValueSets — if this regresses we want to know.
       const url = "http://hl7.org/fhir/ValueSet/administrative-gender";
       const vs = await client.request<ValueSet>({
         path: `/ValueSet/$expand?url=${encodeURIComponent(url)}`,
@@ -270,7 +270,7 @@ describe.skipIf(!reachable)(`integration: FhirClient @ ${FHIR_BASE_URL}`, () => 
       const codes = codesFromValueSet(vs).map((c) => c.code);
       expect(codes).toContain("female");
       expect(codes).toContain("male");
-      // sanity: codesFromValueSet handled whatever shape HAPI returned
+      // sanity: codesFromValueSet handled whatever shape the server returned
       expect(codes.length).toBeGreaterThanOrEqual(2);
     },
     30_000,
@@ -285,13 +285,13 @@ describe.skipIf(!reachable)(`integration: FhirClient @ ${FHIR_BASE_URL}`, () => 
       const url = "http://hl7.org/fhir/ValueSet/goal-status";
       const bundle = await client.search<ValueSet>("ValueSet", { url });
       const vs = bundle.entry?.[0]?.resource;
-      // HAPI might not have this VS at all; tolerate that by skipping the
-      // assertion rather than failing — the fallback chain in useValueSet
+      // The server might not have this VS at all; tolerate that by skipping
+      // the assertion rather than failing — the fallback chain in useValueSet
       // ends at the bundled core copy when the server has neither.
       if (!vs) {
         // eslint-disable-next-line no-console
         console.warn(
-          `[integration] HAPI returned no ValueSet for ${url}; skipping fallback assertions.`,
+          `[integration] server returned no ValueSet for ${url}; skipping fallback assertions.`,
         );
         return;
       }
@@ -328,7 +328,7 @@ describe.skipIf(!reachable)(`integration: FhirClient @ ${FHIR_BASE_URL}`, () => 
       const seen = new Set<string>();
       let nextUrl: string | undefined = undefined;
       let pages = 0;
-      const MAX_PAGES = 10; // hard cap on the loop in case HAPI never stops
+      const MAX_PAGES = 10; // hard cap on the loop in case the server never stops
 
       do {
         const bundle: Bundle<Patient> = nextUrl
@@ -345,15 +345,15 @@ describe.skipIf(!reachable)(`integration: FhirClient @ ${FHIR_BASE_URL}`, () => 
       } while (nextUrl && pages < MAX_PAGES);
 
       // We should have walked ≥ 3 pages (25 / 10 = 3) and recovered every
-      // tagged Patient. Use intersection rather than equality because HAPI
-      // is shared — other test runs may have used the same _id but never
-      // the same _tag, so this set is exclusive to us.
+      // tagged Patient. Use intersection rather than equality because the
+      // server is shared — other test runs may have used the same _id but
+      // never the same _tag, so this set is exclusive to us.
       expect(pages).toBeGreaterThanOrEqual(3);
       for (const id of expectedIds) {
         expect(seen.has(id), `missing ${id} after pagination`).toBe(true);
       }
     },
-    180_000, // 25 creates + 3 pages on shared HAPI can be slow
+    180_000, // 25 creates + 3 pages on a shared public server can be slow
   );
 
   test(

--- a/packages/react-fhir/integration/README.md
+++ b/packages/react-fhir/integration/README.md
@@ -1,6 +1,6 @@
 # Integration tests
 
-These tests run against a **live FHIR server** (public HAPI R4 by default) to
+These tests run against a **live FHIR server** (SMART Health IT R4 by default) to
 catch protocol / shape mismatches that MSW-mocked unit tests can't see.
 
 They're excluded from the default `pnpm test` run and only execute when
@@ -14,29 +14,31 @@ pnpm --filter @fhir-place/react-fhir test:integration
 
 | env var           | default                              | purpose                                               |
 | ----------------- | ------------------------------------ | ----------------------------------------------------- |
-| `FHIR_BASE_URL`   | `https://hapi.fhir.org/baseR4`       | target server                                         |
+| `FHIR_BASE_URL`   | `https://r4.smarthealthit.org`       | target server                                         |
 | `SKIP_IF_UNREACHABLE` | `1`                              | skip the whole suite if `/metadata` 5xx's or times out |
+
+To run against HAPI public instead, set `FHIR_BASE_URL=https://hapi.fhir.org/baseR4`.
 
 ## CI
 
 A dedicated workflow (`.github/workflows/integration.yml`) runs these tests:
 
-- nightly at 05:00 UTC (so public-HAPI hiccups don't block day-time merges)
+- nightly at 05:00 UTC (so live-server hiccups don't block day-time merges)
 - on every push to `main`
 - on manual dispatch via the Actions tab
 
 PRs intentionally skip this suite. A broken protocol assumption should fail
-post-merge via the nightly run, not block unrelated PRs on HAPI downtime.
+post-merge via the nightly run, not block unrelated PRs on live-server downtime.
 
 ## Writing new integration tests
 
 - Every create uses `crypto.randomUUID()` in `identifier[0].value` so the
   resource is unique per test run. Searches filter by that identifier.
-- Clean up in `afterAll` (best-effort `delete`; ignore errors — HAPI may
-  already have wiped the resource).
+- Clean up in `afterAll` (best-effort `delete`; ignore errors — the server
+  may have wiped the resource already).
 - Default per-test timeout is 30 s; give CRUD roundtrips 60 s.
-- Never assert on pre-existing data — HAPI's public instance is reset
-  periodically.
+- Never assert on pre-existing data — the public corpus on SMART can be
+  refreshed without notice.
 - Stop-the-bleed policy: when fixing a production bug or server-contract
   regression, add or extend an integration test in the same PR so the failure
   mode is pinned and cannot silently reappear.

--- a/packages/react-fhir/integration/helpers.ts
+++ b/packages/react-fhir/integration/helpers.ts
@@ -2,7 +2,7 @@ import { FetchFhirClient } from "../src/client/FetchFhirClient.js";
 import { FhirError } from "../src/client/types.js";
 
 export const FHIR_BASE_URL =
-  process.env.FHIR_BASE_URL ?? "https://hapi.fhir.org/baseR4";
+  process.env.FHIR_BASE_URL ?? "https://r4.smarthealthit.org";
 
 /** Identifier system we use for every test resource, so we can find and clean up. */
 export const TEST_IDENTIFIER_SYSTEM = "https://fhir-place.dev/test";
@@ -14,7 +14,7 @@ export const makeClient = () =>
  * Probes the target server with a short-timeout metadata call. When
  * `SKIP_IF_UNREACHABLE` is truthy and the probe fails, we return false so the
  * suite can `describe.skip` itself and avoid polluting CI with flakes caused
- * by HAPI being temporarily down.
+ * by the live server being temporarily down.
  */
 export async function serverReachable(): Promise<boolean> {
   if (process.env.SKIP_IF_UNREACHABLE === "0") return true;


### PR DESCRIPTION
## Summary

- Switches the live-FHIR integration suite default from `https://hapi.fhir.org/baseR4` to `https://r4.smarthealthit.org`
- HAPI public is severely rate-limited and its public bucket is sparse (discovered while building `test-patients.json`). SMART Health IT serves a stable Synthea-generated corpus
- The integration tests' design (random identifiers + cleanup-after) doesn't depend on which server is hit, only that it's a conformant R4 server — no test logic changes needed

## Changes

- [packages/react-fhir/integration/helpers.ts](packages/react-fhir/integration/helpers.ts) — default \`FHIR_BASE_URL\`
- [.github/workflows/integration.yml](.github/workflows/integration.yml) — default \`fhir_base_url\` input, workflow name, comments
- [packages/react-fhir/integration/README.md](packages/react-fhir/integration/README.md) — documents the new default and how to fall back to HAPI
- [FhirClient.integration.test.ts](packages/react-fhir/integration/FhirClient.integration.test.ts) — genericizes HAPI-specific phrasing in comments only

To run the suite against HAPI instead, set \`FHIR_BASE_URL=https://hapi.fhir.org/baseR4\`.

## Test plan

- [ ] Watch the next nightly integration workflow run (or trigger manually) — should still pass against SMART
- [ ] Confirm \`pnpm --filter @fhir-place/react-fhir test:integration\` works locally pointed at SMART

https://claude.ai/code/session_01BY7q7MZaBbxXhFxjguPUtm