### PR TITLE
test(valuesets): verify AC3 — administrative-gender byte-equivalent to generated

### DIFF
--- a/.changeset/auto-generate-bundled-r4-valuesets.md
+++ b/.changeset/auto-generate-bundled-r4-valuesets.md
@@ -1,0 +1,5 @@
+---
+"@fhir-place/react-fhir": minor
+---
+
+Add `pnpm sync:valuesets` script that regenerates `valuesets.generated.ts` from a cached `expansions.json` extracted from the official FHIR R4 `definitions.json.zip`. The generated map now ships ~500 pre-expanded ValueSets (those with ≤500 codes and a complete expansion). `coreValueSet()` consults hand-curated entries first so intentional overrides are preserved. Closes #163.

--- a/packages/react-fhir/src/structure/core/valuesets.test.ts
+++ b/packages/react-fhir/src/structure/core/valuesets.test.ts
@@ -8,6 +8,7 @@ import { MedicationRequestStructureDefinition } from "../../../test/fixtures/Str
 import { PatientStructureDefinition } from "../../../test/fixtures/StructureDefinition-Patient.js";
 import { ProcedureStructureDefinition } from "../../../test/fixtures/StructureDefinition-Procedure.js";
 import { bundledValueSetUrls, coreValueSet, coreValueSets } from "./valuesets.js";
+import { generatedCoreValueSets } from "./valuesets.generated.js";
 
 describe("bundled core ValueSets", () => {
   it("returns undefined for an unknown canonical URL", () => {
@@ -49,6 +50,21 @@ describe("bundled core ValueSets", () => {
     for (const url of coreValueSets.keys()) {
       expect(bundledValueSetUrls).toContain(url);
     }
+  });
+
+  it("administrative-gender hand-curated codes are byte-equivalent to the generated counterpart", () => {
+    // Acceptance criterion: at least one hand-curated entry must match the
+    // generated map exactly so we know the sync script produces correct output.
+    // If a future regen produces different codes/displays, that means spec drift
+    // which should be reviewed and the hand-curated entry updated or marked as
+    // an intentional override.
+    const url = "http://hl7.org/fhir/ValueSet/administrative-gender";
+    const handCurated = codesFromValueSet(coreValueSets.get(url));
+    const generated = codesFromValueSet(generatedCoreValueSets.get(url));
+    expect(generated.length).toBeGreaterThan(0);
+    expect(handCurated.map((c) => ({ system: c.system, code: c.code, display: c.display }))).toEqual(
+      generated.map((c) => ({ system: c.system, code: c.code, display: c.display })),
+    );
   });
 
   it("every bundled ValueSet produces at least one code", () => {


### PR DESCRIPTION
Closes #163

## Summary

- Adds a test to `valuesets.test.ts` that imports `generatedCoreValueSets` directly and asserts the `administrative-gender` hand-curated entry is byte-equivalent (same `system`/`code`/`display` per code) to the generated counterpart — satisfying acceptance criterion 3.
- Adds a changeset entry (`minor`) documenting the auto-generate feature already shipped in main (sync script, generated file, `coreValueSet()` fallback, gitignore, README).

The other acceptance criteria were already satisfied in main by commit `473292d`:
- AC1: `pnpm sync:valuesets` is in `packages/react-fhir/package.json`.
- AC2: `coreValueSet()` checks `coreValueSets.get(canonical)` before `generatedCoreValueSets.get(canonical)`.
- AC4: `packages/react-fhir/scripts/cache/r4-spec/` is gitignored; `README.md` explains how to populate it.
- AC5: All 24 valuesets tests (including the new one) pass.

## Test plan

- [ ] `pnpm --filter @fhir-place/react-fhir test:run` passes with 24 tests in `valuesets.test.ts`
- [ ] `pnpm -r typecheck` passes cleanly
- [ ] New test `administrative-gender hand-curated codes are byte-equivalent to the generated counterpart` is visible in the test output
- [ ] No user-visible change — screenshots: N/A — no user-visible change

https://claude.ai/code/session_01FQLHupPKqebTcrDQrL9cfi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQLHupPKqebTcrDQrL9cfi)_