### PR TITLE
refactor(integration-test): delete duplicate SD walker assertion (closes #382, supersedes #336)

### DIFF
--- a/.changeset/delete-duplicate-sd-walker-integration-test.md
+++ b/.changeset/delete-duplicate-sd-walker-integration-test.md
@@ -1,0 +1,21 @@
+---
+"@fhir-place/react-fhir": patch
+---
+
+Delete the duplicate `StructureDefinition` walker assertion from the live
+integration suite (closes #382, supersedes #336).
+
+The integration test in `packages/react-fhir/integration/FhirClient.integration.test.ts`
+was walking `StructureDefinition/Patient` over the wire and asserting on
+both server-shape (`sd.kind === "resource"`) and walker behavior
+(`directChildren()` produces expected Patient paths). The walker
+behavior is already covered deterministically by
+`packages/react-fhir/src/structure/walker.test.ts` against a vendored
+fixture, so the integration version coupled the suite to whatever the
+live `r4.smarthealthit.org` sandbox happened to return.
+
+Replaced with a shape-only interop probe: read the SD, assert
+`resourceType === "StructureDefinition"`. No assertions on `kind` or
+specific element paths.
+
+Test-only change — no runtime code modified.

--- a/packages/react-fhir/integration/FhirClient.integration.test.ts
+++ b/packages/react-fhir/integration/FhirClient.integration.test.ts
@@ -8,7 +8,7 @@ import type {
 } from "fhir/r4";
 import { afterAll, describe, expect, test } from "vitest";
 import { codesFromValueSet } from "../src/structure/binding.js";
-import { directChildren, walkResource } from "../src/structure/walker.js";
+import { walkResource } from "../src/structure/walker.js";
 import {
   FHIR_BASE_URL,
   isFhirError,
@@ -48,20 +48,18 @@ describe.skipIf(!reachable)(`integration: FhirClient @ ${FHIR_BASE_URL}`, () => 
   );
 
   test(
-    "StructureDefinition for Patient walks cleanly through directChildren()",
+    "StructureDefinition/Patient is reachable and parseable",
     async () => {
+      // Shape-only interop probe: we just want to know the endpoint serves a
+      // StructureDefinition we can parse. Walker correctness against R4
+      // Patient is covered deterministically by walker.test.ts against the
+      // vendored fixture; asserting on `kind` or specific element paths here
+      // couples this suite to whatever a live sandbox happens to return.
       const sd = await client.read<StructureDefinition>(
         "StructureDefinition",
         "Patient",
       );
-      expect(sd.kind).toBe("resource");
-      expect(sd.type).toBe("Patient");
-      const kids = directChildren(sd, "Patient");
-      const paths = kids.map((k) => k.path);
-      // A handful of well-known R4 Patient elements that must always be present.
-      for (const p of ["Patient.id", "Patient.name", "Patient.gender", "Patient.birthDate"]) {
-        expect(paths).toContain(p);
-      }
+      expect(sd.resourceType).toBe("StructureDefinition");
     },
     30_000,
   );


### PR DESCRIPTION
## Summary

- The integration test at `packages/react-fhir/integration/FhirClient.integration.test.ts:50-67` was walking `StructureDefinition/Patient` against the live `r4.smarthealthit.org` sandbox and asserting on both server-shape (`sd.kind === "resource"`, `sd.type === "Patient"`) and walker behavior (`directChildren()` produces expected Patient paths).
- The walker assertion is **already covered deterministically** by [`packages/react-fhir/src/structure/walker.test.ts:25-44`](https://github.com/danielsperoniteam/fhir-place/blob/main/packages/react-fhir/src/structure/walker.test.ts#L25-L44) against the vendored Patient fixture at `packages/react-fhir/test/fixtures/StructureDefinition-Patient.ts`. Coupling the integration suite to whatever the live sandbox returns is the wrong layer to verify walker correctness.
- The smarthealthit sandbox has been returning a malformed Patient SD (`kind: "logical"`), which is what surfaced this duplication in the first place.

## Change

Replaced the duplicate test with a **shape-only interop probe**: read the SD, assert `resourceType === "StructureDefinition"`. No assertions on `kind` or specific element paths — the point is reachability, not SD content correctness.

## Why this supersedes #336

PR #336 widened the assertion (`expect(["primitive-type","complex-type","resource","logical"]).toContain(sd.kind)`) so the test would tolerate the malformed sandbox response. That keeps the structural problem — walker behavior under test against a non-deterministic upstream. Deleting the duplicate assertion fixes the actual issue. **Please close #336 in favor of this PR.**

## Screenshots

N/A — no user-visible change (integration test only).

## Test plan

- [x] `pnpm vitest run src/structure/walker.test.ts` in `packages/react-fhir` — 18/18 pass.
- [x] `pnpm typecheck` in `packages/react-fhir` — clean.
- [ ] Trigger the live integration workflow on `main` after merge — confirm the new shape-only probe passes regardless of the upstream sandbox's SD shape.

Closes #382.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>