### PR TITLE
fix(demo): honour saved column selection on first paint

### DIFF
--- a/apps/demo/e2e/patient-field-picker.spec.ts
+++ b/apps/demo/e2e/patient-field-picker.spec.ts
@@ -46,6 +46,31 @@ test.describe("patient field-picker options", () => {
     ).toBeVisible();
   });
 
+  test("Saved column selection is honoured on the table's first paint, before any toggle", async ({
+    page,
+  }) => {
+    // Regression: the page state used to initialise from defaults while
+    // <ColumnPicker> read localStorage internally, so the table briefly
+    // disagreed with the picker until the user toggled a checkbox.
+    await resetPrefs(page);
+    await page.goto("/");
+    await page.evaluate(
+      ([colKey]) => {
+        localStorage.setItem(colKey, JSON.stringify(["identifier", "name", "id"]));
+        localStorage.setItem("fhir-place-demo-patient-layout", "table");
+      },
+      [COLUMN_KEY],
+    );
+
+    await page.goto("/Patient");
+    await expect(page.getByTestId("resource-table")).toBeVisible();
+
+    // Saved columns should appear without opening the picker or toggling anything.
+    await expect(page.getByRole("columnheader", { name: /identifier/i })).toBeVisible();
+    // Default-but-unselected columns must not render on first paint.
+    await expect(page.getByRole("columnheader", { name: /^gender$/i })).toHaveCount(0);
+  });
+
   test("Fields picker on the patient detail page filters rendered top-level elements", async ({
     page,
   }) => {

--- a/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceListPage.tsx
@@ -42,6 +42,24 @@ const readPageSize = (): number => {
     : DEFAULT_PAGE_SIZE;
 };
 
+// Read a previously-saved column selection so the table's first paint
+// matches what `<ColumnPicker>` will display, instead of falling back to
+// defaults until the user toggles a checkbox.
+const readPersistedColumns = (rt: string): string[] | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(columnKey(rt));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed) && parsed.every((v) => typeof v === "string")) {
+      return parsed;
+    }
+  } catch {
+    // localStorage unavailable or value malformed — treat as missing.
+  }
+  return null;
+};
+
 const readLayout = (rt: string, scoped: boolean): Layout => {
   if (scoped) return "table";
   if (typeof window === "undefined") return "list";
@@ -204,10 +222,16 @@ export function ResourceListPage() {
     [config?.defaultVisibleColumns, derivedDefaults],
   );
 
-  const [columns, setColumns] = useState<string[]>(defaultVisibleColumns);
+  // Single source of truth for column visibility. Reading localStorage in the
+  // lazy initializer means the table's first paint already reflects the
+  // user's saved selection, so it cannot disagree with `<ColumnPicker>`.
+  const [columns, setColumns] = useState<string[]>(
+    () => readPersistedColumns(resourceType) ?? defaultVisibleColumns,
+  );
   useEffect(() => {
     const available = new Set(tableColumns.map((c) => c.path));
-    setColumns(defaultVisibleColumns.filter((path) => available.has(path)));
+    const base = readPersistedColumns(resourceType) ?? defaultVisibleColumns;
+    setColumns(base.filter((path) => available.has(path)));
   }, [resourceType, tableColumns, defaultVisibleColumns]);
 
   const askAI = useCallback(
@@ -456,6 +480,7 @@ export function ResourceListPage() {
         {layout === "table" && (
           <ColumnPicker
             options={tableColumns}
+            selected={columns}
             defaultSelected={defaultVisibleColumns}
             onChange={setColumns}
             storageKey={columnKey(resourceType)}


### PR DESCRIPTION
## Summary

- `ResourceListPage` was initialising `columns` from `defaultVisibleColumns` while `<ColumnPicker>` independently hydrated its `internalSelected` from `localStorage` in a mount effect. On first paint after routing into the table view with persisted preferences, the picker's checkboxes reflected the saved selection but `<ResourceTable>` rendered the defaults — so the user saw fewer (or different) columns than the picker claimed. Toggling any checkbox forced the parent state to sync, which is why "click on a new column" suddenly made the others appear.
- Make `ResourceListPage` the single source of truth: `useState` now uses a lazy initializer that reads `localStorage` synchronously, the reconciliation `useEffect` re-reads `localStorage` so each resource type's selection is applied immediately on navigation, and `<ColumnPicker>` runs in controlled mode via `selected={columns}` — no parallel internal state to drift from the parent.
- Adds a regression e2e (`patient-field-picker.spec.ts`) that pre-seeds `localStorage` with a non-default selection, navigates to `/Patient`, and asserts the chosen columns render on first paint without any toggle.

## Screenshots

N/A — behavior-only fix on first paint. The rendered table and picker now agree on the saved selection (previously they disagreed for one render). No layout, styling, or copy change; existing e2e screenshot baselines remain valid. The new regression test asserts the corrected behaviour directly.

## Test plan

- [x] `pnpm --filter @fhir-place/demo typecheck` passes.
- [ ] `pnpm --filter @fhir-place/demo e2e -- patient-field-picker` passes (including the new "Saved column selection is honoured on the table's first paint" case).
- [ ] Manual: with `fhir-place-demo-patient-columns` set to a non-default array in `localStorage`, navigate to `/Patient` in table layout and confirm the saved columns render immediately.

https://claude.ai/code/session_01BA4uaruhgCETnLUQ3qjVG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BA4uaruhgCETnLUQ3qjVG1)_