### PR TITLE
fix(ci): drop pnpm/action-setup version pin (closes #402)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,8 +54,6 @@ jobs:
           path: staging-src
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
Closes #402.

## Summary

- `pnpm/action-setup@v4` started erroring when both `with: version:` and `package.json#packageManager` are set. `release.yml` and `pages.yml` had both. Drop the pin.

## Why this targets `main`, not `staging`

Standard SDLC says PRs target `staging`. Two reasons that path doesn't work for this fix today:

1. `staging` is 37 commits behind `main`, so the broken `release.yml` shape isn't even on `staging` yet.
2. The auto-sync workflow that should bring `staging` up to date is itself broken (#403). PRing through `staging` would queue this fix behind that bug.

The change is two lines, scoped to `.github/workflows/`, and the failing workflow runs on `push: main` so the fix has to land on `main` to be observable. After this merges, #403 should be the next priority — once the sync workflow works, this kind of fix can route through `staging` like everything else.

## Test plan

- [ ] After merge: `Release` workflow succeeds on next push
- [ ] After merge: `pages.yml` continues to deploy `/` and `/staging/` correctly

## UAT on live staging

N/A — no user-visible change.