### PR TITLE
feat(ci): staging→main promotion workflow with branch protection

### DIFF
--- a/.github/workflows/promote-staging.yml
+++ b/.github/workflows/promote-staging.yml
@@ -1,0 +1,308 @@
+# Automatically opens (or updates) a staging -> main promotion PR whenever
+# something is pushed to the staging branch. The PR body aggregates UAT
+# steps from all PRs merged into staging since the last promotion, giving
+# a reviewer a single checklist to walk before approving the release.
+#
+# The PR is assigned to @danielsperoni. Decisions flagged as needing human
+# review are called out explicitly in the body.
+#
+# If the promotion PR has merge conflicts, the workflow attempts automatic
+# resolution via Claude. If resolution fails, it escalates to @danielsperoni
+# with a label and comment.
+#
+# Merge criteria: someone independently validates UAT steps against
+# https://danielsperoniteam.github.io/fhir-place/staging/ , approves,
+# and merges. That triggers pages.yml to rebuild /.
+
+name: Promote staging to main
+
+on:
+  push:
+    branches:
+      - staging
+  workflow_dispatch:  # Manual "Promote" button in Actions UI
+
+permissions:
+  contents: write        # push conflict-resolution commits to staging
+  pull-requests: write
+  issues: read
+  id-token: write        # required by claude-code-action@v1
+
+concurrency:
+  group: promote-staging
+  cancel-in-progress: true  # latest push wins — PR body will reflect newest state
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: staging
+          fetch-depth: 0
+
+      - name: Gather UAT context and create/update PR
+        id: promotion
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // --- 1. Find PRs merged into staging since last promotion ---
+            const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
+              owner, repo,
+              basehead: `main...staging`
+            });
+
+            // Extract PR numbers from merge commit messages
+            const prNumbers = new Set();
+            for (const commit of comparison.commits) {
+              const mergeMatch = commit.commit.message.match(/Merge pull request #(\d+)/);
+              if (mergeMatch) prNumbers.add(parseInt(mergeMatch[1]));
+              const squashMatch = commit.commit.message.match(/\(#(\d+)\)/);
+              if (squashMatch) prNumbers.add(parseInt(squashMatch[1]));
+            }
+
+            // --- 2. Collect UAT steps and metadata from those PRs ---
+            const uatSections = [];
+            const flaggedItems = [];
+            const closedIssues = [];
+
+            for (const prNum of prNumbers) {
+              try {
+                const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNum });
+                const body = pr.body || '';
+
+                const uatMatch = body.match(/## UAT on live staging\s*\n([\s\S]*?)(?=\n## |\n<!--|\s*$)/);
+                const uatContent = uatMatch ? uatMatch[1].trim() : null;
+
+                const issueMatches = body.matchAll(/[Cc]loses?\s+#(\d+)/g);
+                for (const m of issueMatches) closedIssues.push(m[1]);
+
+                const { data: prLabels } = await github.rest.issues.listLabelsOnIssue({
+                  owner, repo, issue_number: prNum
+                });
+                const hasNeedsHuman = prLabels.some(l => l.name === 'status: needs-human');
+
+                if (uatContent && !uatContent.includes('N/A')) {
+                  uatSections.push({ prNum, title: pr.title, uat: uatContent, needsHuman: hasNeedsHuman });
+                }
+
+                if (hasNeedsHuman) {
+                  flaggedItems.push(`- #${prNum}: ${pr.title} — has \`status: needs-human\` label`);
+                }
+              } catch (e) {
+                core.warning(`Could not fetch PR #${prNum}: ${e.message}`);
+              }
+            }
+
+            // --- 3. Build PR body ---
+            const stagingUrl = 'https://danielsperoniteam.github.io/fhir-place/staging/';
+            const aheadBy = comparison.ahead_by;
+
+            let prBody = `## Staging → Main Promotion\n\n`;
+            prBody += `**${aheadBy} commit(s) ahead of main** | `;
+            prBody += `**${prNumbers.size} PR(s) included**\n\n`;
+            prBody += `Validate all UAT steps below against the deployed staging environment:\n`;
+            prBody += `${stagingUrl}\n\n`;
+
+            if (flaggedItems.length > 0) {
+              prBody += `### ⚠️ Flagged for human review\n\n`;
+              prBody += `The following items were flagged as needing human attention:\n\n`;
+              prBody += flaggedItems.join('\n') + '\n\n';
+              prBody += `@danielsperoni — please review these before approving.\n\n`;
+            }
+
+            prBody += `### UAT checklist\n\n`;
+            prBody += `Walk each section against ${stagingUrl} and confirm no regressions.\n\n`;
+
+            if (uatSections.length === 0) {
+              prBody += `_No UAT steps found in the included PRs. `;
+              prBody += `Verify the staging deployment manually before approving._\n\n`;
+            } else {
+              for (const section of uatSections) {
+                prBody += `#### PR #${section.prNum}: ${section.title}\n\n`;
+                prBody += section.uat + '\n\n';
+              }
+            }
+
+            prBody += `### Included PRs\n\n`;
+            for (const prNum of prNumbers) {
+              prBody += `- #${prNum}\n`;
+            }
+
+            if (closedIssues.length > 0) {
+              prBody += `\n### Issues closed by this promotion\n\n`;
+              for (const issue of closedIssues) {
+                prBody += `- Closes #${issue}\n`;
+              }
+            }
+
+            prBody += `\n---\n`;
+            prBody += `_This PR was automatically created/updated by the promote-staging workflow. `;
+            prBody += `Approve and merge once UAT validation passes on staging._\n`;
+
+            // --- 4. Find existing open promotion PR or create a new one ---
+            const { data: existingPRs } = await github.rest.pulls.list({
+              owner, repo,
+              state: 'open',
+              head: `${owner}:staging`,
+              base: 'main'
+            });
+
+            const title = `chore: promote staging to main`;
+            let prNumber;
+
+            if (existingPRs.length > 0) {
+              const existingPR = existingPRs[0];
+              prNumber = existingPR.number;
+              await github.rest.pulls.update({
+                owner, repo,
+                pull_number: prNumber,
+                body: prBody
+              });
+              core.info(`Updated existing promotion PR #${prNumber}`);
+            } else {
+              const { data: newPR } = await github.rest.pulls.create({
+                owner, repo,
+                title,
+                body: prBody,
+                head: 'staging',
+                base: 'main'
+              });
+              prNumber = newPR.number;
+              core.info(`Created promotion PR #${prNumber}`);
+            }
+
+            await github.rest.issues.addAssignees({
+              owner, repo,
+              issue_number: prNumber,
+              assignees: ['danielsperoni']
+            });
+
+            // --- 5. Check mergeable state ---
+            // GitHub needs a moment to compute mergeable status after PR creation/update
+            let mergeable = null;
+            for (let i = 0; i < 5; i++) {
+              await new Promise(r => setTimeout(r, 3000));
+              const { data: prData } = await github.rest.pulls.get({
+                owner, repo, pull_number: prNumber
+              });
+              mergeable = prData.mergeable;
+              if (mergeable !== null) break;
+            }
+
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('has_conflicts', mergeable === false ? 'true' : 'false');
+
+      - name: Setup pnpm
+        if: steps.promotion.outputs.has_conflicts == 'true'
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        if: steps.promotion.outputs.has_conflicts == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.promotion.outputs.has_conflicts == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure git identity
+        if: steps.promotion.outputs.has_conflicts == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Attempt conflict resolution
+        if: steps.promotion.outputs.has_conflicts == 'true'
+        id: resolve
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            The promotion PR #${{ steps.promotion.outputs.pr_number }} (staging → main)
+            has merge conflicts that need resolving.
+
+            Context:
+            - PR number:    ${{ steps.promotion.outputs.pr_number }}
+            - Head branch:  staging
+            - Base branch:  main
+            - Working directory is already checked out on `staging` with full git history.
+
+            Read the file at docs/prompts/pr-resolve-conflicts.md and execute the
+            instructions in it. Do not modify the prompt file itself.
+
+            Additional context: this is the automated promotion PR from staging to main.
+            The staging branch is the source of truth — when in doubt, prefer staging's
+            version. After resolving, push to the staging branch (not main).
+          claude_args: "--max-turns 100"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if conflicts were resolved
+        if: steps.promotion.outputs.has_conflicts == 'true'
+        id: post-resolve
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = parseInt('${{ steps.promotion.outputs.pr_number }}');
+
+            // Re-check mergeable state after resolution attempt
+            let mergeable = null;
+            for (let i = 0; i < 5; i++) {
+              await new Promise(r => setTimeout(r, 3000));
+              const { data: prData } = await github.rest.pulls.get({
+                owner, repo, pull_number: prNumber
+              });
+              mergeable = prData.mergeable;
+              if (mergeable !== null) break;
+            }
+
+            const resolveStepFailed = '${{ steps.resolve.outcome }}' === 'failure';
+            const stillConflicted = mergeable === false;
+
+            if (resolveStepFailed || stillConflicted) {
+              // Escalate: label + comment + request review from danielsperoni
+              await github.rest.issues.addLabels({
+                owner, repo,
+                issue_number: prNumber,
+                labels: ['status: needs-human']
+              });
+
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: prNumber,
+                body: [
+                  '## ⚠️ Merge conflicts could not be resolved automatically',
+                  '',
+                  'The promotion PR has conflicts between `staging` and `main` that ',
+                  'automated resolution was unable to fix.',
+                  '',
+                  '**Action needed:** @danielsperoni please resolve the conflicts manually ',
+                  'or comment `/resolve-conflicts` to retry.',
+                  '',
+                  '_Automated conflict resolution failed at ' + new Date().toISOString() + '_'
+                ].join('\n')
+              });
+
+              await github.rest.pulls.requestReviewers({
+                owner, repo,
+                pull_number: prNumber,
+                reviewers: ['danielsperoni']
+              });
+
+              core.warning(`Conflict resolution failed for PR #${prNumber} — escalated to @danielsperoni`);
+            } else {
+              core.info(`Conflicts resolved successfully for PR #${prNumber}`);
+            }

--- a/.github/workflows/sync-staging.yml
+++ b/.github/workflows/sync-staging.yml
@@ -1,0 +1,102 @@
+# Keeps staging up-to-date with main after direct-to-main merges.
+#
+# When someone merges a PR directly into main (skipping staging — e.g.,
+# docs-only or CI-only changes), this workflow fast-forwards or merges
+# main into staging so staging never falls behind.
+#
+# Uses the admin bypass on the staging ruleset to push directly.
+# Does NOT trigger if the push to main came from the promotion PR
+# (detected by commit message) to avoid infinite loops.
+
+name: Sync staging with main
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write  # push to staging via admin bypass
+
+concurrency:
+  group: sync-staging
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Skip if this push came from the promotion PR merge (avoid loops)
+    if: "!contains(github.event.head_commit.message, 'promote staging to main')"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Check if staging needs sync
+        id: check
+        run: |
+          git fetch origin staging
+          # Check if main has commits not on staging
+          BEHIND=$(git rev-list --count origin/staging..origin/main)
+          echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
+
+      - name: Merge main into staging
+        if: steps.check.outputs.behind != '0'
+        id: merge
+        continue-on-error: true
+        run: |
+          git checkout staging
+          git merge origin/main --no-edit
+          git push origin staging
+
+      - name: Escalate if merge failed
+        if: steps.check.outputs.behind != '0' && steps.merge.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Find open promotion PR to comment on, or create an issue
+            const { data: openPRs } = await github.rest.pulls.list({
+              owner, repo, state: 'open', head: `${owner}:staging`, base: 'main'
+            });
+
+            const body = [
+              '## ⚠️ Staging sync failed',
+              '',
+              'A direct-to-main merge could not be automatically synced to staging ',
+              'due to merge conflicts.',
+              '',
+              '**Action needed:** @danielsperoni please merge main into staging manually:',
+              '```bash',
+              'git checkout staging && git merge origin/main',
+              '```',
+              '',
+              '_Failed at ' + new Date().toISOString() + '_'
+            ].join('\n');
+
+            if (openPRs.length > 0) {
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: openPRs[0].number,
+                body
+              });
+            } else {
+              await github.rest.issues.create({
+                owner, repo,
+                title: 'Staging sync failed — manual merge needed',
+                body,
+                labels: ['status: needs-human', 'area: infra'],
+                assignees: ['danielsperoni']
+              });
+            }

--- a/docs/sdlc/README.md
+++ b/docs/sdlc/README.md
@@ -26,7 +26,7 @@ rolling tracking issue so the audit trail is in GitHub itself.
 | File | Covers |
 | --- | --- |
 | [`agents.md`](./agents.md) | The eight agent personas, what each is allowed to do, and which workflows invoke them. |
-| [`loops.md`](./loops.md) | The five recurring loops + three event-driven workflows, their cadence, and their concurrency model. |
+| [`loops.md`](./loops.md) | The five recurring loops + four event-driven workflows, their cadence, and their concurrency model. |
 | [`lifecycle.md`](./lifecycle.md) | End-to-end journey of one ticket: issue → triage → branch → PR → staging UAT → merge → deploy → live monitor. |
 | [`branch-protection.md`](./branch-protection.md) | Rulesets for `main` and `staging` — merge queue, required checks, and how they interact with the promotion workflow. |
 | [`safety.md`](./safety.md) | Hard rules, blast-radius caps, dedupe markers, the kill switch, and the deny-list. |

--- a/docs/sdlc/README.md
+++ b/docs/sdlc/README.md
@@ -26,8 +26,9 @@ rolling tracking issue so the audit trail is in GitHub itself.
 | File | Covers |
 | --- | --- |
 | [`agents.md`](./agents.md) | The eight agent personas, what each is allowed to do, and which workflows invoke them. |
-| [`loops.md`](./loops.md) | The five recurring loops + two event-driven workflows, their cadence, and their concurrency model. |
+| [`loops.md`](./loops.md) | The five recurring loops + three event-driven workflows, their cadence, and their concurrency model. |
 | [`lifecycle.md`](./lifecycle.md) | End-to-end journey of one ticket: issue → triage → branch → PR → staging UAT → merge → deploy → live monitor. |
+| [`branch-protection.md`](./branch-protection.md) | Rulesets for `main` and `staging` — merge queue, required checks, and how they interact with the promotion workflow. |
 | [`safety.md`](./safety.md) | Hard rules, blast-radius caps, dedupe markers, the kill switch, and the deny-list. |
 | [`gaps.md`](./gaps.md) | What isn't yet wired up — single-issue gaps and bigger themes (agentic users, feature flags), each annotated with a proposed `human-review-needed: low/medium/high` level. |
 

--- a/docs/sdlc/branch-protection.md
+++ b/docs/sdlc/branch-protection.md
@@ -1,0 +1,75 @@
+# Branch protection
+
+Both `main` and `staging` are protected by GitHub repository rulesets.
+The settings mirror each other — the same quality gate applies to both
+branches so that code hitting staging has already passed CI.
+
+## Why a merge queue on staging
+
+Without a merge queue, approving two PRs in quick succession leads to
+the second one going stale (its CI ran against the old base). A human
+would have to come back, click "Update branch", wait for CI again, then
+merge. The merge queue eliminates this: approve multiple PRs, they queue
+up, GitHub rebases each against the latest staging head, runs CI, and
+merges sequentially — no human round-trips.
+
+## Ruleset: Protect staging
+
+| Rule | Setting | Rationale |
+|------|---------|-----------|
+| Deletion | blocked | Prevent accidental branch deletion |
+| Force push | blocked | Preserve history for audit trail |
+| Require PR | 1 approval, dismiss stale reviews on push | Human code review gate |
+| Required status checks | `test`, `e2e` (strict) | CI must pass against latest base |
+| Merge queue | squash, all-green, 5 max entries, 5 min wait | Batch without conflicts |
+
+**Merge method:** squash — keeps staging history clean and one commit per
+feature for easy UAT tracing.
+
+**Strict status checks:** PRs must be up-to-date with staging before
+merge. The merge queue handles this automatically.
+
+## Ruleset: Protect main
+
+| Rule | Setting | Rationale |
+|------|---------|-----------|
+| Deletion | blocked | Never delete main |
+| Force push | blocked | History is sacred |
+| Required status checks | `test`, `e2e` (strict) | Same CI gate as staging |
+| Merge queue | squash, all-green, 5 max entries, 5 min wait | Batch promotions cleanly |
+
+**Note:** Main's ruleset (ID `15901122`) was created 2026-05-03 and is
+currently `enforcement: disabled`. Enable it when ready to enforce the
+merge queue on promotion PRs.
+
+## Bypass actors
+
+**Staging:** The admin repository role (which includes GitHub Actions
+workflows running with `contents: write`) is configured as a bypass
+actor. This allows the `promote-staging.yml` workflow to push
+conflict-resolution commits directly to `staging` without opening a
+separate PR. Human contributors still go through the PR + merge queue
+flow.
+
+**Main:** No bypass actors. All changes must go through a PR.
+
+## Interaction with the promote-staging workflow
+
+The `promote-staging.yml` workflow creates/updates a PR targeting main.
+When the merge queue is active on main, approving and merging that PR
+enters it into the queue — CI runs one final time against main's head
+before the actual merge lands.
+
+If the promotion PR has conflicts:
+1. The workflow attempts automatic resolution via Claude
+2. If resolution fails, it labels the PR `status: needs-human`, posts
+   an escalation comment, and requests review from `@danielsperoni`
+3. The `/resolve-conflicts` command remains available for manual retries
+
+## How to modify these rules
+
+Rulesets are managed via the GitHub API or the repo Settings > Rules UI:
+- Staging: `gh api repos/danielsperoniteam/fhir-place/rulesets/16171731`
+- Main: `gh api repos/danielsperoniteam/fhir-place/rulesets/15901122`
+
+Changes to branch protection are SDLC changes and require human review.

--- a/docs/sdlc/branch-protection.md
+++ b/docs/sdlc/branch-protection.md
@@ -53,6 +53,22 @@ flow.
 
 **Main:** No bypass actors. All changes must go through a PR.
 
+## Skipping staging (fast-track to main)
+
+For non-user-visible changes (docs, CI workflows, markdown-only) you
+can merge directly to `main` by opening a PR with `base: main`. When
+this happens, `sync-staging.yml` fires on the push to `main` and
+automatically merges main back into staging so it stays current.
+
+Fast-track is appropriate when:
+- All changes are `*.md`, `.github/workflows/`, or other non-deployed files
+- The change doesn't need UAT validation on the staging URL
+- You're confident the change won't conflict with in-flight staging work
+
+If the reverse-sync encounters conflicts, it escalates to
+`@danielsperoni` via a comment on the open promotion PR (or a new issue
+if none exists).
+
 ## Interaction with the promote-staging workflow
 
 The `promote-staging.yml` workflow creates/updates a PR targeting main.

--- a/docs/sdlc/branch-protection.md
+++ b/docs/sdlc/branch-protection.md
@@ -35,23 +35,25 @@ merge. The merge queue handles this automatically.
 |------|---------|-----------|
 | Deletion | blocked | Never delete main |
 | Force push | blocked | History is sacred |
+| Require PR | 1 approval, code owner review, dismiss stale | Only a code owner can approve |
 | Required status checks | `test`, `e2e` (strict) | Same CI gate as staging |
 | Merge queue | squash, all-green, 5 max entries, 5 min wait | Batch promotions cleanly |
 
-**Note:** Main's ruleset (ID `15901122`) was created 2026-05-03 and is
-currently `enforcement: disabled`. Enable it when ready to enforce the
-merge queue on promotion PRs.
+**Enforcement:** active (enabled 2026-05-09).
 
 ## Bypass actors
 
 **Staging:** The admin repository role (which includes GitHub Actions
 workflows running with `contents: write`) is configured as a bypass
-actor. This allows the `promote-staging.yml` workflow to push
-conflict-resolution commits directly to `staging` without opening a
-separate PR. Human contributors still go through the PR + merge queue
-flow.
+actor. This allows the `promote-staging.yml` and `sync-staging.yml`
+workflows to push directly to `staging` without opening a separate PR.
+Human contributors still go through the PR + merge queue flow.
 
-**Main:** No bypass actors. All changes must go through a PR.
+**Main:** Only `@danielsperoni` (user ID `7095019`) is a bypass actor.
+This means only Daniel can merge PRs to main — whether that's a
+promotion PR from staging or a fast-track direct-to-main PR. Code owner
+review (via CODEOWNERS) is also required, ensuring Daniel must approve
+before merging.
 
 ## Skipping staging (fast-track to main)
 

--- a/docs/sdlc/lifecycle.md
+++ b/docs/sdlc/lifecycle.md
@@ -64,15 +64,21 @@ the cadence; this doc is the path through the loops.
        pages.yml rebuilds /staging/ on Pages
                │
                ▼
+       promote-staging.yml opens (or updates) a
+       staging → main PR with aggregated UAT steps
+       from all included PRs, assigned to @danielsperoni
+               │
+               ▼
        Hourly UAT validation (:15) walks the PR's
        "UAT on live staging" checklist against
        https://danielsperoniteam.github.io/fhir-place/staging/
                │
                ▼
-       UAT comment posted on PR (informational, not a review)
+       UAT comment posted on promotion PR (informational)
                │
                ▼
-       Human promotes staging → main (fast-forward / merge)
+       Human independently validates UAT steps on staging,
+       approves the promotion PR, and merges
                │
                ▼
        pages.yml rebuilds /
@@ -200,16 +206,37 @@ attempt at resolving them; otherwise the PR author rebases by hand.
 
 ### 7. Merge into `staging`
 
-A human merges. Two things happen:
+A human merges. Three things happen:
 
 - `pages.yml` rebuilds the `/staging/` slot of the Pages artifact and
   redeploys.
+- `promote-staging.yml` opens (or updates) a single long-lived
+  `staging → main` promotion PR. The PR body aggregates UAT steps from
+  all PRs merged into staging since the last promotion. It is assigned
+  to `@danielsperoni`. Any PRs with `status: needs-human` are flagged
+  at the top of the body for explicit human review.
 - The PR's head SHA is now reachable from `origin/staging`, which means
   the next **hourly UAT validation** run will walk it.
 
 Note: the engineer-dispatch loop's PR is still **open** at this point.
 "Merge into staging" is not "merge into main" — it's a deploy step that
 makes the change visible on the live `/staging/` URL for UAT.
+
+### 7b. Promotion PR
+
+[`promote-staging.yml`](../../.github/workflows/promote-staging.yml)
+
+The promotion PR serves as the formal UAT gate for production. Its body
+contains:
+
+- Commit/PR counts ahead of main
+- Aggregated UAT steps from each included PR
+- Flagged items needing human review (with `@danielsperoni` mention)
+- List of included PRs and issues that will be closed
+
+The PR is a single long-lived instance — each push to staging updates
+its body rather than creating a new PR. When merged, a new one opens
+on the next staging push.
 
 ### 8. UAT validation against the live staging build
 
@@ -230,12 +257,13 @@ not block merge by itself. A human still has to confirm.
 
 ### 9. Promotion: `staging` → `main`
 
-A human promotes `staging` to `main` (fast-forward or merge). At that
-point:
+A human approves and merges the promotion PR. At that point:
 
 - `pages.yml` rebuilds `/`.
-- The PR is closed by GitHub via its `Closes #<N>` trailer.
-- The original issue is closed automatically.
+- Issues listed in the `Closes #<N>` trailers are closed automatically.
+- The promotion PR is closed.
+- The next push to staging (from a subsequent merge) will open a fresh
+  promotion PR.
 
 ### 10. Post-deploy regression check
 
@@ -256,10 +284,14 @@ points:
    (label the loop's tracking issue `status: agent-paused`).
 2. **Reviewing and marking PRs ready, then merging into `staging`.**
    The agent never does this.
-3. **Promoting `staging` to `main`.** Always a human action.
+3. **Approving and merging the promotion PR** (`staging` → `main`).
+   The PR is created automatically, but an independent human must
+   validate UAT steps on the deployed staging environment and approve.
+   Always assigned to `@danielsperoni`.
 4. **Modifying the SDLC itself** — prompts, agent definitions,
    workflows, `CODEOWNERS`. Self-modification is out of scope for every
    agent in the system.
 
 Everything else — triage, branch creation, code, tests, screenshots,
-draft PR, UAT walk, bug-filing — is automated.
+draft PR, UAT walk, bug-filing, and promotion PR creation — is
+automated.

--- a/docs/sdlc/loops.md
+++ b/docs/sdlc/loops.md
@@ -30,6 +30,7 @@ prompt: |
            │
 on demand: ─── Daily doc sync          (workflow_dispatch only)
 on push:   ─── Pages deploy            (push to main or staging)
+on push:   ─── Promote staging         (push to staging → opens/updates promotion PR)
 on /resolve-conflicts: ─ PR conflict resolver
 ```
 
@@ -165,7 +166,35 @@ Node version requirement; missing app READMEs. If anything has drifted,
 the agent opens a `docs/auto-sync-<date>` branch with a small commit and
 a PR targeting `main`. Markdown-only, so CI is fast.
 
-## The two event-driven workflows
+## The three event-driven workflows
+
+### Promote staging — automated promotion PR
+
+- **Workflow:** [`promote-staging.yml`](../../.github/workflows/promote-staging.yml)
+- **Trigger:** `push` to `staging`.
+- **Concurrency group:** `promote-staging` (`cancel-in-progress: true`)
+- **Permissions:** `contents: read`, `pull-requests: write`, `issues: read`
+- **Agent involvement:** none — deterministic `github-script`.
+
+When code lands on `staging`, this workflow opens (or updates) a single
+long-lived PR targeting `main`. The PR body aggregates UAT steps from
+every PR merged into staging since the last promotion, giving a reviewer
+a single checklist to validate against the deployed `/staging/` URL.
+
+The PR is assigned to `@danielsperoni`. Items flagged with
+`status: needs-human` are called out at the top of the body. Once
+someone independently confirms the UAT steps pass and no regressions
+exist, they approve and merge — which triggers Pages to rebuild `/`.
+
+**Automatic conflict resolution:** after creating/updating the PR, the
+workflow checks mergeable state. If conflicts exist, it invokes Claude
+with the same `pr-resolve-conflicts.md` prompt to attempt resolution.
+If resolution fails, it labels the PR `status: needs-human`, posts an
+escalation comment mentioning `@danielsperoni`, and requests review.
+The `/resolve-conflicts` command remains available for manual retries.
+
+If the PR already exists (from a prior staging push), only the body is
+updated. When it's merged, the next staging push creates a fresh one.
 
 ### Live site monitor — nightly regression
 

--- a/docs/sdlc/loops.md
+++ b/docs/sdlc/loops.md
@@ -31,6 +31,7 @@ prompt: |
 on demand: ─── Daily doc sync          (workflow_dispatch only)
 on push:   ─── Pages deploy            (push to main or staging)
 on push:   ─── Promote staging         (push to staging → opens/updates promotion PR)
+on push:   ─── Sync staging            (push to main → merges main back into staging)
 on /resolve-conflicts: ─ PR conflict resolver
 ```
 
@@ -195,6 +196,23 @@ The `/resolve-conflicts` command remains available for manual retries.
 
 If the PR already exists (from a prior staging push), only the body is
 updated. When it's merged, the next staging push creates a fresh one.
+
+### Sync staging — reverse sync after direct-to-main merges
+
+- **Workflow:** [`sync-staging.yml`](../../.github/workflows/sync-staging.yml)
+- **Trigger:** `push` to `main` (skipped if the commit message contains
+  "promote staging to main" to avoid infinite loops).
+- **Concurrency group:** `sync-staging` (`cancel-in-progress: true`)
+- **Permissions:** `contents: write`
+- **Agent involvement:** none — deterministic git merge.
+
+When a PR merges directly to `main` (skipping the staging UAT loop),
+this workflow merges main back into staging so it doesn't fall behind.
+Uses the admin bypass on the staging ruleset to push directly.
+
+If the merge has conflicts it cannot resolve, it escalates to
+`@danielsperoni` by commenting on the open promotion PR or filing a new
+issue with `status: needs-human`.
 
 ### Live site monitor — nightly regression
 


### PR DESCRIPTION
## Summary

Closes #395

- Adds `promote-staging.yml` — on push to staging, opens/updates a single long-lived PR targeting main with aggregated UAT steps and auto conflict resolution
- Adds `sync-staging.yml` — on push to main (fast-track), auto-merges main back into staging so it never falls behind
- Configures branch protection rulesets on both staging (merge queue, required checks, 1 approval) and main (code owner review, Daniel-only merge bypass)

## Changes

- `.github/workflows/promote-staging.yml` — new workflow
- `.github/workflows/sync-staging.yml` — new workflow
- `docs/sdlc/branch-protection.md` — new doc explaining rulesets
- `docs/sdlc/lifecycle.md` — updated stages 7, 7b, 9
- `docs/sdlc/loops.md` — added promote-staging and sync-staging as event-driven workflows
- `docs/sdlc/README.md` — updated index

## UAT on live staging

N/A — no user-visible change. This is CI/infra only.

## Screenshots / recordings

N/A — no user-visible change.

## Risks

- Main ruleset is now **active** with enforcement — if CI check names change, PRs will be blocked until the ruleset is updated
- Staging merge queue adds ~5 min latency to merges (min wait time)

## Follow-ups

- Observe 2–3 promotion PR cycles to confirm UAT aggregation works correctly
- Consider enabling the main branch ruleset's merge queue for promotion PRs once stable

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)