### PR TITLE
Add daily QA pass workflow against real FHIR sandbox

### DIFF
--- a/.github/workflows/daily-qa-pass.yml
+++ b/.github/workflows/daily-qa-pass.yml
@@ -1,0 +1,119 @@
+# Daily exploratory QA pass.
+#
+# Boots the demo dev server pointed at the SMART Health IT R4 sandbox
+# (VITE_USE_MOCK=false), then hands off to Claude Code which drives a
+# desktop browser through the routes listed in docs/qa-agent.md and
+# files GitHub issues for any bugs it finds. Complementary to
+# live-site-monitor.yml: that one runs the fixed Playwright suite
+# against the deployed Pages build; this one is exploratory and runs
+# against a local dev build pointed at a real server.
+#
+# See docs/prompts/daily-qa-pass.md for what the agent does.
+#
+# Setup required (one-time):
+#   1. ANTHROPIC_API_KEY already exists in repo secrets (used by the
+#      PM and engineer-dispatch workflows). No new secret to add.
+#   2. Trigger via Actions → "Daily QA pass" → "Run workflow" once to
+#      confirm the dev server boots, the agent reaches localhost:5173,
+#      and an issue gets filed (or zero, with a clean summary).
+
+name: Daily QA pass
+
+on:
+  schedule:
+    # 05:00 UTC daily — runs before live-site-monitor (06:30 UTC) and
+    # daily-pm-triage (07:00 UTC) so any bugs filed today are visible
+    # to both downstream workflows.
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+  pull-requests: read
+  id-token: write
+
+concurrency:
+  group: daily-qa-pass
+  cancel-in-progress: false
+
+jobs:
+  qa:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright chromium
+        run: pnpm --filter @fhir-place/demo exec playwright install --with-deps chromium
+
+      - name: Start dev server against real FHIR
+        # Background the dev server, then wait for it to respond. Logs go
+        # to apps/demo/dev.log so the agent (and the run artifacts) can
+        # read them if needed.
+        run: |
+          mkdir -p apps/demo
+          (
+            cd apps/demo
+            VITE_USE_MOCK=false \
+            VITE_FHIR_BASE_URL=https://r4.smarthealthit.org \
+            pnpm dev > dev.log 2>&1 &
+            echo $! > dev.pid
+          )
+          # Wait up to 90s for the server to be ready.
+          for i in $(seq 1 90); do
+            if curl -fsS http://localhost:5173 > /dev/null; then
+              echo "dev server up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "dev server failed to start within 90s"
+          tail -n 100 apps/demo/dev.log || true
+          exit 1
+
+      - name: Run Claude Code with the daily-qa-pass prompt
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Same idiom as daily-pm-triage: tell Claude to read the prompt
+          # file rather than slurping it into a workflow input. The prompt
+          # is the source of truth, version-controlled and reviewable.
+          prompt: |
+            Read the file at docs/prompts/daily-qa-pass.md and execute the
+            instructions in it. Do not modify the file. Do not open a
+            branch or PR. The MCP github tools are already configured.
+            The dev server is already running at http://localhost:5173
+            against https://r4.smarthealthit.org. Playwright chromium is
+            installed; use it from a temporary Node script in /tmp.
+          # Exploratory walk across ~10 routes + dedupe + filing — give
+          # plenty of headroom; the workflow timeout-minutes is the real
+          # wall-clock bound.
+          claude_args: "--max-turns 200"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stop dev server
+        if: always()
+        run: |
+          if [ -f apps/demo/dev.pid ]; then
+            kill "$(cat apps/demo/dev.pid)" 2>/dev/null || true
+          fi
+
+      - name: Upload dev server log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qa-pass-dev-log-${{ github.run_id }}
+          path: apps/demo/dev.log
+          if-no-files-found: ignore

--- a/docs/prompts/daily-qa-pass.md
+++ b/docs/prompts/daily-qa-pass.md
@@ -1,0 +1,158 @@
+# Daily QA pass prompt
+
+This prompt runs daily on a cron via `.github/workflows/daily-qa-pass.yml`.
+It drives a desktop browser through the demo app — pointed at a real FHIR
+server, not the MSW mocks — looking for bugs that the existing e2e suites
+can't see (real network shapes, paging quirks, search edge cases). It files
+each new bug as a GitHub issue.
+
+It is the agentic counterpart to `live-site-monitor.yml`, which runs the
+fixed Playwright suite against the deployed Pages build. This pass is
+exploratory: routes and interactions are walked dynamically, with the bug
+signals from `docs/qa-agent.md` as the rubric.
+
+## Environment guarantees from the workflow
+
+- Repo is checked out and `pnpm install --frozen-lockfile` has run.
+- Playwright `chromium` is installed with deps.
+- The dev server is **already running** in the background on
+  `http://localhost:5173`, started with:
+  ```
+  VITE_USE_MOCK=false VITE_FHIR_BASE_URL=https://r4.smarthealthit.org
+  ```
+  i.e. it talks to the SMART Health IT public sandbox, not MSW. Treat it as
+  shared infrastructure: do not write data unless the docs/qa-agent.md
+  playbook explicitly calls for a CRUD assertion on a fresh patient.
+- The GitHub MCP tools (`mcp__github__*`) are configured. Use them to
+  search and file issues. Do **not** use `gh` or open a branch/PR — this
+  prompt is run-state-only.
+
+## Your task
+
+You are the QA engineer for `samsuffolksperoni/fhir-place`. Walk the demo
+app desktop-only at 1280×800 against the real FHIR server. File each
+distinct bug as a GitHub issue.
+
+Run the steps below in order. Log what you do as you go.
+
+### Hard rules
+
+- **Desktop only.** Do not test mobile viewport in this pass — that's
+  scope for a separate workflow.
+- **One issue per distinct bug.** Do not batch.
+- **Dedupe before filing.** Search open issues with `mcp__github__search_issues`
+  using `repo:samsuffolksperoni/fhir-place is:issue is:open in:title "<keyword>" label:"origin: bot-filed"`.
+  If a clear match exists, add a comment instead of filing a new issue.
+- **Do not fix bugs.** Filing only. Fixes happen in a separate PR.
+- **Do not modify any files.** This prompt is GitHub-state-only.
+- **Do not write data to the FHIR server** unless a CRUD test is in
+  scope (Patient/new, edit). If you do, use a clearly-fake name like
+  `QA Bot <ISO timestamp>` so the data is identifiable for cleanup.
+- **Do not use `[bracket]` prefixes in issue titles.** The PM triage
+  agent strips them. Use a plain descriptive title.
+
+### Step 1 — Confirm the dev server is alive
+
+```
+curl -fsS http://localhost:5173 | head -c 200
+```
+
+If this fails, write a one-line note to stderr and stop. The workflow
+will surface the failure in its run log; do not file an issue for the
+QA pass infrastructure itself.
+
+### Step 2 — Scope the existing failures
+
+Read `apps/demo/e2e/README.md` and skim the spec filenames in
+`apps/demo/e2e/`. You don't need to run the suite (the workflow doesn't
+run it for this pass). Use this to recognise behaviour the team
+already considers known-broken when you bump into it during exploration —
+do not re-file those.
+
+### Step 3 — Drive the app with Playwright
+
+Write a temporary Node script in `/tmp/qa-pass.mjs` that uses the
+Playwright API. Do not commit it. Capture:
+
+- console errors (`page.on("console", ...)`)
+- page errors (`page.on("pageerror", ...)`)
+- network failures (`page.on("response", ...)` filtering 4xx/5xx, but
+  ignore expected 404s like `/Patient/NONEXISTENT`)
+
+Walk the routes from `docs/qa-agent.md` "Pages to visit" — desktop only.
+For each route:
+
+1. Navigate, wait for `networkidle` (timeout 15s).
+2. Assert the page has rendered something (no blank body, no infinite
+   spinner, no "Something went wrong" boundary).
+3. Try the primary interaction documented for that route (search,
+   field picker, pagination, etc.).
+4. Record any captured errors with the route and a one-line repro.
+
+Use the bug-signal table in `docs/qa-agent.md` as your detection rubric.
+
+### Step 4 — File issues
+
+For each distinct bug:
+
+1. Search for an existing open issue (see "Hard rules" above).
+2. If a match exists: add a comment with today's run URL, the captured
+   error, and the affected route. Do **not** re-open closed issues.
+3. If no match: file a new issue with:
+   - **Title:** plain descriptive sentence, no bracket prefix.
+     E.g. `Patient detail crashes on patient with no name.given`
+   - **Labels:** `type: bug`, `area: fhir-explorer`, `origin: bot-filed`,
+     and a priority — `priority: high` for crashes, broken navigation,
+     or data loss; `priority: medium` for everything else.
+   - **Body:** use the structure below. The `agent-work-item` issue
+     template's fields are good guidance, but file via `mcp__github__issue_write`
+     with a free-form body — that's what `live-site-monitor.yml` does too.
+
+   ```
+   **Route:** <hash route>
+   **Run:** <workflow run URL — read GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID env>
+   **FHIR server:** https://r4.smarthealthit.org
+   **Viewport:** 1280×800
+
+   **Steps to reproduce:**
+   1. ...
+   2. ...
+
+   **Expected:** ...
+   **Actual:** ...
+
+   **Console errors:**
+   ```
+   <paste, trimmed to ~2 KB>
+   ```
+
+   **Network failures:**
+   - <method> <url> → <status>
+
+   **Likely files:** apps/demo/src/...
+
+   _Filed automatically by `.github/workflows/daily-qa-pass.yml`. The
+   PM-triage workflow will assign final priority and `area:` next._
+   ```
+
+### Step 5 — Report a summary
+
+At the end of the run, print (to stdout — Claude's normal output, no
+issue filing) a short summary:
+
+- Routes visited
+- Bugs filed (issue numbers + URLs)
+- Existing issues commented on (numbers + URLs)
+- Any infrastructure problems hit (FHIR server slow, dev server crashed,
+  etc.) — these are surfaced in the run log only, not filed as issues.
+
+## Scope and limits
+
+- Demo app (`apps/demo/`) only. Do not file issues against
+  `packages/react-fhir` unless a unit-test failure confirms the bug is
+  in the library.
+- Do not touch issues that don't have `origin: bot-filed`. Comment-only
+  on bot-filed dedupes.
+- Stay under ~10 issues filed per run. If you hit 10, stop filing,
+  finish the walk, and surface the remainder in the summary so a human
+  can decide whether to file them by hand.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/daily-qa-pass.yml` — a cron-driven exploratory QA pass that runs at 05:00 UTC daily (and on `workflow_dispatch`).
- Adds `docs/prompts/daily-qa-pass.md` — the agent runbook the workflow points at.
- Boots `pnpm dev` with `VITE_USE_MOCK=false VITE_FHIR_BASE_URL=https://r4.smarthealthit.org` on `localhost:5173`, hands off to `anthropics/claude-code-action@v1`, and files bugs as GitHub issues using the GitHub MCP.

## Why this and not the existing automation

- `live-site-monitor.yml` (06:30 UTC) runs the **fixed** Playwright suite against the **deployed Pages** build — catches regressions in the slice we have specs for.
- This new pass is **exploratory** (Claude walks routes dynamically) and runs against a **local dev build pointed at a real FHIR server** — catches bugs the suite doesn't cover (real network shapes, paging quirks, search edge cases, console errors that aren't asserted).
- 05:00 UTC slot is intentional: any issues filed are visible to live-site-monitor (06:30) and daily-pm-triage (07:00) the same morning.

## Conventions followed

- Same idiom as `daily-pm-triage.yml` / `hourly-engineer-dispatch.yml`: workflow tells Claude to read a versioned prompt file rather than inlining the prompt.
- Issues filed with the canonical labels from `scripts/sync-labels.mjs` — `type: bug`, `area: fhir-explorer`, `origin: bot-filed`, plus a priority. No `[bracket]` title prefixes (PM triage strips them).
- Hard rules in the prompt: desktop only (1280×800), one issue per distinct bug, dedupe before filing via `mcp__github__search_issues`, no fixing in this pass, no editing files, cap at ~10 filings per run.

## Test plan

- [ ] Run via Actions → "Daily QA pass" → "Run workflow" once and confirm:
  - [ ] Dev server boots within 90s and `curl http://localhost:5173` succeeds.
  - [ ] `apps/demo/dev.log` is uploaded as the `qa-pass-dev-log-<run_id>` artifact.
  - [ ] Claude reaches the dev server and produces a summary at the end of the run.
  - [ ] If any bugs are filed, they have `type: bug`, `area: fhir-explorer`, `origin: bot-filed`, and a priority — and no bracket prefix in the title.
  - [ ] Re-running the workflow on the same day comments on the existing bot issue rather than filing a duplicate.
- [ ] After 3–5 successful manual runs, leave the cron schedule on (no follow-up needed unless the manual runs reveal flakiness).
- [ ] Confirm `ANTHROPIC_API_KEY` repo secret is already present (used by `daily-pm-triage.yml` and `hourly-engineer-dispatch.yml`).

https://claude.ai/code/session_01DEL8ABYLawdhEHfoPnu6Zs

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEL8ABYLawdhEHfoPnu6Zs)_