### PR TITLE
add status: labels for engineer-dispatch routine

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ GitHub Issues are the canonical backlog (see `docs/decisions/0001-use-github-iss
 | `type:` | exactly one | `bug`, `feature`, `tech-debt`, `docs`, `spike`, `epic` | What kind of work this is. `epic` = tracker for sub-issues. `spike` = time-boxed exploration. |
 | `area:` | one or more | `fhir-explorer`, `react-fhir`, `workbench`, `cql`, `mcp`, `infra`, `auth`, `security` | Which part of the codebase is touched. `fhir-explorer` is the demo app at `apps/demo/` (legacy names: "demo", "fhir-ui", "live-monitor"). `react-fhir` is the published library at `packages/react-fhir/`. |
 | `priority:` | exactly one | `high`, `medium`, `low` | Triage signal. Bugs default to `high`. Spikes / nice-to-haves default to `low`. Default `medium`. |
-| `status:` | optional | `blocked`, `needs-triage` | Workflow state. Use sparingly. |
+| `status:` | optional | `blocked`, `needs-triage`, `in-progress`, `needs-human`, `agent-paused` | Workflow state. Use sparingly. `in-progress` / `needs-human` are bot-managed by the engineer-dispatch routine; `agent-paused` on the dispatch tracking issue is the kill switch. |
 | `origin:` | optional | `bot-filed` | Filed by automation (e.g. `live-site-monitor.yml`). |
 | `phase-N` | optional | `phase-0`..`phase-3`, `fhir-workbench-phase-a` | Multi-phase epic tracking. Keep as plain (no prefix) for grep-ability. |
 

--- a/scripts/sync-labels.mjs
+++ b/scripts/sync-labels.mjs
@@ -47,6 +47,9 @@ const CANONICAL = [
   // status:
   { name: 'status: blocked', color: '000000', description: 'Cannot progress until a referenced blocker resolves.' },
   { name: 'status: needs-triage', color: 'cccccc', description: 'No type/area/priority set, or PM agent unsure — needs human review.' },
+  { name: 'status: in-progress', color: 'fbca04', description: 'Engineer-dispatch agent has claimed this issue. Bot-managed; humans should not edit.' },
+  { name: 'status: needs-human', color: 'd93f0b', description: 'Engineer-dispatch agent stopped — see latest comment for the failure.' },
+  { name: 'status: agent-paused', color: '000000', description: 'Kill switch — applied to the engineer-dispatch tracking issue, all dispatchers skip their run while present.' },
   // origin:
   { name: 'origin: bot-filed', color: 'ededed', description: 'Auto-filed by automation (e.g. live-site-monitor.yml).' },
   // phase tracking — preserved as-is, no prefix (project-tracking convention).

--- a/scripts/sync-labels.mjs
+++ b/scripts/sync-labels.mjs
@@ -49,7 +49,7 @@ const CANONICAL = [
   { name: 'status: needs-triage', color: 'cccccc', description: 'No type/area/priority set, or PM agent unsure — needs human review.' },
   { name: 'status: in-progress', color: 'fbca04', description: 'Engineer-dispatch agent has claimed this issue. Bot-managed; humans should not edit.' },
   { name: 'status: needs-human', color: 'd93f0b', description: 'Engineer-dispatch agent stopped — see latest comment for the failure.' },
-  { name: 'status: agent-paused', color: '000000', description: 'Kill switch — applied to the engineer-dispatch tracking issue, all dispatchers skip their run while present.' },
+  { name: 'status: agent-paused', color: '000000', description: 'Kill switch on the dispatch tracking issue — dispatchers skip while present.' },
   // origin:
   { name: 'origin: bot-filed', color: 'ededed', description: 'Auto-filed by automation (e.g. live-site-monitor.yml).' },
   // phase tracking — preserved as-is, no prefix (project-tracking convention).


### PR DESCRIPTION
## Summary

Adds three new bot-managed `status:` labels to the canonical vocabulary so the upcoming hourly engineer-dispatch routine can claim, surrender, and pause work without colliding with the existing namespace.

- `status: in-progress` — atomic claim by the dispatch agent
- `status: needs-human` — agent gave up, comment has the reason
- `status: agent-paused` — kill switch on the dispatch tracking issue

Updates `CONTRIBUTING.md` so the label table reflects the new values.

This is PR A of three. PRs B and C add the engineer subagent and the dispatcher prompt + workflow.

## Test plan

- [ ] CI green (sync-labels script unit-tests N/A; this is a pure data change)
- [ ] On merge to `main`, `.github/workflows/sync-labels.yml` runs and creates the three labels in the GitHub repo. Verify in repo Issues → Labels.
- [ ] No issues currently use these label names, so no migration concerns.

https://claude.ai/code/session_01CMEnBa3Jk4nk4eSejvH3Zo

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMEnBa3Jk4nk4eSejvH3Zo)_