### PR TITLE
fix(ci): pin pnpm version in pages.yml to fix Deploy to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,6 +54,8 @@ jobs:
           path: staging-src
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## Summary

- `pages.yml` checks out the repo into `main-src/` and `staging-src/` subdirectories before running `pnpm/action-setup@v4`
- Because the action runs from the runner's root working directory (not `main-src/`), it can't auto-detect the pnpm version from the `packageManager` field in `package.json`
- Fix: explicitly set `version: 10` on the action, matching `"packageManager": "pnpm@10.33.0"` in the root `package.json`

The other workflows (`ci.yml`, `integration.yml`, etc.) check out to `.` so they work fine — no changes needed there.

## Test plan

- [ ] Verify the "Deploy demo to GitHub Pages / build" job passes after merging
- [ ] Confirm the Pages site deploys successfully at the expected URL

## Screenshots

N/A — no user-visible change

https://claude.ai/code/session_01SypcqyS2eLe8Jxjfxuavy5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SypcqyS2eLe8Jxjfxuavy5)_