### PR TITLE
feat(demo): Sentry diagnostics panel on Settings + structured logs

### DIFF
--- a/apps/demo/.env.example.sentry
+++ b/apps/demo/.env.example.sentry
@@ -13,7 +13,8 @@
 
 # ── Runtime (client) ──────────────────────────────────────────────────────
 # Required: DSN from Sentry project settings → Client Keys.
-# When unset, src/instrument.ts is a no-op and the app behaves as today.
+# When unset, src/instrument.ts is a no-op, the Settings page hides its
+# "Sentry diagnostics" section, and the app behaves as today.
 VITE_SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project-id>
 
 # Optional: tags every event with a release. Recommended in CI; pass the

--- a/apps/demo/src/instrument.ts
+++ b/apps/demo/src/instrument.ts
@@ -33,6 +33,8 @@ if (dsn) {
     tracePropagationTargets: parseTraceTargets(
       import.meta.env.VITE_SENTRY_TRACE_TARGETS,
     ),
+    // Enables Sentry.logger.* (structured log → trace correlation in Sentry).
+    enableLogs: true,
   });
 }
 

--- a/apps/demo/src/routes/fhir-ui/pages/SettingsPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/SettingsPage.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/react";
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import {
@@ -238,7 +239,59 @@ export function SettingsPage() {
           />
         </label>
       </section>
+
+      {/* Sentry diagnostics — only shown when a DSN is configured at build time. */}
+      {import.meta.env.VITE_SENTRY_DSN && <SentryDiagnostics />}
     </div>
+  );
+}
+
+function SentryDiagnostics() {
+  return (
+    <section
+      style={{
+        background: "var(--surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 10,
+        padding: 20,
+        marginTop: 16,
+      }}
+      data-testid="sentry-diagnostics-section"
+    >
+      <h2 style={{ fontSize: 14, fontWeight: 600, margin: "0 0 4px", color: "var(--text)" }}>
+        Sentry diagnostics
+      </h2>
+      <p style={{ fontSize: 12, color: "var(--text-muted)", margin: "0 0 14px", lineHeight: 1.5 }}>
+        Send a test event to verify the dashboard is wired up. Visible only when{" "}
+        <code style={{ fontFamily: CC_MONO, fontSize: 11 }}>VITE_SENTRY_DSN</code> is set at build time.
+      </p>
+      <div style={{ display: "flex", gap: 8 }}>
+        <button
+          onClick={() =>
+            Sentry.captureMessage("Sentry diagnostics: test message", "info")
+          }
+          style={ccBtn("ghost")}
+          data-testid="sentry-test-message"
+        >
+          Send test message
+        </button>
+        <button
+          onClick={() => {
+            Sentry.logger.info("User triggered test error", {
+              action: "settings_test_error_button",
+            });
+            // Thrown from an event handler — bypasses ErrorBoundary by design
+            // (React 16+ doesn't catch event-handler errors), reaches Sentry
+            // via window.onerror so the page stays usable.
+            throw new Error("Sentry diagnostics: this is your first error!");
+          }}
+          style={ccBtn("danger")}
+          data-testid="sentry-test-error"
+        >
+          Break the world
+        </button>
+      </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
Follow-up to #236. Adds a self-service way to verify Sentry is wired up without crafting a console one-liner.

## What

- New "Sentry diagnostics" section on the Settings page with two buttons:
  - **Send test message** — calls `Sentry.captureMessage("…", "info")`. Shows up under Issues as a non-error event.
  - **Break the world** — calls `Sentry.logger.info(…)` then `throw new Error(…)`. The throw originates from a React event handler so it bypasses `Sentry.ErrorBoundary` (React 16+ doesn't catch event-handler errors by design) and reaches Sentry via `window.onerror`. The page stays usable.
- Section is gated on `import.meta.env.VITE_SENTRY_DSN` being set at build time, so it stays hidden on the public GitHub Pages deploy and doesn't appear for ordinary visitors.
- `enableLogs: true` added to `Sentry.init()` in `apps/demo/src/instrument.ts` — `Sentry.logger.*` is otherwise a no-op.

## Test plan

- [x] `pnpm --filter @fhir-place/demo typecheck` passes
- [x] `pnpm --filter @fhir-place/demo build` passes (no DSN set → section is dead code, panel hidden)
- [ ] Build with `VITE_SENTRY_DSN=...` → Settings page shows the diagnostics section
- [ ] Click **Send test message** → event appears under Issues in the Sentry dashboard within ~15s
- [ ] Click **Break the world** → unhandled error event appears in dashboard, page stays usable

## Notes

- No e2e regression added — the section is gated on a build-time env var that the test suite doesn't set, so a positive Playwright assertion would need a separate Sentry-enabled build profile. Out of scope for this PR.
- Once you've confirmed the dashboard is receiving events, you can leave the panel in place (it's only visible to deploys with a DSN) or remove it in a one-liner cleanup PR.

https://claude.ai/code/session_01KpNjh12E2X76WZoAdQvpz7

---
_Generated by [Claude Code](https://claude.ai/code/session_012as4h7outhqcQxZ7PXGPbw)_