### PR TITLE
feat: add Codespaces devcontainer and Claude Code session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote Claude Code (web) sessions
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Ensure pnpm is available
+if ! command -v pnpm &>/dev/null; then
+  npm install -g pnpm@10.33.0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
+
+# Install all workspace dependencies (fast when node_modules is cached)
+pnpm install
+
+# Build the react-fhir package so the demo app can import it
+pnpm --filter @fhir-place/react-fhir build
+
+# Install Playwright's Chromium browser if not already present
+npx playwright install chromium --with-deps 2>/dev/null || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "fhir-place",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    }
+  },
+  "postCreateCommand": "npm install -g pnpm@10.33.0 && pnpm install && pnpm --filter @fhir-place/react-fhir build && npx playwright install --with-deps chromium",
+  "forwardPorts": [5173, 4173],
+  "portsAttributes": {
+    "5173": {
+      "label": "Dev server",
+      "onAutoForward": "notify"
+    },
+    "4173": {
+      "label": "Preview server",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        "ms-playwright.playwright"
+      ],
+      "settings": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true,
+        "typescript.tsdk": "node_modules/typescript/lib"
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ packages/react-fhir/fhir_spec/
 # JSON files under apps/demo/public/fhir-r4/ ARE committed.
 apps/demo/scripts/cache/
 
-# Claude editor metadata (ignore everything except shared subagent definitions)
+# Claude editor metadata (ignore everything except shared subagent definitions,
+# the session-start hook, and project settings)
 .claude/*
 !.claude/agents/
+!.claude/hooks/
+!.claude/settings.json


### PR DESCRIPTION
## Summary

- Adds `.devcontainer/devcontainer.json` so GitHub Codespaces spin up with Node 22, pnpm pre-installed, `react-fhir` built, Chromium for Playwright, and ports 5173/4173 forwarded
- Adds `.claude/hooks/session-start.sh` — a Claude Code on the web session-start hook that runs `pnpm install` + `react-fhir build` before each session, so tests and linters are ready immediately
- Updates `.gitignore` to also track `.claude/hooks/` and `.claude/settings.json` (previously fully ignored)

## N/A — no user-visible change

This is a pure infrastructure change; no demo app UI was modified.

## Test plan

- [ ] Open a new Codespace from `main` (or this branch) — verify the `postCreateCommand` completes and `pnpm dev` starts the Vite server on port 5173
- [ ] Verify `pnpm test:run` passes in the Codespace (387 unit tests)
- [ ] Verify `pnpm --filter @fhir-place/react-fhir lint` runs (pre-existing lint error in `HintedDetail.tsx` is unrelated to this PR)
- [ ] For Claude Code on the web: start a session against this branch and confirm dependencies are installed before the first prompt

https://claude.ai/code/session_01NA2keWwUQ8FtRf2o4qpMLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01NA2keWwUQ8FtRf2o4qpMLA)_