### PR TITLE
fix(ci): indent JS template literal inside integration.yml

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -100,9 +100,9 @@ jobs:
                   issue_number: match.number,
                   body: `Failed again in ${runUrl}
 
-\`\`\`
-${failureText}
-\`\`\``,
+            \`\`\`
+            ${failureText}
+            \`\`\``,
                 });
               } else {
                 await github.rest.issues.create({


### PR DESCRIPTION
## Summary

Lines 103-105 of `.github/workflows/integration.yml` had no leading whitespace. The YAML `script: |` block scalar's minimum indent is 12 (set by line 55), so those three lines escaped the block and were parsed as top-level YAML — producing `Invalid workflow file: .github/workflows/integration.yml#L103` on every push to main (e.g. [run 25355608980](https://github.com/danielsperoniteam/fhir-place/actions/runs/25355608980)).

Fix: indent the three lines to exactly 12 spaces. After YAML strips the indent, the JS template literal still produces a column-0 ``` markdown fence in the issue body, so the user-visible output is unchanged.

## Notes

- This is **not** a permissions issue and not the Pages workflow. The branch was named for permissions because that was the initial hypothesis; the actual root cause was a YAML syntax error.
- If `pages.yml` is also failing, please link a Pages run and I'll dig into that separately.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/integration.yml'))"` parses cleanly.
- [ ] Confirm next push to main no longer shows the "Invalid workflow file" annotation on `integration.yml`.

N/A — no user-visible change.

https://claude.ai/code/session_016vH1VpXFqgQKWxR3Ttszog

---
_Generated by [Claude Code](https://claude.ai/code/session_016vH1VpXFqgQKWxR3Ttszog)_