### PR TITLE
feat(ci): engineer auto-review on every PR; blockers gate merge

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,107 @@
+# Runs the engineer review prompt whenever a PR opens or moves from
+# draft to ready-for-review. Mirrors issue-review.yml but with a
+# diff-aware brief and a single (engineer) reviewer — PM-level
+# product framing is settled at the issue stage by issue-review.yml,
+# so PR-time review is purely about code correctness.
+#
+# See docs/prompts/pr-review.md for what the agent does.
+#
+# Setup required (one-time):
+#   1. ANTHROPIC_API_KEY already exists in repo secrets (used by every
+#      Claude workflow). No new secret to add.
+#   2. The reviewer subagent at .claude/agents/senior-fhir-engineer.md
+#      must exist.
+#
+# Security:
+#   - Author-association gate skips PRs from forks / first-time
+#     contributors. Without this, anyone could open a PR from a fork
+#     and burn ANTHROPIC_API_KEY tokens. OWNER, MEMBER, COLLABORATOR
+#     can trigger; everyone else is silently skipped.
+#   - Review-only: no `contents: write`. The orchestrator's allowed
+#     tools list excludes Edit/Write/Bash, so even under prompt
+#     injection it cannot modify the repo.
+
+name: PR review (engineer)
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  # Manual re-run for a specific PR, e.g. when the workflow was added
+  # after the PR was already open, or to retry after a transient
+  # failure.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review"
+        required: true
+        type: string
+
+permissions:
+  pull-requests: write  # post review comments
+  contents: read        # read prompt and agent files plus the diff
+  id-token: write       # required by claude-code-action@v1
+
+concurrency:
+  # Per-PR: never run two reviews on the same PR at once, but
+  # different PRs can review in parallel.
+  group: pr-review-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+    steps:
+      - id: check
+        env:
+          ASSOC: ${{ github.event.pull_request.author_association }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          # workflow_dispatch is gated by GitHub itself (write-access
+          # users only). For pull_request events we re-check the
+          # author's association so a fork PR doesn't burn tokens.
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          case "$ASSOC" in
+            OWNER|MEMBER|COLLABORATOR)
+              echo "allowed=true"  >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "allowed=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::Skipping PR review — author_association=$ASSOC is not OWNER/MEMBER/COLLABORATOR." ;;
+          esac
+
+  review:
+    needs: gate
+    if: needs.gate.outputs.allowed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Claude Code with the pr-review prompt
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Read the file at docs/prompts/pr-review.md and execute
+            the instructions in it for PR #${{ github.event.pull_request.number || inputs.pr_number }}.
+            Do not modify the prompt file. Do not push, branch, or
+            edit any source. The MCP github tools are configured and
+            the senior-fhir-engineer subagent at .claude/agents/ is
+            available for dispatch via the Agent tool.
+          # --max-turns 40: read PR + diff, single subagent call,
+          # post one review. 40 leaves headroom for retries.
+          # --allowedTools: deliberately excludes Edit, Write, and
+          # general Bash. The single Bash exception is `gh pr review`
+          # so the orchestrator can post a REQUEST_CHANGES review
+          # (which gates merge) or a plain COMMENT review (advisory)
+          # depending on the subagent's verdict. The subagent
+          # inherits the allow-list, so it cannot edit or shell out
+          # either.
+          claude_args: "--max-turns 40 --allowedTools Read,Grep,Glob,Agent,mcp__github__*,Bash(gh pr review:*)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/prompts/pr-review.md
+++ b/docs/prompts/pr-review.md
@@ -1,0 +1,173 @@
+# PR review prompt
+
+When a PR opens or moves from draft to ready-for-review, a senior FHIR
+engineer reads the diff and posts a GitHub review. The reviewer
+returns a verdict; if it's a **blocker**, the orchestrator posts a
+`REQUEST_CHANGES` review that gates merge until a human dismisses it
+or the author addresses the feedback. Otherwise the orchestrator posts
+a `COMMENT` review that's advisory only.
+
+PM-level questions (is this the right thing to ship? does it solve the
+JTBD?) are answered at the **issue** stage by `issue-review.yml`. By
+the time something is a PR, the product framing is settled — code
+correctness is what gates merge.
+
+This prompt is invoked by `.github/workflows/pr-review.yml`. The
+workflow passes the PR number into the orchestrator's prompt as
+`#<N>`.
+
+---
+
+## Your task
+
+You are the orchestrator. Use the GitHub MCP tools (`mcp__github__*`)
+to read the PR and its diff, dispatch the engineer reviewer, then post
+**one GitHub review** that either requests changes or just comments
+based on the reviewer's verdict.
+
+### Hard rules (do not violate)
+
+- **Read-only on the repository.** No `Edit`, no `Write`, no commits,
+  no branches, no pushes. The orchestrator runs without those tools;
+  brief the subagent the same way.
+- **Never post `APPROVE`.** Bot approval would bypass the human review
+  gate in branch protection. The orchestrator only ever posts
+  `REQUEST_CHANGES` (when a blocker exists) or `COMMENT` (advisory).
+  Humans approve.
+- **Skip if a review already exists.** Before doing any work, list
+  existing reviews on the PR and look for the marker
+  `<!-- pr-review:bot -->` in any review body. If present, exit
+  without re-running — the workflow may have been re-triggered.
+- **Be specific about blockers.** A `blocker` verdict must cite
+  concrete evidence in the diff. Vague unease is not a blocker —
+  note it as advisory and move on.
+
+### What counts as a blocker
+
+The reviewer should return verdict `blocker` only for issues that
+would cause real harm if merged as-is:
+
+- Clear bug in the change (the code does something different from
+  what the PR description claims, or a logic error visible in the
+  diff)
+- Security / privacy regression — PHI handling change, auth bypass,
+  secret committed in the diff, sensitive log output added
+- FHIR conformance break — wrong cardinality, profile violation,
+  terminology binding ignored, choice[x] handled incorrectly,
+  reference shape wrong
+- Missing tests for a behavior change in `apps/demo/src/**` or
+  `packages/*/src/**` (the `CLAUDE.md` test-update gate)
+- Breaking API change to `packages/react-fhir/**` without a
+  `.changeset/*.md` entry
+- Path on the agent deny-list (`.github/workflows/**`,
+  `.github/actions/**`, `.env*`, `**/secrets/**`, etc.) edited
+  without explicit human authorization captured in the PR
+  description
+
+Style nits, naming preferences, "I'd refactor this differently",
+unrelated tech debt, "could add another test for X" — all advisory,
+not blocking.
+
+### Steps
+
+1. **Fetch the PR** via `mcp__github__pull_request_read` for `#<N>`:
+   pull `title`, `body`, `state`, `draft`, `user.login`, `base.ref`,
+   `head.ref`, `additions`, `deletions`, `changed_files`. Skip if
+   `draft: true` (we only review on `opened` for non-drafts and
+   `ready_for_review` transitions). Bail on the duplicate-review
+   rule above before spending subagent budget.
+
+2. **Fetch the diff.** Use `mcp__github__get_file_contents` per
+   changed file or pull the unified diff. The reviewer needs to see
+   what actually changed, not just the description.
+
+3. **Dispatch the engineer reviewer** — `senior-fhir-engineer`
+   subagent. Pass it the PR title, body, list of changed files, the
+   diff, and any linked-issue numbers from the body
+   (`Closes #N`, `Fixes #N`). The subagent should not re-fetch.
+
+   Brief: code-review PR `#<N>`. Cover, with bullets:
+   - **Diff scope** — files / packages touched, anything outside
+     the linked issue's stated scope.
+   - **FHIR / clinical correctness** — resource shape, profile
+     conformance, terminology bindings, cardinality, choice[x]
+     handling, references, modifierExtension.
+   - **Architectural risks** — security, privacy/PHI, perf, error
+     handling, race conditions, regression surface.
+   - **Test coverage** — for any user-facing or behavior change in
+     `apps/demo/src/**` or `packages/*/src/**`, is there a matching
+     `*.test.ts(x)` or `apps/demo/e2e/**` change?
+     `packages/react-fhir/**` changes require a `.changeset/*.md`.
+   - **Specific edits to suggest** — file path + line, only when
+     concrete.
+   - **Verdict**: `blocker` or `non-blocking`. One short sentence
+     of justification on the verdict line.
+
+   Hard caps for the subagent: 250 words, no file edits, no
+   branches, no PRs, no test runs, output text only. Last line of
+   the output must be `verdict: blocker` or
+   `verdict: non-blocking`. Brief it that this is a **review-only**
+   pass — the branch / PR flow in its agent definition does not
+   apply here.
+
+4. **Parse the verdict.** Read the last `verdict: ...` line from
+   the subagent's output. If the subagent fails or returns no
+   parseable verdict, treat it as `non-blocking` (do not invent
+   reasons to block).
+
+5. **Build the review body.** Include the marker first so the
+   duplicate-review check in step 1 works on re-runs:
+
+   ```
+   <!-- pr-review:bot -->
+   ## Engineering review (Marco)
+
+   <engineer subagent output verbatim>
+
+   ---
+   _Auto-generated by `.github/workflows/pr-review.yml`. The
+   `REQUEST_CHANGES` state is set when the reviewer returned
+   `verdict: blocker` — humans can dismiss the review to unblock
+   merge, or the author can address the feedback and push (which
+   dismisses stale reviews per branch protection)._
+   ```
+
+6. **Post the review** via `gh pr review`. Pick the state based on
+   the parsed verdict:
+   - If `blocker`:
+     `gh pr review <N> --request-changes --body-file <path>`
+   - Otherwise:
+     `gh pr review <N> --comment --body-file <path>`
+
+   Pass the body via `--body-file` rather than `--body` so multi-line
+   markdown survives intact. The workflow's allow-list permits
+   `Bash(gh pr review:*)`; if your harness blocks the redirect needed
+   to write the body file, fall back to `--body` with the value
+   carefully escaped. Do **not** attempt other shell commands.
+
+7. Stop. No follow-up comments. No labels. No re-runs.
+
+---
+
+## Operational notes
+
+- The workflow runs with `GITHUB_TOKEN` from the workflow — same
+  permissions as the workflow's `permissions:` block
+  (`pull-requests: write`, `contents: read`).
+- Token budget: this workflow runs once per PR open / ready event.
+  The subagent should read the diff plus the obvious neighboring
+  files, not the whole repo. Lean on the issue linked from the PR
+  body for product context — most of that has already been written
+  down.
+- If the subagent fails entirely, exit without posting a review.
+  Surface the failure in the workflow logs. **Do not invent a
+  review.**
+- Do not @-mention humans in the review. The reviewer is advisory
+  unless it returns `blocker`.
+- The bot's review is dismissed on push per branch-protection's
+  `dismiss_stale_reviews_on_push: true`. The author addresses the
+  feedback by pushing a fix; the workflow does not re-trigger on
+  `synchronize` (we only listen for `opened` and
+  `ready_for_review`). To re-invoke after a fix, use the
+  `workflow_dispatch` input with the PR number, or move the PR to
+  draft and back to ready-for-review.


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/pr-review.yml` — `senior-fhir-engineer` subagent reviews every opening / ready-for-review PR
- New prompt `docs/prompts/pr-review.md` tailored to PRs (vs the existing issue-review prompt)
- **Blocker verdicts gate merge.** The reviewer returns `verdict: blocker` or `verdict: non-blocking` on the last line of its output. If `blocker`, the bot posts a `REQUEST_CHANGES` review. Branch protection's "1 approving review" rule + `dismiss_stale_reviews_on_push: true` handle the lifecycle from there.

## Why

We had `issue-review.yml` for new issues but nothing for PRs. PM-level questions (is this the right thing to ship?) are settled at the **issue** stage. By PR time, what gates merge is **code correctness** — so this is engineer-only, not PM + engineer.

## Behavior

| Trigger | What happens |
|---|---|
| PR opens (not draft) by a `OWNER`/`MEMBER`/`COLLABORATOR` | Auto-reviews |
| Draft → ready-for-review (same author tier) | Auto-reviews |
| Fork PR / first-time contributor | Silently skipped (don't burn `ANTHROPIC_API_KEY`) |
| Re-trigger needed after a fix | `workflow_dispatch` with PR number, or draft → ready toggle |

| Reviewer verdict | Posted as |
|---|---|
| `blocker` | `REQUEST_CHANGES` review with engineer's feedback in body |
| `non-blocking` | `COMMENT` review (advisory) |
| Subagent fails | No review posted, failure surfaced in workflow logs |

The bot **never** posts `APPROVE`. Human review is still required for merge.

## Blocker policy (in the prompt)

Concrete, not vague:

- Clear bug in the diff
- Security / privacy / PHI regression
- FHIR conformance break (cardinality, profile, terminology, choice[x], references)
- Missing tests for a behavior change in `apps/demo/src/**` or `packages/*/src/**`
- Breaking `packages/react-fhir/**` change without a `.changeset/*.md`
- Deny-list path (`.github/workflows/**`, `.env*`, etc.) edited without explicit auth captured in the PR description

Style nits, naming, "could refactor differently", unrelated tech debt → advisory only.

## Security

- Author-association gate prevents fork PRs from triggering token spend
- `permissions:` block has `pull-requests: write` only — no `contents: write`
- `--allowedTools` excludes `Edit`, `Write`, and general `Bash`. The single Bash exception is `Bash(gh pr review:*)` so the orchestrator can actually post the review
- Subagent inherits the allow-list — so even under prompt injection through PR title or description, the bot can't edit files or shell out arbitrarily

## Test plan

- [ ] After merge: open a small no-op PR (typo fix). Confirm the bot posts a single `COMMENT` review with engineer feedback.
- [ ] Open a PR that intentionally violates the deny-list (e.g. modifies `.github/workflows/` without explicit "User authorized" in the body). Confirm the engineer subagent returns `verdict: blocker` and the bot posts `REQUEST_CHANGES`.
- [ ] Confirm fork PRs don't trigger the workflow (no Actions run created).

## Screenshots

N/A — workflow YAML + prompt markdown only.