### PR TITLE
PM cleanup: label conventions + daily triage automation

### DIFF
--- a/.github/workflows/daily-pm-triage.yml
+++ b/.github/workflows/daily-pm-triage.yml
@@ -1,0 +1,52 @@
+# Runs the PM triage prompt daily on the open-issue backlog.
+# See docs/prompts/daily-pm-triage.md for what the agent does.
+#
+# Setup required (one-time):
+#   1. Add ANTHROPIC_API_KEY to repo secrets (Settings → Secrets → Actions).
+#   2. Merge this workflow.
+#   3. Manually trigger once via Actions → "Daily PM triage" → "Run workflow"
+#      to confirm permissions are right and the report issue gets created.
+
+name: Daily PM triage
+
+on:
+  schedule:
+    # 07:00 UTC daily — runs after live-site-monitor (06:30 UTC) so any
+    # bot-filed issues from this morning are included in today's pass.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: daily-pm-triage
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Claude Code with the daily-pm-triage prompt
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # The action's built-in MCP setup gives Claude the GitHub MCP tools
+          # using GITHUB_TOKEN. The prompt explicitly tells the agent not to
+          # touch files or open PRs — this is GitHub-state-only.
+          prompt_file: docs/prompts/daily-pm-triage.md
+          allowed_tools: |
+            mcp__github__list_issues
+            mcp__github__issue_read
+            mcp__github__issue_write
+            mcp__github__add_issue_comment
+            mcp__github__list_pull_requests
+            mcp__github__pull_request_read
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/live-site-monitor.yml
+++ b/.github/workflows/live-site-monitor.yml
@@ -111,7 +111,7 @@ jobs:
             }
 
             for (const g of grouped.values()) {
-              const issueTitle = `[demo] ${g.title}`;
+              const issueTitle = g.title;
               const body = [
                 `**Failed in run:** ${runUrl}`,
                 `**Affected projects:** ${g.projects.join(', ')}`,
@@ -149,7 +149,7 @@ jobs:
                   repo: context.repo.repo,
                   title: issueTitle,
                   body,
-                  labels: ['bug', 'live-monitor'],
+                  labels: ['type: bug', 'area: fhir-explorer', 'origin: bot-filed'],
                 });
               }
             }

--- a/.github/workflows/live-site-monitor.yml
+++ b/.github/workflows/live-site-monitor.yml
@@ -127,9 +127,11 @@ jobs:
                 '_This issue was opened automatically by `.github/workflows/live-site-monitor.yml`. If the test passes on a future run, this issue will be commented on, not closed — close it manually once the underlying bug is fixed._',
               ].join('\n');
 
-              // Dedupe: search for an open issue with the same title.
+              // Dedupe: search for an open bot-filed issue with the same title.
+              // Scoping to the origin label prevents accidental collisions with
+              // human-filed issues that happen to share a title.
               const existing = await github.rest.search.issuesAndPullRequests({
-                q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${issueTitle}"`,
+                q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${issueTitle}" label:"origin: bot-filed"`,
                 per_page: 5,
               });
               const match = existing.data.items.find((i) => i.title === issueTitle);
@@ -149,7 +151,7 @@ jobs:
                   repo: context.repo.repo,
                   title: issueTitle,
                   body,
-                  labels: ['type: bug', 'area: fhir-explorer', 'origin: bot-filed'],
+                  labels: ['type: bug', 'area: fhir-explorer', 'priority: high', 'origin: bot-filed'],
                 });
               }
             }

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,44 @@
+# Bootstrap and maintain the canonical label set defined in
+# scripts/sync-labels.mjs. Runs on push to main when the script changes,
+# and via manual workflow_dispatch (for the post-merge bootstrap).
+
+name: Sync labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/sync-labels.mjs'
+      - '.github/workflows/sync-labels.yml'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (log only, no changes)'
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: sync-labels
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Sync labels
+        run: node scripts/sync-labels.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run && '1' || '' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,30 @@ Keep these in mind when making changes:
 - Integration tests target a real FHIR server and live in `packages/react-fhir/integration/`. Default target is public HAPI; override with `FHIR_BASE_URL`.
 - Playwright e2e lives in `apps/demo/e2e/`. Screenshots go in `screenshots/` and get committed.
 
+## Issue & label conventions
+
+GitHub Issues are the canonical backlog (see `docs/decisions/0001-use-github-issues-as-source-of-truth.md`). To keep them scannable, every open issue should carry one `type:`, at least one `area:`, and one `priority:` label. Other prefixes are optional.
+
+**Title convention:** plain, declarative, no `[bracket]` prefixes — labels carry the type / area signal.
+
+**Label vocabulary:**
+
+| Prefix | Cardinality | Values | Meaning |
+| --- | --- | --- | --- |
+| `type:` | exactly one | `bug`, `feature`, `tech-debt`, `docs`, `spike`, `epic` | What kind of work this is. `epic` = tracker for sub-issues. `spike` = time-boxed exploration. |
+| `area:` | one or more | `fhir-explorer`, `react-fhir`, `workbench`, `cql`, `mcp`, `infra`, `auth`, `security` | Which part of the codebase is touched. `fhir-explorer` is the demo app at `apps/demo/` (legacy names: "demo", "fhir-ui", "live-monitor"). `react-fhir` is the published library at `packages/react-fhir/`. |
+| `priority:` | exactly one | `high`, `medium`, `low` | Triage signal. Bugs default to `high`. Spikes / nice-to-haves default to `low`. Default `medium`. |
+| `status:` | optional | `blocked`, `needs-triage` | Workflow state. Use sparingly. |
+| `origin:` | optional | `bot-filed` | Filed by automation (e.g. `live-site-monitor.yml`). |
+| `phase-N` | optional | `phase-0`..`phase-3`, `fhir-workbench-phase-a` | Multi-phase epic tracking. Keep as plain (no prefix) for grep-ability. |
+
+**When you open an issue:**
+- Pick exactly one `type:`, at least one `area:`, exactly one `priority:`.
+- Skip `status:` / `origin:` unless they apply.
+- No `[bracket]` in the title — write it as a sentence.
+
+**Renaming `apps/demo/`:** the directory and package will move to `apps/fhir-explorer/` (`@fhir-place/fhir-explorer`). Until that lands, code paths still say `demo`; the label and conversational name is `fhir-explorer`.
+
 ## Questions?
 
 Open an issue. We're pre-1.0, so preferences and defaults are still moving.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,8 @@ GitHub Issues are the canonical backlog (see `docs/decisions/0001-use-github-iss
 
 **Renaming `apps/demo/`:** the directory and package will move to `apps/fhir-explorer/` (`@fhir-place/fhir-explorer`). Until that lands, code paths still say `demo`; the label and conversational name is `fhir-explorer`.
 
+**Automation:** the canonical label set is managed by `scripts/sync-labels.mjs` and re-applied on every push to `main` via `.github/workflows/sync-labels.yml`. A daily cron (`.github/workflows/daily-pm-triage.yml`) runs the prompt at `docs/prompts/daily-pm-triage.md` to label new issues, strip bracket prefixes, dedup bot-filed bugs, close finished epics, and post a rolling daily report.
+
 ## Questions?
 
 Open an issue. We're pre-1.0, so preferences and defaults are still moving.

--- a/docs/prompts/daily-pm-triage.md
+++ b/docs/prompts/daily-pm-triage.md
@@ -1,0 +1,165 @@
+# Daily PM triage prompt
+
+This prompt runs daily on a cron and keeps the GitHub-issues backlog
+clean per the conventions in `CONTRIBUTING.md` ("Issue & label
+conventions"). It does the work a human PM would otherwise do
+on a Monday morning — labeling new issues, stripping bracketed titles,
+deduping bot-filed bugs, closing finished epics, and surfacing stale items.
+
+The agent is **aggressive** by design (per ADR 0003 + the choice on
+PR #244): it edits issue state directly. The single rolling report
+issue is your audit trail.
+
+---
+
+## Your task
+
+You are the PM for `samsuffolksperoni/fhir-place`. Use the GitHub MCP
+tools (`mcp__github__*`) to read and write issues. Do **not** open a
+git branch or PR — this prompt is GitHub-state-only. Touch no files.
+
+Run the checks below in order. After each check, log what you did. At
+the end, update (or create) the rolling report issue.
+
+The source of truth for the label vocabulary is `CONTRIBUTING.md` →
+"Issue & label conventions". If you ever disagree with that doc, leave
+the issue alone and surface it in the report — do not improvise a new
+label or convention.
+
+### Hard rules (do not violate)
+
+- **Never** delete an issue or a label.
+- **Never** edit an issue body — only `title`, `labels`, `state`,
+  and add new comments.
+- **Never** force a `priority:` change on an issue an owner has already
+  set; only fill in missing priorities.
+- **Never** close anything except: (a) bot-filed duplicates, (b) epics
+  whose sub-issues are all closed AND that haven't been touched by a
+  human in 30+ days, (c) `status: blocked` issues whose blocker is now
+  closed AND have been open for 14+ days.
+- **Never** strip a bracket prefix that contains an actual word
+  ("Workbench", "CQL", etc.) without rewording the title to keep meaning.
+  Stripping `[work]` / `[demo]` / `[live-monitor]` is always safe — they
+  add no information.
+- If a check is ambiguous, **leave it alone** and add an
+  `Unresolved:` line to the report. A human will deal with it.
+
+---
+
+## Checks (run in order)
+
+### 1. Untriaged open issues
+
+List all open issues. For each, check whether it has:
+
+- exactly one `type:` label (`bug`, `feature`, `tech-debt`, `docs`, `spike`, `epic`)
+- at least one `area:` label (`fhir-explorer`, `react-fhir`, `workbench`, `cql`, `mcp`, `infra`, `auth`, `security`)
+- exactly one `priority:` label (`high`, `medium`, `low`)
+
+If any are missing, infer them from the title + body using these heuristics:
+
+- **type:** title starting with `fix(...)` / `bug:` / "broken" / "regression" → `type: bug`. Title starting with `feat(...)` / `add` / `support` / `expose` → `type: feature`. `refactor(...)` / "cleanup" / "drop" / "consolidate" → `type: tech-debt`. `docs(...)` / "document" / "README" → `type: docs`. `spike(...)` / "experiment" / "explore" → `type: spike`. "Epic:" / "tracking issue" / "meta issue" → `type: epic`.
+- **area:** scan body for file paths. `apps/demo/` or `apps/fhir-explorer/` → `area: fhir-explorer`. `packages/react-fhir/` → `area: react-fhir`. `packages/cql/` → `area: cql`. `.github/` or CI-related → `area: infra`. Auth / Cognito / SMART / OAuth → `area: auth`. Multi-area allowed.
+- **priority:** bugs default `high`. Spikes / "nice-to-have" / "experimental" default `low`. Everything else `medium`.
+
+Apply the labels via `mcp__github__issue_write method=update labels=[...]`. Note: this **replaces** the label set, so always include any pre-existing labels you want to keep (status:, origin:, phase-*).
+
+If you cannot infer with confidence, add `status: needs-triage` and surface in the report.
+
+### 2. Title-convention violations
+
+For every open issue, check the title. If it starts with `[anything]`:
+
+- `[work]`, `[demo]`, `[live-monitor]`, `[bot]` → strip the prefix entirely.
+- `[workbench]`, `[cql]`, `[mcp]` → reword inline ("Workbench: …" or "Workbench …") so the title still makes sense, then save.
+- Anything else → leave alone, surface in report.
+
+Update via `mcp__github__issue_write method=update title="..."` (no label change in this step).
+
+### 3. Bot-filed duplicates
+
+List all open issues with `origin: bot-filed`. Group by title (case-insensitive). If multiple issues share a title:
+
+- The **oldest** is canonical.
+- Close the others with `state_reason=duplicate`, `duplicate_of=<canonical>`, and a one-line comment: "Closing as duplicate of #N — same auto-filed failure under a renamed title."
+
+Also check for near-duplicates (same spec file `:line` reference in body, different titles). Surface those in the report — do **not** auto-close, since the title difference may be meaningful.
+
+### 4. Closed-out epics
+
+List all open issues with `type: epic`. For each, fetch sub-issues via `mcp__github__issue_read method=get_sub_issues`. If every sub-issue is closed AND the epic itself has had no human activity in 30+ days, close the epic with a comment listing the sub-issues that closed it out: "All sub-issues complete: #X, #Y, #Z. Closing this tracker."
+
+### 5. Stale `status: blocked`
+
+List all open issues with `status: blocked`. For each, check the most recent comment date. If it's been >14 days:
+
+- Read the latest triage comment to identify the blocker (look for "blocked by #N" pattern).
+- Use `mcp__github__issue_read` to check whether the blocker is closed.
+- If blocker is closed: remove `status: blocked` and add a comment "Blocker #N is closed — un-blocking. Re-check whether this issue is still relevant."
+- If blocker is still open: add a one-line comment "Still blocked by #N (last checked YYYY-MM-DD)" so the activity timestamp updates.
+- If you cannot identify the blocker: add `status: needs-triage` and surface in report.
+
+### 6. Long-open issues without priority signal
+
+List open issues created >90 days ago that have neither `priority: high` nor any `phase-*` label. Add `status: needs-triage` and surface in the report. Do not change the existing priority.
+
+### 7. Roll-up daily report
+
+Find the open issue titled exactly `PM triage — daily report`. If it exists, **update its body** (do not append a new comment) with the day's results. If it doesn't exist, create it with labels `[type: docs, area: infra, priority: low, origin: bot-filed]` and assign nobody.
+
+Body format:
+
+```
+_Last run: YYYY-MM-DD HH:MM UTC. Auto-updated by `.github/workflows/daily-pm-triage.yml`._
+
+## Today
+
+### Triaged (N issues)
+- #123 — set [type: feature, area: fhir-explorer, priority: medium]
+- ...
+
+### Titles cleaned (N)
+- #232 — stripped `[work]` prefix
+- ...
+
+### Closed as duplicate (N)
+- #150 → #53 — same bot-filed failure, renamed title
+
+### Epics closed (N)
+- #189 — all sub-issues complete (#190, #191, #192)
+
+### Un-blocked (N)
+- #54 — blocker #51 is closed
+
+### Marked needs-triage (N)
+- #999 — open 95 days, no priority
+
+## Unresolved (need a human)
+- #888 — bracket prefix `[smoketest]` — unfamiliar, please advise
+- #777 — `status: blocked` but no blocker reference in any comment
+- #666 / #665 — possible near-duplicates, same spec line different titles
+
+## Stats
+- Open issues: N
+- Untriaged at end of run: N (target 0)
+- `status: blocked`: N
+- `status: needs-triage`: N
+```
+
+If today produced zero changes and no unresolved items, still update the timestamp so it's clear the run happened.
+
+---
+
+## Operational notes
+
+- The agent runs with `GITHUB_TOKEN` from the workflow — same permissions
+  as the workflow's `permissions:` block (issues: write).
+- The MCP `mcp__github__issue_write update labels=[...]` call **replaces**
+  the full label set. Always include the labels you want to keep.
+- The MCP server in this workflow does not expose label create/delete.
+  If you discover a missing canonical label, surface it in the report —
+  the `scripts/sync-labels.mjs` script (run on push to `main`) is what
+  manages the label vocabulary itself.
+- Limit yourself to ~150 API calls per run. If the backlog grows past
+  what fits, do checks 1-3 (highest value) and defer the rest to
+  tomorrow with a note in the report.

--- a/scripts/sync-labels.mjs
+++ b/scripts/sync-labels.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+// Idempotent label bootstrap for samsuffolksperoni/fhir-place.
+//
+// - Ensures every canonical label in CANONICAL exists with the right color
+//   and description; updates any whose color/description drifted.
+// - Deletes legacy labels in LEGACY_DELETE that have ZERO attached issues
+//   (open or closed). Skips with a warning if any issues still reference
+//   the legacy label.
+//
+// Required env:
+//   GITHUB_TOKEN   token with `repo` scope (or workflow GITHUB_TOKEN)
+// Optional env:
+//   GITHUB_REPOSITORY   "owner/repo" (defaults to samsuffolksperoni/fhir-place)
+//   DRY_RUN             "1" to log without making changes
+
+const REPO = process.env.GITHUB_REPOSITORY || 'samsuffolksperoni/fhir-place';
+const TOKEN = process.env.GITHUB_TOKEN;
+const DRY_RUN = process.env.DRY_RUN === '1';
+const API = 'https://api.github.com';
+
+if (!TOKEN) {
+  console.error('GITHUB_TOKEN is required');
+  process.exit(1);
+}
+
+const CANONICAL = [
+  // type:
+  { name: 'type: bug', color: 'd73a4a', description: 'Defect or regression. Bugs default to priority: high.' },
+  { name: 'type: feature', color: 'a2eeef', description: 'New capability or user-visible enhancement.' },
+  { name: 'type: tech-debt', color: 'd4c5f9', description: 'Refactor, cleanup, build/perf, or non-functional improvement.' },
+  { name: 'type: docs', color: '0075ca', description: 'Documentation only.' },
+  { name: 'type: spike', color: 'fbca04', description: 'Time-boxed exploration; no shipping commitment.' },
+  { name: 'type: epic', color: '5319e7', description: 'Tracker for sub-issues. Closes when all sub-issues close.' },
+  // area:
+  { name: 'area: fhir-explorer', color: '1d76db', description: 'apps/demo (canonical name: fhir-explorer; legacy: demo, fhir-ui, live-monitor).' },
+  { name: 'area: react-fhir', color: '0e8a16', description: 'packages/react-fhir — the published library.' },
+  { name: 'area: workbench', color: '8b00ff', description: 'Workbench app/page surface.' },
+  { name: 'area: cql', color: 'c5def5', description: '@fhir-place/cql companion package.' },
+  { name: 'area: mcp', color: 'c5def5', description: '@fhir-place/mcp companion package.' },
+  { name: 'area: infra', color: '393b3a', description: 'CI, build tooling, deployment.' },
+  { name: 'area: auth', color: 'b60205', description: 'Authentication / authorization.' },
+  { name: 'area: security', color: 'b60205', description: 'Security-sensitive change or review.' },
+  // priority:
+  { name: 'priority: high', color: 'e11d21', description: 'Top of the queue.' },
+  { name: 'priority: medium', color: 'fbca04', description: 'Default priority.' },
+  { name: 'priority: low', color: '0e8a16', description: 'Nice-to-have.' },
+  // status:
+  { name: 'status: blocked', color: '000000', description: 'Cannot progress until a referenced blocker resolves.' },
+  { name: 'status: needs-triage', color: 'cccccc', description: 'No type/area/priority set, or PM agent unsure — needs human review.' },
+  // origin:
+  { name: 'origin: bot-filed', color: 'ededed', description: 'Auto-filed by automation (e.g. live-site-monitor.yml).' },
+  // phase tracking — preserved as-is, no prefix (project-tracking convention).
+  { name: 'phase-0', color: 'fef2c0', description: 'Phase 0 epic.' },
+  { name: 'phase-1', color: 'fef2c0', description: 'Phase 1 epic.' },
+  { name: 'phase-2', color: 'fef2c0', description: 'Phase 2 epic.' },
+  { name: 'phase-3', color: 'fef2c0', description: 'Phase 3 epic.' },
+  { name: 'fhir-workbench-phase-a', color: 'fef2c0', description: 'Workbench Phase A epic.' },
+];
+
+const LEGACY_DELETE = [
+  'enhancement',     // → type: feature
+  'bug',             // → type: bug
+  'tech-debt',       // → type: tech-debt   (note: same name, different label id; old one orphaned)
+  'epic',            // → type: epic
+  'meta',            // → type: epic
+  'demo',            // → area: fhir-explorer
+  'live-monitor',    // → origin: bot-filed
+  'workbench',       // → area: workbench
+  'frontend',        // dropped (subsumed by area:)
+  'backend',         // dropped (subsumed by area:)
+  'infra',           // → area: infra
+  'auth',            // → area: auth
+  'security',        // → area: security
+  'blocked',         // → status: blocked
+];
+
+async function gh(method, path, body) {
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: {
+      'Authorization': `Bearer ${TOKEN}`,
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${method} ${path} → ${res.status}: ${text}`);
+  }
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+async function listAllLabels() {
+  const out = [];
+  let page = 1;
+  // Pre-existing labels in this repo: the response includes `name` only; pagination via Link header.
+  while (true) {
+    const batch = await gh('GET', `/repos/${REPO}/labels?per_page=100&page=${page}`);
+    if (!batch || batch.length === 0) break;
+    out.push(...batch);
+    if (batch.length < 100) break;
+    page++;
+  }
+  return out;
+}
+
+async function countIssuesWithLabel(label) {
+  // search counts both open + closed
+  const q = encodeURIComponent(`repo:${REPO} label:"${label}"`);
+  const res = await gh('GET', `/search/issues?q=${q}&per_page=1`);
+  return res?.total_count ?? 0;
+}
+
+async function ensureLabel(spec, existing) {
+  const cur = existing.find((l) => l.name === spec.name);
+  if (!cur) {
+    console.log(`+ create  ${spec.name}  #${spec.color}`);
+    if (!DRY_RUN) await gh('POST', `/repos/${REPO}/labels`, spec);
+    return;
+  }
+  if (cur.color === spec.color && (cur.description ?? '') === spec.description) {
+    return; // already in the right state
+  }
+  console.log(`~ update  ${spec.name}  ${cur.color} → ${spec.color}`);
+  if (!DRY_RUN) {
+    await gh('PATCH', `/repos/${REPO}/labels/${encodeURIComponent(cur.name)}`, {
+      new_name: spec.name,
+      color: spec.color,
+      description: spec.description,
+    });
+  }
+}
+
+async function maybeDeleteLegacy(name, existing) {
+  if (!existing.some((l) => l.name === name)) return;
+  const count = await countIssuesWithLabel(name);
+  if (count > 0) {
+    console.log(`! skip    ${name} — still attached to ${count} issue(s)`);
+    return;
+  }
+  console.log(`- delete  ${name} (orphaned)`);
+  if (!DRY_RUN) await gh('DELETE', `/repos/${REPO}/labels/${encodeURIComponent(name)}`);
+}
+
+async function main() {
+  console.log(`sync-labels: repo=${REPO} dry_run=${DRY_RUN}`);
+  const existing = await listAllLabels();
+  console.log(`found ${existing.length} existing labels`);
+
+  for (const spec of CANONICAL) {
+    await ensureLabel(spec, existing);
+  }
+
+  // Re-list because we may have created/updated labels above.
+  const refreshed = await listAllLabels();
+  for (const name of LEGACY_DELETE) {
+    await maybeDeleteLegacy(name, refreshed);
+  }
+
+  console.log('done');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Two-part PM cleanup:
1. **One-time backlog cleanup** (already applied via API — described below)
2. **Standing automation** so the cleanup doesn't decay

### Code changes in this PR

- **`CONTRIBUTING.md`** — new "Issue & label conventions" section. Defines the `type:` / `area:` / `priority:` / optional `status:` / `origin:` taxonomy, the no-bracket title rule, and points contributors at the automation.
- **`.github/workflows/live-site-monitor.yml`** — drops the `[demo]` title prefix; emits the new label set (`type: bug`, `area: fhir-explorer`, `priority: high`, `origin: bot-filed`); scopes dedup search to `label:"origin: bot-filed"` so the bot never collides with a human-filed issue that happens to share a title.
- **`docs/prompts/daily-pm-triage.md`** — the daily PM agent prompt. Aggressive autonomy: labels new issues, strips bracket prefixes, dedupes bot-filed bugs, closes finished epics, un-blocks resolved blockers, posts a rolling daily report. Hard rules forbid file edits, branch creation, or closing anything outside an explicit allow-list.
- **`.github/workflows/daily-pm-triage.yml`** — cron at 07:00 UTC (after `live-site-monitor` at 06:30) that runs the prompt via `anthropics/claude-code-action`. Requires `ANTHROPIC_API_KEY` repo secret.
- **`scripts/sync-labels.mjs`** — idempotent label bootstrap. Ensures the 25 canonical labels exist with correct colors + descriptions; deletes the 14 legacy labels only if they have zero attached issues. Safe to re-run; supports `DRY_RUN=1`.
- **`.github/workflows/sync-labels.yml`** — runs the script on push to `main` when the script changes, plus `workflow_dispatch` with a dry-run toggle for the post-merge bootstrap.

### GitHub-state changes already applied (out-of-band)

- Closed **#150** as duplicate of #53.
- Stripped `[bracket]` prefixes from 11 titles: #52-#56, #69, #78, #232, #237-#239.
- Migrated all 41 remaining open issues onto the new label vocabulary. Mapping: `enhancement → type: feature`, `bug → type: bug`, `tech-debt → type: tech-debt`, `epic`/`meta → type: epic`, `demo → area: fhir-explorer`, `live-monitor → origin: bot-filed`, `workbench → area: workbench`, `frontend`/`backend` dropped, `infra`/`auth`/`security → area:` versions, `blocked → status: blocked`. Phase labels preserved as-is.
- Filed **#243** for the actual `apps/demo` → `apps/fhir-explorer` code rename (separate, larger PR).
- All previously untriaged issues (#28, #121-#129, #136, #141-#146, #159-#166, #169, #170, #178-#193, #223, #232, #237-#239) now carry exactly one `type:`, at least one `area:`, and exactly one `priority:`.

## Codex review feedback addressed

- **Comment on line 114** ("restore unique namespace for monitor titles"): kept the no-bracket title rule (per the new convention) and instead scoped the dedup search to `label:"origin: bot-filed"` — same protection, no namespace pollution.
- **Comment on line 152** ("add a priority label"): added `priority: high` to the bot's default labels (matches the "bugs default to high" rule). The 5 existing bot-filed issues #52-#56 were already migrated with this label.

## After merging

1. **Add `ANTHROPIC_API_KEY` repo secret** (Settings → Secrets → Actions). Required for the daily PM triage workflow.
2. **Trigger `sync-labels.yml` once** via Actions → "Sync labels" → "Run workflow". This recolors the new labels and deletes the 14 orphaned legacy ones. Run with `dry_run=true` first if you want to review.
3. **Trigger `daily-pm-triage.yml` once** via Actions → "Daily PM triage" → "Run workflow" to confirm the cron runs cleanly and the rolling report issue gets created.
4. **Tackle #243** when convenient — it's a larger code rename PR.

## Test plan

- [ ] CI passes on the PR
- [ ] Spot-check 2-3 relabeled open issues in the GitHub UI
- [ ] After merge: dry-run `sync-labels` and confirm the diff matches expectations (creates ~25 labels, deletes ~14)
- [ ] After merge: real run of `sync-labels`; confirm orphan deletion + recolor
- [ ] After merge + secret added: manual run of `daily-pm-triage`; confirm rolling report issue is created and no destructive surprises
- [ ] Wait for next `live-site-monitor` cron — confirm any new failure on the Patient detail spec dedupes into #53 with the new label-scoped query

https://claude.ai/code/session_01EeB3ZfEV61YGpAiN9tFuYu