### PR TITLE
fix: render Observation value cells for non-Quantity choice variants

### DIFF
--- a/apps/demo/src/compartment.ts
+++ b/apps/demo/src/compartment.ts
@@ -47,12 +47,12 @@ export const PATIENT_COMPARTMENT: Array<
   {
     resourceType: "Observation",
     title: "Observations",
-    columns: ["status", "code", "effectiveDateTime", "valueQuantity"],
+    columns: ["status", "code", "effectiveDateTime", "value[x]"],
     columnLabels: {
       status: "Status",
       code: "Observation",
       effectiveDateTime: "Observed",
-      valueQuantity: "Value",
+      "value[x]": "Value",
     },
   },
   {

--- a/packages/react-fhir/src/components/ResourceTable.test.tsx
+++ b/packages/react-fhir/src/components/ResourceTable.test.tsx
@@ -234,6 +234,50 @@ describe("ResourceTable", () => {
     expect(within(rows[1]!).queryByText(/"coding":/)).not.toBeInTheDocument();
   });
 
+  it("strips array indices when resolving choice variants on nested paths", () => {
+    // Indexed-component observation: `component[0].value[x]` has an array
+    // index in the runtime path, but StructureDefinition element paths don't
+    // (`Observation.component.value[x]`). Without stripping the index before
+    // findChoiceVariant, the SD lookup misses and resolvedTypeCode falls back
+    // to the header-time default — which for `value[x]` is the first declared
+    // variant (Quantity). A CodeableConcept variant would then dispatch to
+    // QuantityRenderer and render blank. Use a CodeableConcept value here so
+    // this test would fail without index normalisation.
+    const observation: Observation = {
+      resourceType: "Observation",
+      id: "o1",
+      status: "final",
+      code: { text: "Lab panel" },
+      component: [
+        {
+          code: { text: "Result" },
+          valueCodeableConcept: {
+            coding: [
+              { system: "http://snomed.info/sct", code: "260385009", display: "Negative" },
+            ],
+            text: "Negative",
+          },
+        },
+      ],
+    };
+    render(
+      <ResourceTable<Observation>
+        resources={[observation]}
+        columns={["code.text", "component[0].value[x]"]}
+        columnLabels={{
+          "code.text": "Observation",
+          "component[0].value[x]": "Result",
+        }}
+        structureDefinition={ObservationStructureDefinition}
+      />,
+      { wrapper: wrap() },
+    );
+    const row = screen.getByTestId("resource-row");
+    // CodeableConceptRenderer surfaces "Negative". The Quantity fallback
+    // would render an empty <span> here (no .value/.unit on a CodeableConcept).
+    expect(within(row).getByText(/Negative/)).toBeInTheDocument();
+  });
+
   it("renders a card layout on narrow viewports (layout=cards)", () => {
     render(
       <ResourceTable<Patient>

--- a/packages/react-fhir/src/components/ResourceTable.test.tsx
+++ b/packages/react-fhir/src/components/ResourceTable.test.tsx
@@ -195,6 +195,45 @@ describe("ResourceTable", () => {
     expect(within(row).queryByText(/"value":/)).not.toBeInTheDocument();
   });
 
+  it("resolves value[x] per-row to the materialised choice variant", () => {
+    const heartRate: Observation = {
+      resourceType: "Observation",
+      id: "o1",
+      status: "final",
+      code: { text: "Heart rate" },
+      valueQuantity: { value: 72, unit: "beats/minute" },
+    };
+    const smoking: Observation = {
+      resourceType: "Observation",
+      id: "o2",
+      status: "final",
+      code: { text: "Tobacco smoking status NHIS" },
+      valueCodeableConcept: {
+        coding: [
+          { system: "http://snomed.info/sct", code: "266919005", display: "Never smoker" },
+        ],
+        text: "Never smoker",
+      },
+    };
+    render(
+      <ResourceTable<Observation>
+        resources={[heartRate, smoking]}
+        columns={["code.text", "value[x]"]}
+        columnLabels={{ "code.text": "Observation", "value[x]": "Value" }}
+        structureDefinition={ObservationStructureDefinition}
+      />,
+      { wrapper: wrap() },
+    );
+    const rows = screen.getAllByTestId("resource-row");
+    // Quantity variant dispatches to QuantityRenderer.
+    expect(within(rows[0]!).getByText(/72/)).toBeInTheDocument();
+    expect(within(rows[0]!).getByText(/beats\/minute/)).toBeInTheDocument();
+    // CodeableConcept variant dispatches to CodeableConceptRenderer (text "Never smoker"),
+    // not the raw JSON fallback.
+    expect(within(rows[1]!).getByText(/Never smoker/)).toBeInTheDocument();
+    expect(within(rows[1]!).queryByText(/"coding":/)).not.toBeInTheDocument();
+  });
+
   it("renders a card layout on narrow viewports (layout=cards)", () => {
     render(
       <ResourceTable<Patient>

--- a/packages/react-fhir/src/components/ResourceTable.tsx
+++ b/packages/react-fhir/src/components/ResourceTable.tsx
@@ -66,16 +66,40 @@ export function getByPath(obj: unknown, path: string): unknown {
   for (const segment of path.split(".")) {
     if (cur === null || cur === undefined) return undefined;
     // Support "coding[0]" segments by resolving the index separately.
-    const match = segment.match(/^(\w+)\[(\d+)\]$/);
-    if (match) {
-      cur = (cur as Record<string, unknown>)[match[1]!];
-      if (Array.isArray(cur)) cur = cur[Number(match[2])];
-    } else {
-      cur = (cur as Record<string, unknown>)[segment];
-      if (Array.isArray(cur)) cur = cur[0]; // auto-pick first item for non-indexed segments
+    const indexMatch = segment.match(/^(\w+)\[(\d+)\]$/);
+    if (indexMatch) {
+      cur = (cur as Record<string, unknown>)[indexMatch[1]!];
+      if (Array.isArray(cur)) cur = cur[Number(indexMatch[2])];
+      continue;
     }
+    // Support choice segments like "value[x]" — pick the materialised key
+    // (e.g. valueQuantity, valueCodeableConcept) actually present on the object.
+    if (segment.endsWith("[x]")) {
+      const base = segment.slice(0, -3);
+      const key = resolveChoiceKey(cur, base);
+      cur = key ? (cur as Record<string, unknown>)[key] : undefined;
+      if (Array.isArray(cur)) cur = cur[0];
+      continue;
+    }
+    cur = (cur as Record<string, unknown>)[segment];
+    if (Array.isArray(cur)) cur = cur[0]; // auto-pick first item for non-indexed segments
   }
   return cur;
+}
+
+function resolveChoiceKey(obj: unknown, base: string): string | undefined {
+  if (!obj || typeof obj !== "object") return undefined;
+  for (const key of Object.keys(obj)) {
+    if (
+      key.length > base.length &&
+      key.startsWith(base) &&
+      key[base.length] === key[base.length]!.toUpperCase() &&
+      key[base.length] !== key[base.length]!.toLowerCase()
+    ) {
+      return key;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -213,6 +237,8 @@ export function ResourceTable<T extends Resource = Resource>({
                         cellRenderers,
                         renderers,
                         onReferenceClick,
+                        sd,
+                        resourceType,
                       })}
                     </td>
                   </Fragment>
@@ -269,6 +295,8 @@ export function ResourceTable<T extends Resource = Resource>({
                       cellRenderers,
                       renderers,
                       onReferenceClick,
+                      sd,
+                      resourceType,
                     })}
                   </dd>
                 </Fragment>
@@ -307,6 +335,8 @@ interface RenderCellParams<T extends Resource> {
   cellRenderers?: Record<string, (r: T) => ReactNode>;
   renderers: TypeRenderers;
   onReferenceClick?: (ref: Reference) => void;
+  sd: StructureDefinition | undefined;
+  resourceType: string;
 }
 
 function renderCell<T extends Resource>({
@@ -316,6 +346,8 @@ function renderCell<T extends Resource>({
   cellRenderers,
   renderers,
   onReferenceClick,
+  sd,
+  resourceType,
 }: RenderCellParams<T>): ReactNode {
   const custom = cellRenderers?.[path];
   if (custom) return custom(resource);
@@ -325,13 +357,27 @@ function renderCell<T extends Resource>({
     return <span className="text-[var(--text-subtle)]">—</span>;
   }
 
+  // For choice paths (e.g. `value[x]`), the concrete variant is per-row, so the
+  // typeCode resolved at header time is just the `[x]` element. Re-resolve
+  // against the materialised key actually present on this resource.
+  let resolvedTypeCode = typeCode;
+  let resolvedPath = path;
+  if (sd && path.includes("[x]")) {
+    const concrete = resolveConcreteChoicePath(resource, path);
+    if (concrete) {
+      resolvedPath = concrete;
+      const variant = findChoiceVariant(sd, `${resourceType}.${concrete}`);
+      if (variant?.typeCode) resolvedTypeCode = variant.typeCode;
+    }
+  }
+
   const ctx: RendererContext = {
-    path,
-    typeCode,
+    path: resolvedPath,
+    typeCode: resolvedTypeCode,
     ...(onReferenceClick ? { onReferenceClick } : {}),
   };
 
-  const renderer = typeCode ? renderers[typeCode] : undefined;
+  const renderer = resolvedTypeCode ? renderers[resolvedTypeCode] : undefined;
   if (renderer) return <>{renderer(value, ctx)}</>;
 
   // Fallback for unknown types or plain primitives.
@@ -343,4 +389,32 @@ function renderCell<T extends Resource>({
       {JSON.stringify(value).slice(0, 60)}
     </code>
   );
+}
+
+/** Walk `path` against `resource`, replacing each `name[x]` segment with the
+ *  materialised key (e.g. `valueCodeableConcept`) actually present. */
+function resolveConcreteChoicePath(resource: unknown, path: string): string | undefined {
+  let cur: unknown = resource;
+  const out: string[] = [];
+  for (const segment of path.split(".")) {
+    if (cur === null || cur === undefined) return undefined;
+    if (segment.endsWith("[x]")) {
+      const base = segment.slice(0, -3);
+      const key = resolveChoiceKey(cur, base);
+      if (!key) return undefined;
+      out.push(key);
+      cur = (cur as Record<string, unknown>)[key];
+    } else {
+      const indexMatch = segment.match(/^(\w+)\[(\d+)\]$/);
+      if (indexMatch) {
+        cur = (cur as Record<string, unknown>)[indexMatch[1]!];
+        if (Array.isArray(cur)) cur = cur[Number(indexMatch[2])];
+      } else {
+        cur = (cur as Record<string, unknown>)[segment];
+        if (Array.isArray(cur)) cur = cur[0];
+      }
+      out.push(segment);
+    }
+  }
+  return out.join(".");
 }

--- a/packages/react-fhir/src/components/ResourceTable.tsx
+++ b/packages/react-fhir/src/components/ResourceTable.tsx
@@ -366,7 +366,12 @@ function renderCell<T extends Resource>({
     const concrete = resolveConcreteChoicePath(resource, path);
     if (concrete) {
       resolvedPath = concrete;
-      const variant = findChoiceVariant(sd, `${resourceType}.${concrete}`);
+      // Strip array indices (`component[1]`, `name.0`) before the SD lookup —
+      // StructureDefinition element paths don't carry indices, so leaving them
+      // in causes findChoiceVariant to miss and fall back to the header-time
+      // typeCode (often the wrong choice variant).
+      const cleaned = concrete.replace(/\[\d+\]/g, "").replace(/\.\d+(?=\.|$)/g, "");
+      const variant = findChoiceVariant(sd, `${resourceType}.${cleaned}`);
       if (variant?.typeCode) resolvedTypeCode = variant.typeCode;
     }
   }


### PR DESCRIPTION
## Summary

- Observation compartment table's Value column was pinned to `valueQuantity`, so rows using a different `value[x]` variant (e.g. CodeableConcept for smoking-status surveys) rendered as "—" despite having data.
- Switched the column path to `value[x]` and taught `ResourceTable` to resolve choice paths per-row: `getByPath` picks whichever materialised key is present, and `renderCell` re-resolves `typeCode` against the concrete variant so each row dispatches to the matching renderer (Quantity / CodeableConcept / etc.) instead of the JSON fallback.
- Filed #232 to track the same hard-pinning pattern in other compartment columns (`Condition.onset[x]`, `MedicationRequest.medication[x]`, `Procedure.performed[x]`, `Immunization.occurrence[x]`).

## Test plan

- [x] `pnpm --filter @fhir-place/react-fhir test --run ResourceTable` — 20/20 pass (added regression test covering both `valueQuantity` and `valueCodeableConcept` rows in the same table).
- [x] `pnpm --filter @fhir-place/react-fhir typecheck` and `pnpm --filter @fhir-place/demo typecheck` clean.
- [ ] `pnpm --filter @fhir-place/demo e2e` — re-snapshot patient-compartment screenshots if previously-blank cells now show values.
- [ ] Manual: load a patient with a smoking-status (or other non-Quantity) Observation and confirm the Value cell renders the coded display text instead of "—".

🤖 Generated with [Claude Code](https://claude.com/claude-code)