### PR TITLE
docs(dispatch): remove 10-open-bot-PRs cap

### DIFF
--- a/docs/prompts/hourly-engineer-dispatch.md
+++ b/docs/prompts/hourly-engineer-dispatch.md
@@ -34,8 +34,6 @@ See also:
   - At most 3 tickets per invocation.
   - At most 200 GitHub API calls. If close to the cap, finish the current
     ticket and skip the rest.
-  - Skip the whole run if there are already 10+ open `bot/*` PRs — drain
-    first.
 
 ---
 
@@ -147,7 +145,7 @@ _Last run: YYYY-MM-DD HH:MM UTC. Pause: add `status: agent-paused` to this issue
 - Ready (derived): N
 - status: in-progress: N
 - status: needs-human: N
-- Open `bot/*` PRs: N / 10 cap
+- Open `bot/*` PRs: N
 
 ## Kill switch
 


### PR DESCRIPTION
## Summary

- Drop the hard rule in `docs/prompts/hourly-engineer-dispatch.md` that skipped the hourly engineer-dispatch run whenever 10+ `bot/*` PRs were already open.
- Remove the matching `/ 10 cap` suffix from the rolling tracking-issue template so the dashboard just reports `Open bot/* PRs: N`.

## Why

There are currently 12 open `bot/*` PRs, which means dispatch is freezing instead of picking up new work. The cap was meant as a drain-first safety valve, but it's now blocking throughput; the per-run caps (3 tickets, 200 API calls) are still in place, so blast radius is unchanged.

## Test plan

N/A — no user-visible change. Documentation/prompt-only edit; no code, tests, or UI affected.

https://claude.ai/code/session_01U8jTzANFRBSjhxQmga4gC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8jTzANFRBSjhxQmga4gC6)_