### PR TITLE
Gate demo writes by FHIR capabilities

### DIFF
--- a/.changeset/capability-gated-demo-writes.md
+++ b/.changeset/capability-gated-demo-writes.md
@@ -1,0 +1,5 @@
+---
+"@fhir-place/react-fhir": patch
+---
+
+Export `useResourceCapabilities(resourceType)` for CapabilityStatement-driven create, update, delete, and search gating.

--- a/apps/demo/e2e/crud.screenshot.spec.ts
+++ b/apps/demo/e2e/crud.screenshot.spec.ts
@@ -89,4 +89,18 @@ test.describe("CRUD flows", () => {
     await expect(page).toHaveURL(/\/Patient$/);
     await expect(page.getByText("Margaret Hamilton-Apollo")).toHaveCount(0);
   });
+
+  test("read-only CapabilityStatement resources hide write buttons", async ({ page }) => {
+    await page.goto("/Patient");
+    await expect(page.getByTestId("create-patient")).toBeVisible();
+
+    await page.goto("/AllergyIntolerance");
+    await expect(page.getByRole("heading", { name: /allergies & intolerances/i })).toBeVisible();
+    await expect(page.getByTestId("create-allergyintolerance")).toHaveCount(0);
+
+    await page.goto("/AllergyIntolerance/ai-pen-ada");
+    await expect(page.getByTestId("resource-view")).toBeVisible();
+    await expect(page.getByTestId("edit-resource")).toHaveCount(0);
+    await expect(page.getByTestId("delete-resource")).toHaveCount(0);
+  });
 });

--- a/apps/demo/src/mocks/handlers.ts
+++ b/apps/demo/src/mocks/handlers.ts
@@ -36,6 +36,14 @@ const okJson = (data: any, init?: ResponseInit) =>
     },
   });
 
+const patientInteractions = [
+  { code: "read" },
+  { code: "search-type" },
+  { code: "create" },
+  { code: "update" },
+  { code: "delete" },
+];
+
 export const handlers = [
   http.get(`*${BASE}/metadata`, () =>
     okJson({
@@ -51,13 +59,7 @@ export const handlers = [
           resource: [
             {
               type: "Patient",
-              interaction: [
-                { code: "read" },
-                { code: "search-type" },
-                { code: "create" },
-                { code: "update" },
-                { code: "delete" },
-              ],
+              interaction: patientInteractions,
               searchParam: [
                 { name: "_id", type: "token", documentation: "Logical id" },
                 { name: "name", type: "string", documentation: "Any of the names" },

--- a/apps/demo/src/routes/fhir-ui/pages/ResourceDetailPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceDetailPage.tsx
@@ -4,6 +4,7 @@ import {
   ResourceView,
   useDeleteResource,
   useResource,
+  useResourceCapabilities,
   useStructureDefinition,
 } from "@fhir-place/react-fhir";
 import type { Reference, Resource } from "fhir/r4";
@@ -44,6 +45,7 @@ export function ResourceDetailPage() {
   const notFound =
     error instanceof FhirError && (error.status === 404 || error.status === 410);
   const del = useDeleteResource();
+  const { canUpdate, canDelete } = useResourceCapabilities(resourceType);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [rightPane, setRightPane] = useState<"formatted" | "json" | "refs">("formatted");
 
@@ -108,25 +110,29 @@ export function ResourceDetailPage() {
               buttonLabel="Fields"
             />
           )}
-          <Link
-            to={`/fhir-ui/${resourceType}/${id}/edit`}
-            style={ccBtn("secondary")}
-            data-testid="edit-resource"
-          >
-            Edit
-          </Link>
-          <button
-            onClick={() => setConfirmingDelete(true)}
-            style={ccBtn("danger")}
-            data-testid="delete-resource"
-          >
-            Delete
-          </button>
+          {canUpdate && (
+            <Link
+              to={`/fhir-ui/${resourceType}/${id}/edit`}
+              style={ccBtn("secondary")}
+              data-testid="edit-resource"
+            >
+              Edit
+            </Link>
+          )}
+          {canDelete && (
+            <button
+              onClick={() => setConfirmingDelete(true)}
+              style={ccBtn("danger")}
+              data-testid="delete-resource"
+            >
+              Delete
+            </button>
+          )}
         </div>
       </div>
 
       {/* Delete confirm */}
-      {confirmingDelete && (
+      {canDelete && confirmingDelete && (
         <div
           data-testid="delete-confirm"
           style={{

--- a/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
@@ -5,6 +5,7 @@ import {
   SortPicker,
   useFhirClient,
   useInfiniteSearch,
+  useResourceCapabilities,
   useStructureDefinition,
 } from "@fhir-place/react-fhir";
 import type { Reference, Resource } from "fhir/r4";
@@ -114,6 +115,7 @@ export function ResourceListPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const client = useFhirClient();
+  const { canCreate } = useResourceCapabilities(resourceType);
 
   const onReferenceClick = (ref: Reference) => {
     const r = ref.reference;
@@ -253,7 +255,7 @@ export function ResourceListPage() {
 
   const heading = patientId ? resourceType : config?.title ?? resourceType;
   const singular = config?.singular ?? resourceType.toLowerCase();
-  const showCreate = !patientId && Boolean(config);
+  const showCreate = !patientId && canCreate;
   const priorityParams = config?.priorityParams;
 
   const totalStr = (() => {
@@ -323,7 +325,7 @@ export function ResourceListPage() {
               style={{ ...ccBtn("primary"), marginLeft: "auto" }}
               data-testid={`create-${resourceType.toLowerCase()}`}
             >
-              + New {resourceType}
+              + New {singular}
             </Link>
           )}
         </div>

--- a/packages/react-fhir/src/hooks/queries.test.tsx
+++ b/packages/react-fhir/src/hooks/queries.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import type { Patient } from "fhir/r4";
+import type { CapabilityStatement, Patient } from "fhir/r4";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -22,6 +22,7 @@ import {
   useInfiniteSearch,
   useReadReferences,
   useResource,
+  useResourceCapabilities,
   useResources,
   useSearch,
   useSearchParameter,
@@ -79,6 +80,63 @@ describe("query hooks", () => {
     const { result } = renderHook(() => useCapabilities(), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.resourceType).toBe("CapabilityStatement");
+  });
+
+  it("useResourceCapabilities maps resource interactions from /metadata", async () => {
+    const cap: CapabilityStatement = {
+      resourceType: "CapabilityStatement",
+      status: "active",
+      date: "2024-01-01",
+      kind: "instance",
+      fhirVersion: "4.0.1",
+      format: ["json"],
+      rest: [
+        {
+          mode: "server",
+          resource: [
+            {
+              type: "Patient",
+              interaction: [
+                { code: "read" },
+                { code: "search-type" },
+                { code: "create" },
+                { code: "update" },
+                { code: "delete" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const { wrapper, qc, client } = mkWrapper();
+    qc.setQueryData(fhirQueryKeys.capabilities(client.baseUrl), cap);
+    const { result } = renderHook(() => useResourceCapabilities("Patient"), { wrapper });
+
+    expect(result.current).toEqual({
+      canCreate: true,
+      canUpdate: true,
+      canDelete: true,
+      canSearch: true,
+    });
+  });
+
+  it("useResourceCapabilities defaults unknown resources to no write access", () => {
+    const { wrapper, qc, client } = mkWrapper();
+    qc.setQueryData(fhirQueryKeys.capabilities(client.baseUrl), {
+      resourceType: "CapabilityStatement",
+      status: "active",
+      rest: [{ mode: "server", resource: [{ type: "Patient" }] }],
+    });
+    const { result } = renderHook(() => useResourceCapabilities("Observation"), {
+      wrapper,
+    });
+
+    expect(result.current).toEqual({
+      canCreate: false,
+      canUpdate: false,
+      canDelete: false,
+      canSearch: false,
+    });
   });
 
   it("useResource is disabled when id is undefined", () => {

--- a/packages/react-fhir/src/hooks/queries.ts
+++ b/packages/react-fhir/src/hooks/queries.ts
@@ -9,6 +9,7 @@ import {
 import type {
   Bundle,
   CapabilityStatement,
+  CapabilityStatementRestResource,
   Reference,
   Resource,
   SearchParameter,
@@ -59,6 +60,48 @@ export function useCapabilities(options?: ReadQueryOpts<CapabilityStatement>) {
     staleTime: 5 * 60_000,
     ...options,
   });
+}
+
+export interface ResourceCapabilities {
+  canCreate: boolean;
+  canUpdate: boolean;
+  canDelete: boolean;
+  canSearch: boolean;
+}
+
+const emptyCapabilities: ResourceCapabilities = {
+  canCreate: false,
+  canUpdate: false,
+  canDelete: false,
+  canSearch: false,
+};
+
+function findCapabilityResource(
+  cap: CapabilityStatement | undefined,
+  resourceType: string | undefined,
+): CapabilityStatementRestResource | undefined {
+  if (!resourceType) return undefined;
+  for (const rest of cap?.rest ?? []) {
+    const hit = rest.resource?.find((resource) => resource.type === resourceType);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+export function useResourceCapabilities(
+  resourceType: string | undefined,
+): ResourceCapabilities {
+  const { data: cap } = useCapabilities({ enabled: Boolean(resourceType) });
+  const resource = findCapabilityResource(cap, resourceType);
+  if (!resource) return emptyCapabilities;
+
+  const interactions = new Set(resource.interaction?.map((i) => i.code) ?? []);
+  return {
+    canCreate: interactions.has("create"),
+    canUpdate: interactions.has("update"),
+    canDelete: interactions.has("delete"),
+    canSearch: interactions.has("search-type"),
+  };
 }
 
 export function useResource<T extends Resource = Resource>(


### PR DESCRIPTION
Closes #159

Summary:
- Add useResourceCapabilities(resourceType) as the shared CapabilityStatement interaction gate.
- Hide demo create/edit/delete controls unless the active server advertises create/update/delete for that resource type.
- Keep Patient write interactions explicit in the mock CapabilityStatement and add read-only AllergyIntolerance e2e coverage.

Test plan:
- [x] pnpm -r typecheck
- [ ] pnpm -r test:run (fails in existing MSW/jsdom/localStorage suites; focused useResourceCapabilities tests pass)
- [ ] pnpm --filter @fhir-place/demo e2e (full suite has existing strict-mode compartment assertion failures; focused read-only capability e2e passes)
- [x] pnpm --filter @fhir-place/react-fhir build
- [x] pnpm --filter @fhir-place/demo build