### PR TITLE
fix(ci): drop pnpm version input that collides with packageManager

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,8 +54,6 @@ jobs:
           path: staging-src
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## Summary

- `pnpm/action-setup@v4` was failing with `ERR_PNPM_BAD_PM_VERSION` because
  it received `version: 10` from the workflow *and* `pnpm@10.33.0` from
  `package.json`'s `packageManager` field.
- Removed the redundant `version: 10` input from `pages.yml` and
  `release.yml` so the action derives the version from `packageManager`
  (the recommended single source of truth, matching all other workflows in
  the repo).

N/A — no user-visible change.

## Test plan

- [ ] CI green on this PR (the same `actions/checkout` + `pnpm/action-setup` step that was failing now runs).
- [ ] `pages.yml` and `release.yml` resolve pnpm 10.33.0 from `package.json`.

https://claude.ai/code/session_01G2WPWcvEstNgoAd3YRLNFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2WPWcvEstNgoAd3YRLNFm)_