### PR TITLE
fix(ci): trigger CI on merge_group so the queue can land PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- Adds `merge_group:` to `.github/workflows/ci.yml` triggers
- Without this, the merge queue's synthetic merge commit never gets `test` / `e2e` runs, the required checks never report, and after 60 min `check_response_timeout` the queue dequeues the PR

## Why

Branch-protection rulesets on `main` and `staging` require `test` and `e2e` to pass. The merge queue runs those required checks against the merge commit it builds (on `gh-readonly-queue/*` refs, fired as `merge_group` events). `ci.yml` was only listening for `pull_request` and `push`, so nothing ran on the queue's commit, the required checks stayed in pending forever, and the queue timed out at 60 min.

PRs that hit this loop today:
- #384 — added 17:36 → dequeued 18:40 → re-added 19:31 → dequeued 20:34 → currently re-queued
- #405 — added 19:52 → dequeued 20:55

The other PRs that landed today (#391, #393, #394, #396) used the admin bypass on `main`, not the queue.

After this merges, queued PRs will run the same `test` + `e2e` jobs against the synthetic merge commit and land in ~3 min instead of timing out.

## Test plan

- [ ] After merge: re-queue #384 and #405; confirm both land within ~3 min instead of getting dequeued
- [ ] Confirm `test` and `e2e` jobs show up under the `merge_group` event in the Actions tab

## Screenshots

N/A — workflow YAML only.