### PR TITLE
chore: clarify MIT copyright attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 samsuffolksperoni
+Copyright (c) 2026 Daniel Speroni
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "fhir-place",
   "private": true,
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {


### PR DESCRIPTION
## Summary

Two small attribution clarifiers. No code or behavior change.

- **`LICENSE`**: change copyright holder from `samsuffolksperoni` (a GitHub handle) to `Daniel Speroni`. MIT copyright should attach to a natural person, not a username.
- **Root `package.json`**: add `"license": "MIT"`. The root currently has no license field. The published `packages/react-fhir/package.json` already declares MIT, so this just makes the repo root consistent. Apps under `apps/**` are `private: true` and don't need the field.

## Test plan

- [ ] `LICENSE` line 3 reads `Copyright (c) 2026 Daniel Speroni`
- [ ] Root `package.json` has `"license": "MIT"` and remains valid JSON
- [ ] No other files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)