### PR TITLE
ci: auto-trigger Codex + UAT validation on PR sync

### DIFF
--- a/.github/workflows/codex-on-pr-sync.yml
+++ b/.github/workflows/codex-on-pr-sync.yml
@@ -1,0 +1,46 @@
+# Re-trigger Codex review when a PR head changes.
+#
+# Codex (chatgpt-codex-connector) reviews on PR open and on `@codex review`,
+# but does not re-run on push. When an author addresses Codex feedback and
+# pushes a fix, Codex is silent until someone manually pings it. This
+# workflow closes that loop: on every PR `synchronize` it posts an
+# `@codex review` comment, debounced by a 30s wait + concurrency
+# cancellation so a rapid-fire push only produces one re-review.
+#
+# Why a small debounce: a fix is often 2-3 quick commits. We want one
+# Codex re-review for the final state, not three for intermediate states.
+# `cancel-in-progress: true` cancels the prior wait when a new push lands;
+# only the last sync survives the wait and posts the comment.
+
+name: Codex re-review on PR sync
+
+on:
+  pull_request:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: codex-on-pr-sync-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  rereview:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Debounce — wait for rapid follow-up pushes
+        run: sleep 30
+
+      - name: Post @codex review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '@codex review',
+            });

--- a/.github/workflows/hourly-uat-validation.yml
+++ b/.github/workflows/hourly-uat-validation.yml
@@ -29,13 +29,6 @@ on:
   # schedule:
   #   - cron: "15 * * * *"   # :15 of every hour, offset from engineer-dispatch (:05)
   workflow_dispatch:
-  # Also trigger on PR push so an author who fixes UAT-feedback gets the
-  # validator re-walking within minutes instead of within an hour. The
-  # prompt's SHA-marker dedupe (`<!-- uat-validation:run sha=... -->`)
-  # makes repeat triggers cheap — only PRs whose head SHA changed are
-  # actually re-walked.
-  pull_request:
-    types: [synchronize, ready_for_review, opened]
 
 permissions:
   contents: read         # read prompt file from the checkout

--- a/.github/workflows/hourly-uat-validation.yml
+++ b/.github/workflows/hourly-uat-validation.yml
@@ -29,6 +29,13 @@ on:
   # schedule:
   #   - cron: "15 * * * *"   # :15 of every hour, offset from engineer-dispatch (:05)
   workflow_dispatch:
+  # Also trigger on PR push so an author who fixes UAT-feedback gets the
+  # validator re-walking within minutes instead of within an hour. The
+  # prompt's SHA-marker dedupe (`<!-- uat-validation:run sha=... -->`)
+  # makes repeat triggers cheap — only PRs whose head SHA changed are
+  # actually re-walked.
+  pull_request:
+    types: [synchronize, ready_for_review, opened]
 
 permissions:
   contents: read         # read prompt file from the checkout


### PR DESCRIPTION
## Summary (revised after #413 landed)

- New workflow `codex-on-pr-sync.yml` posts `@codex review` on every PR `synchronize`, debounced 30s + concurrency-cancelled so rapid-fire pushes collapse to one re-review.

UAT-on-sync hunk was dropped — see Trade-offs below.

Net effect: push a fix → Codex re-reviews in ~1 min, instead of waiting for someone to ping it manually.

## Why this targets `main`, not `staging`

Per `docs/sdlc/branch-protection.md`, `.github/workflows/` changes are documented as fast-track-eligible (no UAT against the live build because there's no user-visible change). Same lane as #405. `sync-staging.yml` (#403) will bring this back to staging once that's working.

## Trade-offs considered

- **Why a 30s debounce on the Codex workflow?** Authors often push 2–3 commits in quick succession when responding to feedback. Without debounce we'd post three `@codex review` comments and Codex would re-review intermediate states. `cancel-in-progress: true` cancels the wait when a new sync arrives; only the last sync's wait completes and posts the comment.
- **Why was UAT-on-sync dropped?** #413 (engineer auto-review with REQUEST_CHANGES gating) shipped with an explicit design choice to *not* re-trigger on push, to avoid burning Anthropic credits per commit. Triggering UAT validation on every sync violates that same principle (each re-walk is an Anthropic call). Honoring the design preference is more consistent than overriding it.
- **Risk: Codex cost.** Codex bills against the chatgpt-codex-connector subscription, not `ANTHROPIC_API_KEY`. Initial assumption was "this is effectively free for our usage" — that's unverified. #423 tracks the follow-up to actually measure cost after this lands and decide whether to keep, throttle, or drop.

## Test plan

- [ ] After merge, push a follow-up commit to any open PR. Expect one `@codex review` comment from `github-actions[bot]` ~30s after push, then a Codex review within ~1 min.
- [ ] Push two commits in quick succession (< 30s). Expect only **one** `@codex review` comment.
- [ ] Open a draft PR. Expect Codex re-review workflow to skip (`if: github.event.pull_request.draft == false`).

## UAT on live staging

N/A — no user-visible change.

## Related

- #413 — engineer auto-review (shipped in parallel; complementary)
- #423 — follow-up to measure Codex cost after this lands