### PR TITLE
feat(scripts): local engineer-dispatch driver (uses Max OAuth, not API key)

### DIFF
--- a/scripts/dispatch-engineer.README
+++ b/scripts/dispatch-engineer.README
@@ -1,0 +1,111 @@
+# dispatch-engineer.sh — local driver
+
+Local equivalent of `.github/workflows/hourly-engineer-dispatch.yml`. Picks
+ready issues, hands them to the `engineer` subagent in isolated worktrees,
+opens draft PRs. The two runners (this one and the GHA workflow) coexist
+safely via the `status: in-progress` label, which acts as a cross-runner
+atomic claim — no ticket can be picked up twice.
+
+Why a local copy at all? Cost.
+
+- **GHA workflow** runs on a clean Ubuntu runner under `ANTHROPIC_API_KEY`
+  (paid API tokens, real dollars per run).
+- **This local driver** runs on Daniel's Mac under the saved `claude login`
+  OAuth session. With no `ANTHROPIC_API_KEY` in the env, `claude` falls back
+  to that session and bills against the Claude Max subscription instead.
+
+Same prompt, same engineer subagent, same safety rules. Different wallet.
+
+## One-time setup
+
+1. **Log in to Claude Code on this machine.** The driver needs a saved
+   OAuth session at `~/.claude/.credentials.json`.
+   ```
+   claude login
+   ```
+   Confirm: `claude --version` works and an interactive `claude` session
+   shows your account, not an API-key auth path.
+
+2. **Store the GitHub PAT in keychain.** The driver pulls it via
+   `security find-generic-password -s github-pat-fhir-place`.
+   Required scopes: `repo`, `workflow`, `read:org`. PAT must have access to
+   `danielsperoniteam/fhir-place`.
+   ```
+   security add-generic-password -s github-pat-fhir-place -a "$USER" -w
+   # paste the PAT at the prompt; -w hides it from history
+   ```
+   Verify (rc=0 means item exists; this command does NOT print the secret):
+   ```
+   security find-generic-password -s github-pat-fhir-place -a "$USER" >/dev/null
+   echo $?
+   ```
+
+3. **Smoke-test by hand.** Run from a clean working tree:
+   ```
+   ~/src/fhir-place/scripts/dispatch-engineer.sh
+   ```
+   Expected: a log file at `logs/engineer-dispatch-<RUN_ID>.log`, no
+   "missing GITHUB_TOKEN" error, claude either says "no ready tickets"
+   (zero-cost run) or claims up to 3 issues.
+
+## launchd job
+
+Plist at `~/Library/LaunchAgents/com.danielsperoni.fhir-place-dispatch.plist`.
+Runs every 6 hours via `StartInterval`, `RunAtLoad=false` (first fire is on
+your terms, not at install time).
+
+Install:
+```
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.danielsperoni.fhir-place-dispatch.plist
+```
+
+Verify it's loaded:
+```
+launchctl print gui/$(id -u)/com.danielsperoni.fhir-place-dispatch | head -30
+```
+
+Trigger a run by hand (without waiting for the timer):
+```
+launchctl kickstart -k gui/$(id -u)/com.danielsperoni.fhir-place-dispatch
+```
+
+Tail the log:
+```
+tail -f ~/src/fhir-place/logs/engineer-dispatch-*.log
+```
+
+## Pause / resume / uninstall
+
+Pause (driver no-ops on next tick, lock file untouched):
+```
+touch ~/.fhir-place-pause
+```
+
+Resume:
+```
+rm ~/.fhir-place-pause
+```
+
+Uninstall the launchd job entirely:
+```
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.danielsperoni.fhir-place-dispatch.plist
+rm ~/Library/LaunchAgents/com.danielsperoni.fhir-place-dispatch.plist
+```
+
+## Built-in safety
+
+The driver itself is thin; the heavy rules live in
+`.claude/agents/engineer.md` and `docs/prompts/hourly-engineer-dispatch.md`.
+What this driver enforces directly:
+
+- **Lock file** at `/tmp/fhir-place-dispatch.lock` — at most one run at a
+  time on this machine. Stale locks (PID gone) clear automatically.
+- **Pause file** at `~/.fhir-place-pause` — short-circuit before doing any
+  work; useful when you're about to rebase main or do anything destructive.
+- **Dirty-tree refusal** — exits cleanly if `~/src/fhir-place` has uncommitted
+  changes. Daniel mid-edit > unattended bot.
+- **Tool allow-list** passed to `claude --allowedTools`, defense-in-depth
+  on top of the subagent's own permissions.
+- **iMessage on failure** — non-zero exit pings `+15082827897` with the run
+  ID and log path.
+- **Log rotation** — logs older than 14 days are pruned each run.

--- a/scripts/dispatch-engineer.sh
+++ b/scripts/dispatch-engineer.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Local engineer-dispatch driver. Mirrors the GH Actions workflow at
+# .github/workflows/hourly-engineer-dispatch.yml but invokes claude headlessly.
+# Designed to be fired by launchd; safe to run by hand for testing.
+#
+# Auth: this driver intentionally does NOT export ANTHROPIC_API_KEY. With no
+# API key in the env, `claude` falls back to its saved OAuth login session and
+# bills against the Claude Max subscription instead of paid API tokens. Run
+# `claude login` once on this machine before installing the launchd job.
+# The GHA workflow keeps using the API key — it has no logged-in user.
+#
+# See docs/decisions/0003-agent-safety-rules.md for the safety model.
+# The engineer subagent (.claude/agents/engineer.md) enforces all hard rules;
+# this script just wraps env, locking, logging, and notification.
+
+set -Eeuo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/src/fhir-place}"
+LOG_DIR="$REPO_ROOT/logs"
+LOCK_DIR="/tmp/fhir-place-dispatch.lock"
+PAUSE_FILE="$HOME/.fhir-place-pause"
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+LOG_FILE="$LOG_DIR/engineer-dispatch-$RUN_ID.log"
+PHONE="+15082827897"
+
+# launchd does not inherit shell PATH. Cover Apple Silicon, Intel, npm
+# global, pnpm self-install, and ~/.local/bin.
+export PATH="$HOME/Library/pnpm:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+# GitHub PAT from macOS keychain (one-time setup in scripts/dispatch-engineer.README).
+# No ANTHROPIC_API_KEY here on purpose — see auth note in the header comment.
+export GITHUB_TOKEN="$(security find-generic-password -s github-pat-fhir-place -a "$USER" -w 2>/dev/null || true)"
+export GH_TOKEN="$GITHUB_TOKEN"
+
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_FILE") 2>&1
+echo "=== run $RUN_ID ==="
+
+[[ -z "$GITHUB_TOKEN" ]] && { echo "missing GITHUB_TOKEN"; exit 2; }
+
+if [[ -f "$PAUSE_FILE" ]]; then
+  echo "pause file present at $PAUSE_FILE — skipping"; exit 0
+fi
+
+# Single-run lock via mkdir (atomic on POSIX). Stale lock recovery checks
+# whether the recorded PID is still alive.
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  STALE_PID="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+  if [[ -n "$STALE_PID" ]] && ! kill -0 "$STALE_PID" 2>/dev/null; then
+    echo "stale lock from pid $STALE_PID — clearing"
+    rm -rf "$LOCK_DIR"
+    mkdir "$LOCK_DIR"
+  else
+    echo "another dispatch is running (pid ${STALE_PID:-unknown})"; exit 0
+  fi
+fi
+echo $$ > "$LOCK_DIR/pid"
+trap 'rm -rf "$LOCK_DIR"' EXIT
+
+cd "$REPO_ROOT"
+
+# Refuse to run with a dirty primary checkout — likely Daniel mid-edit.
+# The engineer subagent works in worktrees, never the primary checkout.
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "dirty working tree at $REPO_ROOT — skipping"; exit 0
+fi
+
+git fetch origin --prune --tags --quiet
+git worktree prune
+
+# Tool allow-list. Defense in depth: engineer subagent has its own hard
+# rules; this just bounds what a prompt-injected dispatcher can call.
+ALLOWED="Read,Edit,Write,Bash,Grep,Glob,Agent,mcp__github__*"
+
+# Worktrees live at $(dirname $REPO_ROOT)/wt-<N> per engineer.md.
+# claude restricts file ops to cwd by default, so widen the scope.
+WORKTREE_PARENT="$(dirname "$REPO_ROOT")"
+
+set +e
+claude \
+  --print \
+  --add-dir "$WORKTREE_PARENT" \
+  --allowedTools "$ALLOWED" \
+  --dangerously-skip-permissions \
+  <<'PROMPT'
+Read the file at docs/prompts/hourly-engineer-dispatch.md and execute
+the instructions in it. Do not modify the prompt file itself. The MCP
+github tools are configured and the engineer subagent at
+.claude/agents/engineer.md is available for dispatch.
+PROMPT
+RC=$?
+set -e
+
+if [[ $RC -ne 0 ]]; then
+  osascript -e "tell application \"Messages\" to send \"engineer-dispatch failed rc=$RC run=$RUN_ID — see $LOG_FILE\" to participant \"$PHONE\" of (service 1 whose service type is iMessage)" || true
+fi
+
+# Trim old logs (~14 days).
+find "$LOG_DIR" -name 'engineer-dispatch-*.log' -mtime +14 -delete 2>/dev/null || true
+
+echo "=== run $RUN_ID complete (rc=$RC) ==="
+exit "$RC"


### PR DESCRIPTION
## Summary

Adds `scripts/dispatch-engineer.sh` and a setup README for running the existing engineer-dispatch routine locally on a workstation (Daniel's Mac, fired by launchd every 6 hours).

## Why this exists alongside the GHA workflow

`.github/workflows/hourly-engineer-dispatch.yml` runs the same prompt on a clean Ubuntu runner under `ANTHROPIC_API_KEY` — every run bills paid API tokens. This local driver intentionally **does not** export `ANTHROPIC_API_KEY`. With no key in the env, `claude` falls back to the saved `claude login` OAuth session and the run bills against the Claude Max subscription instead. Same prompt, same engineer subagent, same safety rules — different wallet.

The two runners are safe to run in parallel: the existing `status: in-progress` label is the cross-runner atomic claim, so no ticket is picked up twice.

## What the driver itself enforces

- Keychain-sourced GitHub PAT (`security find-generic-password -s github-pat-fhir-place`); no secrets in git
- Lock file at `/tmp/fhir-place-dispatch.lock` with stale-PID recovery
- Pause file at `~/.fhir-place-pause` for one-touch kill switch
- Dirty-tree refusal (`git diff --quiet`) — Daniel mid-edit beats unattended bot
- Tool allow-list passed to `claude --allowedTools`
- iMessage notification to `+15082827897` on non-zero exit
- Log rotation (>14d auto-pruned)

All heavy safety still lives downstream in `.claude/agents/engineer.md` and `docs/prompts/hourly-engineer-dispatch.md`. This driver only wraps env, locking, logging, and notification.

## Files

- `scripts/dispatch-engineer.sh` — the driver
- `scripts/dispatch-engineer.README` — one-time setup (claude login + keychain item) and launchd install / pause / uninstall recipes

## Test plan

- [ ] `bash -n scripts/dispatch-engineer.sh` passes (already verified locally)
- [ ] On a fresh Mac with `claude login` done and `github-pat-fhir-place` in keychain: `~/src/fhir-place/scripts/dispatch-engineer.sh` either reports "no ready tickets" or claims up to 3 tickets without API-key auth errors
- [ ] `touch ~/.fhir-place-pause` causes the next run to short-circuit cleanly
- [ ] Dirty working tree causes the next run to short-circuit cleanly

N/A — no user-visible change (infra only).