### PR TITLE
Add Pinned section to CCSidebar and topbar pin action

### DIFF
--- a/apps/demo/e2e/sidebar-pinned.spec.ts
+++ b/apps/demo/e2e/sidebar-pinned.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Pinned sidebar section + topbar pin action.
+ *
+ * The pinned state is per-server in localStorage, so tests clear
+ * `fhir-place:pinned` before each run to avoid contamination across the
+ * suite.
+ */
+
+test.describe("Sidebar Pinned section", () => {
+  // Wipe persisted pins once at the start of each test, then let subsequent
+  // navigations (including reload) read whatever the test wrote during the
+  // run. A `beforeEach` using `addInitScript` would also fire on reload and
+  // erase the very pin we're trying to verify survives.
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/fhir-ui/Patient");
+    await page.evaluate(() => {
+      try {
+        window.localStorage.removeItem("fhir-place:pinned");
+      } catch {
+        /* private mode */
+      }
+    });
+    await page.reload();
+  });
+
+  test("renders an empty state with helper copy when no pins exist", async ({
+    page,
+  }) => {
+    const section = page.getByTestId("sidebar-pinned-section");
+    await expect(section).toBeVisible();
+    await expect(section).toContainText(/pinned/i);
+
+    const empty = page.getByTestId("pinned-empty-state");
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText(
+      /click the pin icon in the topbar/i,
+    );
+  });
+
+  test("topbar pin adds a row that survives a reload and toggles off", async ({
+    page,
+  }) => {
+    // No pins yet — empty state visible.
+    await expect(page.getByTestId("pinned-empty-state")).toBeVisible();
+
+    // Pin the current route.
+    await page.getByTestId("topbar-pin").click();
+
+    // Empty state goes away; a pin row appears with label "Patient".
+    await expect(page.getByTestId("pinned-empty-state")).toHaveCount(0);
+    const section = page.getByTestId("sidebar-pinned-section");
+    await expect(section).toContainText("Patient");
+
+    // Reload and confirm persistence.
+    await page.reload();
+    await expect(page.getByTestId("sidebar-pinned-section")).toContainText(
+      "Patient",
+    );
+    await expect(page.getByTestId("pinned-empty-state")).toHaveCount(0);
+
+    // Toggle off — pressing pin again on the same route removes it.
+    await page.getByTestId("topbar-pin").click();
+    await expect(page.getByTestId("pinned-empty-state")).toBeVisible();
+  });
+
+  test("clicking a pinned row navigates to its route", async ({ page }) => {
+    await page.goto("/fhir-ui/Observation");
+    await page.getByTestId("topbar-pin").click();
+
+    // Move to a different route, then click the pin to come back.
+    await page.goto("/fhir-ui/Patient");
+    const section = page.getByTestId("sidebar-pinned-section");
+    await expect(section).toContainText("Observation");
+
+    // The row is keyed by a generated id, so locate it by its label text
+    // inside the pinned section instead of guessing the id.
+    await section.getByText("Observation", { exact: true }).click();
+    await expect(page).toHaveURL(/\/fhir-ui\/Observation$/);
+  });
+});

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -4,6 +4,7 @@ import { CCSidebar } from "./components/CCSidebar.js";
 import { CCTabs } from "./components/CCTabs.js";
 import { ThemeProvider } from "./context/ThemeContext.js";
 import { RouteTabSync, TabsProvider } from "./context/TabsContext.js";
+import { PinnedProvider } from "./state/pinned.js";
 import { AskPage } from "./routes/fhir-ui/pages/AskPage.js";
 import { ResourceCreatePage } from "./routes/fhir-ui/pages/ResourceCreatePage.js";
 import { ResourceDetailPage } from "./routes/fhir-ui/pages/ResourceDetailPage.js";
@@ -17,7 +18,9 @@ export function App() {
   return (
     <ThemeProvider>
       <TabsProvider>
-        <Shell />
+        <PinnedProvider>
+          <Shell />
+        </PinnedProvider>
       </TabsProvider>
     </ThemeProvider>
   );

--- a/apps/demo/src/components/CCSidebar.tsx
+++ b/apps/demo/src/components/CCSidebar.tsx
@@ -5,6 +5,7 @@ import { useQueries } from "@tanstack/react-query";
 import type { Bundle, Resource } from "fhir/r4";
 import { ACTIVE_SERVER_CONFIG, loadActiveServerId, loadServers, saveActiveServerId } from "../config.js";
 import { TOP_RESOURCE_TYPES } from "../resourceListConfig.js";
+import { usePinned } from "../state/pinned.js";
 import { JumpDialog } from "./JumpDialog.js";
 import { CC_MONO } from "./ccStyles.js";
 
@@ -21,6 +22,7 @@ export function CCSidebar() {
   const [pickerOpen, setPickerOpen] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
   const [jumpOpen, setJumpOpen] = useState(false);
+  const { pins, removePin, renamePin } = usePinned();
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -274,8 +276,10 @@ export function CCSidebar() {
 
       <JumpDialog open={jumpOpen} onClose={() => setJumpOpen(false)} />
 
+      {/* Resources + Pinned scroll region */}
+      <div style={{ overflowY: "auto", flex: 1 }} data-testid="sidebar-scroll">
       {/* Resources */}
-      <div style={{ padding: "12px 8px", overflowY: "auto", flex: 1 }}>
+      <div style={{ padding: "12px 8px 4px" }}>
         <div
           style={{
             fontSize: 10,
@@ -348,6 +352,94 @@ export function CCSidebar() {
             </div>
           );
         })}
+      </div>
+
+      {/* Pinned */}
+      <div
+        data-testid="sidebar-pinned-section"
+        style={{ padding: "8px 8px 12px", borderTop: "1px solid var(--border)", marginTop: 8 }}
+      >
+        <div
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            color: "var(--text-subtle)",
+            letterSpacing: 0.6,
+            textTransform: "uppercase",
+            padding: "6px 10px 8px",
+          }}
+        >
+          Pinned
+        </div>
+        {pins.length === 0 ? (
+          <div
+            data-testid="pinned-empty-state"
+            style={{
+              margin: "2px 6px",
+              padding: "10px 12px",
+              border: "1px dashed var(--border-strong, var(--border))",
+              borderRadius: 6,
+              fontSize: 11,
+              color: "var(--text-subtle)",
+              lineHeight: 1.4,
+            }}
+          >
+            Click the pin icon in the topbar to save a query or resource here.
+          </div>
+        ) : (
+          pins.map((pin) => {
+            const isActive = pin.path === `${location.pathname}${location.search}`;
+            return (
+              <div
+                key={pin.id}
+                data-testid={`pinned-row-${pin.id}`}
+                onClick={() => navigate(pin.path)}
+                onContextMenu={(e) => handlePinContext(e, pin, renamePin, removePin)}
+                title="Right-click to rename or remove"
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "5px 10px",
+                  borderRadius: 6,
+                  background: isActive ? "var(--accent-soft)" : "transparent",
+                  color: isActive ? "var(--accent-text)" : "var(--text)",
+                  cursor: "pointer",
+                  marginBottom: 1,
+                  transition: "background 80ms ease",
+                }}
+              >
+                <BookmarkIcon active={isActive} />
+                <span
+                  data-testid={`pinned-label-${pin.id}`}
+                  style={{
+                    fontSize: 13,
+                    fontWeight: isActive ? 600 : 400,
+                    flex: 1,
+                    minWidth: 0,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {pin.label}
+                </span>
+                <span
+                  data-testid={`pinned-kind-${pin.id}`}
+                  style={{
+                    fontSize: 11,
+                    fontFamily: CC_MONO,
+                    color: isActive ? "var(--accent-text)" : "var(--text-muted)",
+                    flexShrink: 0,
+                  }}
+                >
+                  {pin.kind}
+                </span>
+              </div>
+            );
+          })
+        )}
+      </div>
       </div>
 
       {/* Footer */}
@@ -449,6 +541,49 @@ export function CCSidebar() {
       </div>
     </div>
   );
+}
+
+function BookmarkIcon({ active }: { active: boolean }) {
+  return (
+    <svg
+      width="11"
+      height="11"
+      viewBox="0 0 14 14"
+      fill={active ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+      style={{ flexShrink: 0 }}
+    >
+      <path d="M3.5 1.5h7v9.25L7 8.5 3.5 10.75z" />
+    </svg>
+  );
+}
+
+/**
+ * v1 right-click handler. Native confirm/prompt keep this off the critical
+ * path while we wait for the design system's menu primitive (#TBD).
+ */
+function handlePinContext(
+  e: React.MouseEvent,
+  pin: { id: string; label: string },
+  rename: (id: string, label: string) => void,
+  remove: (id: string) => void,
+) {
+  e.preventDefault();
+  const action = window.prompt(
+    `Type "rename" to rename "${pin.label}" or "remove" to delete it.`,
+    "rename",
+  );
+  if (!action) return;
+  if (action.toLowerCase() === "remove") {
+    if (window.confirm(`Remove pin "${pin.label}"?`)) remove(pin.id);
+    return;
+  }
+  if (action.toLowerCase() === "rename") {
+    const next = window.prompt("Rename pin", pin.label);
+    if (next !== null) rename(pin.id, next);
+  }
 }
 
 interface SidebarCountProps {

--- a/apps/demo/src/components/CCTopbar.tsx
+++ b/apps/demo/src/components/CCTopbar.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from "react-router-dom";
 import { useTheme } from "../context/ThemeContext.js";
+import { usePinned } from "../state/pinned.js";
 import { CC_FONT, CC_MONO, ccBtn } from "./ccStyles.js";
 
 function SunIcon() {
@@ -19,10 +20,38 @@ function MoonIcon() {
   );
 }
 
+function PinIcon({ filled }: { filled: boolean }) {
+  // Bookmark/pin glyph; switches to a filled fill when the route is pinned
+  // so the topbar reads as a toggle, not a one-shot action.
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 14 14"
+      fill={filled ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+    >
+      <path d="M3.5 1.5h7v9.25L7 8.5 3.5 10.75z" />
+    </svg>
+  );
+}
+
 export function CCTopbar() {
   const location = useLocation();
   const { theme, toggle } = useTheme();
+  const { isPinned, togglePin } = usePinned();
   const isSettings = location.pathname === "/fhir-ui/settings";
+
+  const fullPath = `${location.pathname}${location.search}`;
+  const pinnable =
+    location.pathname.startsWith("/fhir-ui/") &&
+    location.pathname !== "/fhir-ui/settings" &&
+    location.pathname !== "/fhir-ui/ask" &&
+    location.pathname !== "/fhir-ui/types" &&
+    !location.pathname.endsWith("/new");
+  const pinned = pinnable && isPinned(fullPath);
 
   // useParams() returns {} when rendered outside <Routes>, so parse from pathname directly.
   const p = location.pathname;
@@ -92,6 +121,22 @@ export function CCTopbar() {
 
       {/* Actions */}
       <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <button
+          onClick={() => pinnable && togglePin(fullPath)}
+          disabled={!pinnable}
+          style={{
+            ...ccBtn("ghost"),
+            color: pinned ? "var(--accent-text)" : "var(--text-muted)",
+            background: pinned ? "var(--accent-soft)" : "transparent",
+            opacity: pinnable ? 1 : 0.4,
+            cursor: pinnable ? "pointer" : "not-allowed",
+          }}
+          title={pinned ? "Unpin this view" : "Pin this view"}
+          aria-pressed={pinned}
+          data-testid="topbar-pin"
+        >
+          <PinIcon filled={pinned} />
+        </button>
         <button
           onClick={toggle}
           style={ccBtn("ghost")}

--- a/apps/demo/src/state/pinned.tsx
+++ b/apps/demo/src/state/pinned.tsx
@@ -1,0 +1,129 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { ACTIVE_SERVER_CONFIG, loadActiveServerId } from "../config.js";
+
+export type PinKind = "search" | "id" | "list";
+
+export interface PinnedItem {
+  id: string;
+  kind: PinKind;
+  label: string;
+  /** Full route incl. search string; canonical key for de-duplication. */
+  path: string;
+  /** Set when kind === "search" — the encoded query string. */
+  query?: string;
+  /** Set for kinds that target a specific resource type. */
+  resourceType?: string;
+  /** Set when kind === "id" — e.g. "Patient/eve-baker". */
+  ref?: string;
+}
+
+type ByServer = Record<string, PinnedItem[]>;
+
+const STORAGE_KEY = "fhir-place:pinned";
+const RESERVED = new Set(["settings", "ask", "types"]);
+
+function load(): ByServer {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as { byServer?: ByServer } | null;
+    return (parsed?.byServer && typeof parsed.byServer === "object") ? parsed.byServer : {};
+  } catch {
+    return {};
+  }
+}
+
+function save(byServer: ByServer): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ byServer }));
+  } catch {
+    /* private mode / quota */
+  }
+}
+
+const newId = (): string =>
+  `pin-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+/**
+ * Convert a route + search string into a PinnedItem. Returns null for routes
+ * we deliberately don't pin (settings, ask, /new, etc.). Edit routes are
+ * filtered upstream by the topbar's pinnable gate.
+ */
+export function pathToPin(pathname: string, search: string): PinnedItem | null {
+  const detail = pathname.match(/^\/fhir-ui\/([^/]+)\/([^/]+)$/);
+  if (detail?.[1] && detail[2] && detail[2] !== "new") {
+    return {
+      id: newId(), kind: "id", label: detail[2],
+      ref: `${detail[1]}/${detail[2]}`, path: pathname,
+    };
+  }
+  const list = pathname.match(/^\/fhir-ui\/([^/]+)$/);
+  if (list?.[1] && !RESERVED.has(list[1])) {
+    const rt = list[1];
+    const q = search.startsWith("?") ? search.slice(1) : search;
+    return q
+      ? { id: newId(), kind: "search", label: rt, resourceType: rt, query: q, path: `${pathname}${search}` }
+      : { id: newId(), kind: "list", label: rt, resourceType: rt, path: pathname };
+  }
+  return null;
+}
+
+interface PinnedCtx {
+  pins: PinnedItem[];
+  isPinned: (path: string) => boolean;
+  togglePin: (path: string) => void;
+  removePin: (id: string) => void;
+  renamePin: (id: string, label: string) => void;
+}
+
+const PinnedContext = createContext<PinnedCtx>({
+  pins: [], isPinned: () => false, togglePin: () => {}, removePin: () => {}, renamePin: () => {},
+});
+
+export function PinnedProvider({ children }: { children: ReactNode }) {
+  const [byServer, setByServer] = useState<ByServer>(load);
+  const serverId = loadActiveServerId() ?? ACTIVE_SERVER_CONFIG.id;
+
+  useEffect(() => save(byServer), [byServer]);
+
+  const pins = useMemo(() => byServer[serverId] ?? [], [byServer, serverId]);
+
+  const update = useCallback(
+    (fn: (prev: PinnedItem[]) => PinnedItem[]) =>
+      setByServer((prev) => ({ ...prev, [serverId]: fn(prev[serverId] ?? []) })),
+    [serverId],
+  );
+
+  const value = useMemo<PinnedCtx>(() => ({
+    pins,
+    isPinned: (path) => pins.some((p) => p.path === path),
+    togglePin: (path) => {
+      const existing = pins.find((p) => p.path === path);
+      if (existing) return update((prev) => prev.filter((p) => p.id !== existing.id));
+      const [pathname, ...rest] = path.split("?");
+      const search = rest.length > 0 ? `?${rest.join("?")}` : "";
+      const item = pathToPin(pathname ?? path, search);
+      if (item) update((prev) => [...prev, item]);
+    },
+    removePin: (id) => update((prev) => prev.filter((p) => p.id !== id)),
+    renamePin: (id, label) => {
+      const trimmed = label.trim();
+      if (!trimmed) return;
+      update((prev) => prev.map((p) => (p.id === id ? { ...p, label: trimmed } : p)));
+    },
+  }), [pins, update]);
+
+  return <PinnedContext.Provider value={value}>{children}</PinnedContext.Provider>;
+}
+
+export const usePinned = () => useContext(PinnedContext);


### PR DESCRIPTION
Closes #248

## Summary

Phase 1 of the FHIR Explorer redesign (#245). Adds a Pinned section to `CCSidebar` between Resources and the footer, plus a topbar pin action that toggles the current route into / out of Pinned.

- New context provider `apps/demo/src/state/pinned.tsx` keeps pins in `localStorage` under `fhir-place:pinned`, scoped per active server (mirrors the tab-state persistence pattern).
- Topbar pin button (`data-testid="topbar-pin"`) reads filled vs. outline based on whether the current route is pinned, and is disabled on routes where pinning makes no sense (settings, ask, types, `*/new`).
- Pinned rows show bookmark icon + label + small kind label (`id` / `search` / `list`). Active row uses `--accent-soft` / `--accent-text`. Empty state is a dashed-border row with the design's helper copy.
- Right-click on a pin offers Rename + Remove via native dialogs (placeholder until the design system gets a menu primitive — see #248 follow-ups).
- Tier-indicator dots are intentionally **not** included; that's #250 and is gated on #249.

## Test plan

- [x] `pnpm --filter @fhir-place/demo typecheck`
- [x] `pnpm --filter @fhir-place/demo test:run`
- [x] `pnpm --filter @fhir-place/demo e2e` — all 65 specs pass; 3 new pinned specs in `apps/demo/e2e/sidebar-pinned.spec.ts` cover empty state, persistence across reload, and click-to-navigate.
- [x] `pnpm --filter @fhir-place/demo build` (and `react-fhir build`)
- [ ] Manual: pin a Patient list, pin a search-with-query, pin a specific Patient detail, rename one, remove one, switch servers and confirm pins are server-scoped.

## Notes for review

- The `apps/demo/src/state/pinned.ts` filename in the issue is a `.tsx` here because the provider returns JSX.
- Pre-existing `packages/react-fhir` test failures (`AbortSignal` mismatch in vitest 2.x) are unrelated to this change and reproduce on `main`.