### PR TITLE
fix(security): escape FHIR data in JSON viewer (#360)

### DIFF
--- a/apps/demo/e2e/json-viewer-xss.spec.ts
+++ b/apps/demo/e2e/json-viewer-xss.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Regression for issue #360 — stored XSS in the JSON viewer on every
+ * resource detail page. `colorJson` used to feed FHIR data straight into
+ * `dangerouslySetInnerHTML` without HTML-escaping. A Patient with a
+ * crafted `text.div` (a required FHIR element on most resources) carrying
+ * `<img src=x onerror=...>` would execute attacker JS in the viewer's
+ * origin and could exfiltrate the bearer tokens / Anthropic API key we
+ * cache in localStorage.
+ *
+ * The fix HTML-escapes each line before the highlighter runs, so the
+ * payload renders as text. This test asserts:
+ *   1. `window.__pwn` is never set (the onerror handler never fires).
+ *   2. No `<img>` element materializes in the document.
+ */
+test.describe("JSON viewer XSS", () => {
+  test("escapes attacker-supplied HTML in FHIR data", async ({ page }) => {
+    // Inject a one-shot MSW handler that returns a poisoned Patient. The
+    // dev SPA runs MSW in a service worker and exposes its handles via
+    // `window.__msw` (see apps/demo/src/main.tsx) — same pattern as
+    // delete-error.spec.ts.
+    await page.goto("/fhir-ui/Patient");
+    await page.waitForFunction(() => {
+      return Boolean((window as unknown as { __msw?: unknown }).__msw);
+    });
+    await page.evaluate(() => {
+      const m = (
+        window as unknown as {
+          __msw: {
+            worker: { use: (...args: unknown[]) => void };
+            http: { get: (path: string, h: () => unknown) => unknown };
+            HttpResponse: { json: (body: unknown, init?: unknown) => unknown };
+          };
+        }
+      ).__msw;
+      m.worker.use(
+        m.http.get("*/fhir/Patient/poc-xss", () =>
+          m.HttpResponse.json({
+            resourceType: "Patient",
+            id: "poc-xss",
+            text: {
+              status: "generated",
+              div: '<div xmlns="http://www.w3.org/1999/xhtml"><img src=x onerror="window.__pwn=true"></div>',
+            },
+            name: [{ given: ["Pwn"], family: "Test" }],
+          }),
+        ),
+      );
+    });
+
+    // Navigate within the SPA via the History API rather than `page.goto`,
+    // which would do a full reload and tear down the MSW worker (along with
+    // our one-shot handler).
+    await page.evaluate(() => {
+      window.history.pushState({}, "", "/fhir-ui/Patient/poc-xss");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    await expect(page.getByTestId("resource-json")).toBeVisible();
+
+    // The onerror payload must never run. If `__pwn` is set, the viewer
+    // parsed the FHIR-supplied HTML — that's the bug.
+    expect(
+      await page.evaluate(() => (window as unknown as { __pwn?: boolean }).__pwn),
+    ).toBeUndefined();
+
+    // And the payload must not have materialized as an actual <img> in
+    // the document — neither inside the JSON pane nor anywhere else.
+    await expect(page.locator("img[onerror]")).toHaveCount(0);
+
+    // Sanity check: the escaped payload IS visible as text in the JSON
+    // viewer, so the fix didn't accidentally drop the field.
+    await expect(page.getByTestId("resource-json")).toContainText("onerror");
+  });
+});

--- a/apps/demo/src/routes/fhir-ui/pages/ResourceDetailPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceDetailPage.tsx
@@ -19,8 +19,27 @@ import { patientFieldOptions } from "../../../patientFields.js";
 
 const PATIENT_FIELDS_KEY = "fhir-place-demo-patient-detail-fields";
 
+// Stored XSS in the JSON viewer (issue #360): the highlighter output below
+// is fed into `dangerouslySetInnerHTML`, so any FHIR data containing `<`,
+// `>`, or `&` (e.g. a Patient's `text.div` carrying `<img src=x onerror=...>`)
+// used to execute attacker JS in the viewer's origin and could exfiltrate
+// the bearer tokens we cache in localStorage. Escape every line BEFORE
+// running the highlight regexes. We deliberately do not escape `"` or `'`
+// — they are harmless in HTML text-content position (the highlighter writes
+// its spans there, never into attribute values) and leaving them alone keeps
+// the existing token regexes working unchanged.
+const HTML_ESCAPE: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+};
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>]/g, (c) => HTML_ESCAPE[c] ?? c);
+}
+
 function colorJson(line: string): string {
-  return line
+  return escapeHtml(line)
     .replace(
       /("(?:[^"\\]|\\.)*")(\s*:)/g,
       `<span style="color:var(--accent-text)">$1</span>$2`,
@@ -431,6 +450,7 @@ export function ResourceDetailPage() {
             {/* JSON content */}
             {(rightPane === "json" || rightPane === "formatted") && (
               <div
+                data-testid="resource-json"
                 style={{
                   flex: 1,
                   overflow: "auto",


### PR DESCRIPTION
## Summary

P0 stored XSS in the JSON viewer on every resource detail page. `colorJson` in `apps/demo/src/routes/fhir-ui/pages/ResourceDetailPage.tsx` wrapped JSON tokens in `<span>` tags and fed the result into `dangerouslySetInnerHTML` without HTML-escaping the input. Any FHIR resource whose serialized JSON contained `<`, `>`, or `&` (essentially any resource with a `text.div` narrative — required on most resources per the FHIR spec) injected raw HTML into the viewer's origin. A crafted Patient `text.div` like `<img src=x onerror="...">` ran attacker JS and could exfiltrate the bearer tokens / Anthropic API key cached in `localStorage`.

## Fix

Issue #360 sketched two options. This is option 2 (minimum diff, preserves syntax highlighting).

- New `escapeHtml(s)` helper escapes `&`, `<`, `>` only.
- `colorJson` runs the input through `escapeHtml` before the four highlight regexes fire. The regexes match against `"`, `:`, digits, and the keywords `true`/`false`/`null` — none of which become entity refs after escaping — so highlighted output for benign FHIR data is byte-identical.
- `"` and `'` are deliberately left alone. They are harmless in HTML text-content position (the highlighter writes its spans there, never into attribute values) and leaving them lets the existing `"`-anchored token regexes keep working.
- Added `data-testid="resource-json"` on the JSON pane container so the regression spec can target it.

## Audit (acceptance criterion 3)

Searched `apps/demo/src/**/*.tsx` and `packages/**/*.tsx` for `dangerouslySetInnerHTML`. Findings:

| Location | Status |
|---|---|
| `apps/demo/src/routes/fhir-ui/pages/ResourceDetailPage.tsx:460` | **Fixed** in this PR. |
| `packages/react-fhir/src/components/Narrative.tsx:30` | **Safe.** Routes input through `DOMPurify.sanitize` with a tight allow-list (`FORBID_TAGS: script/style/iframe/object/embed/form/input`, `FORBID_ATTR: style/on*`). Documented as the single sanctioned sink for FHIR narrative HTML; `packages/react-fhir/README.md` mirrors that contract. |

No other `dangerouslySetInnerHTML` occurrences exist in the demo app or library.

## Test added

`apps/demo/e2e/json-viewer-xss.spec.ts` — adopts the issue's test plan with two adjustments forced by the runtime:

1. Uses the existing `window.__msw` runtime-override pattern (same as `delete-error.spec.ts`) rather than `page.route` — the SPA's MSW worker intercepts FHIR calls before Playwright sees them.
2. Navigates to `/fhir-ui/Patient/poc-xss` via `history.pushState` + `popstate` rather than `page.goto`, because BrowserRouter does a full reload on `goto` and that tears down the MSW worker (and the one-shot handler) before the FHIR request fires.

Asserts:
- `window.__pwn` is never set (the `onerror` payload never fires)
- `page.locator("img[onerror]")` has count 0 (no `<img>` element materializes)
- The JSON pane still contains the literal text `onerror` (sanity check that the field rendered as text, not silently dropped)

## Tests run

- `pnpm --filter @fhir-place/demo typecheck` — clean
- `pnpm --filter @fhir-place/demo test:run` — 78/78 pass
- `pnpm exec playwright test json-viewer-xss --project=chromium` — pass
- Sanity-checked adjacent specs (`delete-error`, `missing-resource`, `patient-field-picker`, `hinted-detail`, `crud.screenshot`) — all pass, no regressions

The repo-wide lint job has a pre-existing unused-import error in `packages/react-fhir/src/components/HintedDetail.tsx` on `main`. Not touched by this PR.

## Screenshots

N/A — security fix, no user-visible change. Highlighted output is unchanged for benign FHIR data.

## Follow-ups

The issue notes that a full `text.div` rendering pass (DOMPurify config tuning, narrative-vs-source toggle, lint rule banning unsanctioned `dangerouslySetInnerHTML`) belongs in a separate ticket. Out of scope here.

Closes #360