### PR TITLE
fix(ci): allow-list dispatch agent tools so it can actually claim issues

### DIFF
--- a/.github/workflows/hourly-engineer-dispatch.yml
+++ b/.github/workflows/hourly-engineer-dispatch.yml
@@ -79,6 +79,21 @@ jobs:
           # subagent invocation needs more turns than the PM routine. Cap
           # at 300 — the workflow timeout-minutes is the real wall-clock
           # bound; this just prevents pathological loops from racing it.
-          claude_args: "--max-turns 300"
+          #
+          # --allowedTools: the action's default tool set is conservative
+          # and excludes Bash, Edit, Write, and Agent. Without this flag
+          # the dispatcher cannot spawn the engineer subagent or do any
+          # of its git/PR work — every call returns a permission denial
+          # (run 25584355918 hit 8 denials and accomplished nothing).
+          # Mirrors the local driver at scripts/dispatch-engineer.sh
+          # (line 68). Verified flag spelling against the action's docs
+          # at docs/configuration.md (camelCase, not --allowed-tools).
+          # Defense in depth: the engineer subagent enforces its own
+          # hard rules; this just bounds what a prompt-injected
+          # dispatcher can call.
+          claude_args: "--max-turns 300 --allowedTools Read,Edit,Write,Bash,Grep,Glob,Agent,mcp__github__*"
+          # Temporary: show full output until 5–10 successful manual runs
+          # (per workflow's own setup notes). Remove once cron is enabled.
+          show_full_output: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Diagnosis

First run of the hourly engineer dispatch ([run 25584355918](https://github.com/danielsperoniteam/fhir-place/actions/runs/25584355918)) finished in 96s with `permission_denials_count: 8` and produced no PRs, no issue claims, no tracking-issue update.

Root cause: `anthropics/claude-code-action@v1` ships with a conservative default tool set. `Bash`, `Edit`, `Write`, and `Agent` are all excluded. The dispatcher prompt at `docs/prompts/hourly-engineer-dispatch.md` needs all of them — `Bash` to check git state, `Agent` to spawn the engineer subagent, and the engineer subagent in turn needs `Bash`/`Edit`/`Write` inside its worktree. Without an explicit allow-list, every meaningful call returns a denial and the agent stalls.

The local driver at `scripts/dispatch-engineer.sh` (line 68) has the working allow-list. It runs successfully against the same prompt; only the GH Actions plumbing was broken.

The action's log also redacts denial messages by default (`Running Claude Code via SDK (full output hidden for security)... enable show_full_output: true in your workflow file for full output`), which is why this took a postmortem to spot.

## Fix

Two edits to `.github/workflows/hourly-engineer-dispatch.yml`:

1. Append `--allowedTools Read,Edit,Write,Bash,Grep,Glob,Agent,mcp__github__*` to `claude_args`. Same allow-list as the local driver. Defense in depth still holds — the engineer subagent's own hard rules (in `.claude/agents/engineer.md`) bound what each invocation can actually do.
2. Add `show_full_output: true` so the next manual run's tool calls and any remaining denials are visible in the log. Marked as temporary in a comment alongside the workflow's existing "5–10 manual runs before enabling cron" note.

## Flag-name verification

Source of truth used:

- `https://raw.githubusercontent.com/anthropics/claude-code-action/main/docs/configuration.md` — quotes the example `"--allowedTools Tool1,Tool2"` (camelCase).
- `https://raw.githubusercontent.com/anthropics/claude-code-action/main/action.yml` — confirms `show_full_output` is a real input on the action.
- Local driver `scripts/dispatch-engineer.sh` line 78 also uses `--allowedTools` (camelCase) and runs cleanly.

Note: the original issue brief proposed `--allowed-tools` (kebab-case) as the likely flag name but flagged it for verification. The verified spelling is camelCase `--allowedTools`.

## Scope

Single-purpose PR. One file, two edits. No changes to:

- `.claude/agents/engineer.md` (engineer subagent — working as designed)
- `docs/prompts/hourly-engineer-dispatch.md` (dispatcher prompt — working as designed)
- Any other workflow file
- Lockfiles, package.json, secrets

## How to verify

After merge:

```
gh workflow run hourly-engineer-dispatch.yml -R danielsperoniteam/fhir-place
```

Or against this branch directly before merge:

```
gh workflow run hourly-engineer-dispatch.yml -R danielsperoniteam/fhir-place --ref bot/fix-engineer-dispatch-allowed-tools
```

Watch the latest run for:

- `permission_denials_count: 0` (or absent)
- Non-zero count of new draft PRs opened on the `bot/issue-*` branch pattern
- The "Engineer dispatch — hourly report" tracking issue picks up an updated comment

If denials persist with `show_full_output: true`, the next debug step has visible denial messages to chase.

## Screenshots

N/A — no user-visible change. CI workflow only.

## Test plan

- [ ] Trigger workflow against this branch via `gh workflow run hourly-engineer-dispatch.yml -R danielsperoniteam/fhir-place --ref bot/fix-engineer-dispatch-allowed-tools`
- [ ] Confirm `permission_denials_count` is 0 in the run summary
- [ ] Confirm at least one draft PR is opened (or, if no ready issues, the dispatcher logs that fact and exits cleanly)
- [ ] Confirm the run log now shows full tool-call output