### PR TITLE
fix(ci): point pages.yml pnpm/action-setup at main-src/package.json

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,6 +54,8 @@ jobs:
           path: staging-src
 
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: main-src/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## Summary

- Adds `package_json_file: main-src/package.json` to the `pnpm/action-setup` step in `pages.yml`
- This is the followup fix to #405, which broke Pages by dropping the version pin without redirecting the action to where the canonical `packageManager` field lives

## Why

#405 dropped `version: 10` from both `release.yml` and `pages.yml` to use `package.json`'s `packageManager: "pnpm@10.33.0"` as the single source of truth. That worked for `release.yml` (checkout at repo root, so `package.json` is in the action's default search path) but broke `pages.yml`:

- `pages.yml` does `actions/checkout@v4` to `path: main-src/` (it builds main and staging side-by-side, so each gets its own subdir)
- `pnpm/action-setup` runs at the workflow root, where there's no `package.json`
- Result on the latest run on `dba439a8`: `Error: No pnpm version is specified` → Deploy demo job failed → no Pages artifact

Setting `package_json_file: main-src/package.json` points the action at the right file. Single-source `packageManager` discipline preserved.

## Test plan

- [ ] After merge: confirm next push to main produces a successful Pages deploy
- [ ] Confirm `/` and `/staging/` both refresh on the live site

## Screenshots

N/A — workflow YAML only.