### PR TITLE
fix(ci): drop redundant pnpm version pin (closes #319)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,8 +54,6 @@ jobs:
           path: staging-src
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## Summary

- Removes the redundant `version: 10` input from `pnpm/action-setup@v4` in both `release.yml` and `pages.yml`
- `package.json` `packageManager: "pnpm@10.33.0"` stays as the single source of truth — the action reads from there

## Why

Every Release run since the pnpm-version-conflict check landed has been failing with:

```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.33.0 in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors
```

(Latest example: [run 25603796590](https://github.com/danielsperoniteam/fhir-place/actions/runs/25603796590))

The action now rejects double-specification. Removing the workflow input is the right side of the fix — `packageManager` is the canonical place to pin pnpm and corepack respects it too.

`pages.yml` has the same misconfiguration but has been incidentally succeeding (the conflict check fires under specific working-directory ordering — pages.yml does its action-setup before the relevant `package.json` is in scope). Fixing it preemptively in the same PR so a future action release that tightens the check doesn't break Pages too.

Note: prior engineer-dispatch attempts on #319 diagnosed the root cause as branch protection blocking force-push to `changeset-release/main`. That diagnosis was wrong — the workflow was failing before the `changesets/action` step ever ran. Logged as another data point on #386 (engineer hallucination tracking).

Closes #319.

## Test plan

- [ ] Merge to main and confirm the next Release run reaches `changesets/action` (currently fails at pnpm setup)
- [ ] Confirm Pages still deploys cleanly after the change

## Screenshots

N/A — workflow YAML only, no user-visible change.