### PR TITLE
Default to SMART Health IT instead of HAPI

### DIFF
--- a/apps/demo/src/config.ts
+++ b/apps/demo/src/config.ts
@@ -28,16 +28,16 @@ export interface ServerConfig {
  */
 export const BUILTIN_SERVERS: ReadonlyArray<ServerConfig> = [
   {
-    id: "builtin-hapi",
-    label: "HAPI Public Test Server",
-    baseUrl: "https://hapi.fhir.org/baseR4",
+    id: "builtin-smart",
+    label: "SMART Health IT (R4)",
+    baseUrl: "https://r4.smarthealthit.org",
     authMode: "none",
     builtin: true,
   },
   {
-    id: "builtin-smart",
-    label: "SMART Health IT (R4)",
-    baseUrl: "https://r4.smarthealthit.org",
+    id: "builtin-hapi",
+    label: "HAPI Public Test Server",
+    baseUrl: "https://hapi.fhir.org/baseR4",
     authMode: "none",
     builtin: true,
   },
@@ -173,9 +173,9 @@ export const saveActiveServerId = (id: string): void => {
 };
 
 const FALLBACK_SERVER: ServerConfig = {
-  id: "builtin-hapi",
-  label: "HAPI Public Test Server",
-  baseUrl: "https://hapi.fhir.org/baseR4",
+  id: "builtin-smart",
+  label: "SMART Health IT (R4)",
+  baseUrl: "https://r4.smarthealthit.org",
   authMode: "none",
   builtin: true,
 };

--- a/apps/goals-tasks/src/config.ts
+++ b/apps/goals-tasks/src/config.ts
@@ -5,7 +5,7 @@ const BASE = import.meta.env.BASE_URL;
 
 export const FHIR_BASE_URL: string =
   import.meta.env.VITE_FHIR_BASE_URL ??
-  (USE_MOCK ? `${BASE}fhir` : "https://hapi.fhir.org/baseR4");
+  (USE_MOCK ? `${BASE}fhir` : "https://r4.smarthealthit.org");
 
 export const ROUTER_BASENAME: string = BASE.replace(/\/$/, "") || "/";
 


### PR DESCRIPTION
## Summary

- Reorder `BUILTIN_SERVERS` in `apps/demo/src/config.ts` so `builtin-smart` is first. `resolveActiveServer` returns `servers[0]` when no active id is stored, so first-time visitors now land on SMART Health IT instead of HAPI.
- Update the hardcoded `FALLBACK_SERVER` (used only when the merged builtins list is empty) to match.
- Update `apps/goals-tasks/src/config.ts` non-mock fallback URL to `https://r4.smarthealthit.org` so both demo apps pick the same default.

Existing user customizations are preserved — anyone who already picked a server has its id in `localStorage` under `fhir-place:active-server` and `resolveActiveServer` will keep using it. Only fresh sessions see the new default.

## Test plan

- [x] `pnpm --filter @fhir-place/demo test:run` — 78/78 pass (config tests rely on `BUILTIN_SERVERS[0]!.id`, so they automatically follow the reorder)
- [ ] Manual: open the demo with cleared localStorage; verify the base-URL chip reads "SMART Health IT (R4)" and the patient list loads from `r4.smarthealthit.org`
- [ ] Manual: open with an existing `fhir-place:active-server` set to `builtin-hapi`; verify it still resolves to HAPI

## Screenshots

N/A — the only user-visible difference is the header chip text and the data shown (which comes from the upstream FHIR server). No layout, component, or styling change. Playwright browsers could not be installed in this sandbox, so I could not capture before/after frames; please regenerate `apps/demo/e2e/__screenshots__/` if any baseline contains the HAPI label as part of the chip.

https://claude.ai/code/session_01BkzuJf6qXPJHkKARkJFYh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkzuJf6qXPJHkKARkJFYh9)_