### PR TITLE
chore: rename priority labels (high/medium/low → P0/P1/P2/P3) + sprint-aware SDLC sync

### DIFF
--- a/.github/workflows/live-site-monitor.yml
+++ b/.github/workflows/live-site-monitor.yml
@@ -151,7 +151,7 @@ jobs:
                   repo: context.repo.repo,
                   title: issueTitle,
                   body,
-                  labels: ['type: bug', 'area: fhir-explorer', 'priority: high', 'origin: bot-filed'],
+                  labels: ['type: bug', 'area: fhir-explorer', 'priority: P0', 'origin: bot-filed'],
                 });
               }
             }

--- a/.github/workflows/on-failure-issue.yml
+++ b/.github/workflows/on-failure-issue.yml
@@ -100,6 +100,6 @@ jobs:
                 repo: context.repo.repo,
                 title,
                 body,
-                labels: ['type: bug', 'area: infra', 'priority: high', 'origin: bot-filed'],
+                labels: ['type: bug', 'area: infra', 'priority: P0', 'origin: bot-filed'],
               });
             }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ GitHub Issues are the canonical backlog (see `docs/decisions/0001-use-github-iss
 | --- | --- | --- | --- |
 | `type:` | exactly one | `bug`, `feature`, `tech-debt`, `docs`, `spike`, `epic` | What kind of work this is. `epic` = tracker for sub-issues. `spike` = time-boxed exploration. |
 | `area:` | one or more | `fhir-explorer`, `react-fhir`, `workbench`, `cql`, `mcp`, `infra`, `auth`, `security` | Which part of the codebase is touched. `fhir-explorer` is the demo app at `apps/demo/` (legacy names: "demo", "fhir-ui", "live-monitor"). `react-fhir` is the published library at `packages/react-fhir/`. |
-| `priority:` | exactly one | `high`, `medium`, `low` | Triage signal. Bugs default to `high`. Spikes / nice-to-haves default to `low`. Default `medium`. |
+| `priority:` | exactly one | `P0`, `P1`, `P2`, `P3` | Triage signal. Bugs default to `P0`. Spikes / nice-to-haves default to `P2`. `P3` is the explicit-deferral bucket — out of current sprint, "someday" — not the same as no priority. Default `P1`. |
 | `status:` | optional | `blocked`, `needs-triage`, `in-progress`, `needs-human`, `agent-paused` | Workflow state. Use sparingly. `in-progress` / `needs-human` are bot-managed by the engineer-dispatch routine; `agent-paused` on the dispatch tracking issue is the kill switch. |
 | `origin:` | optional | `bot-filed` | Filed by automation (e.g. `live-site-monitor.yml`). |
 | `phase-N` | optional | `phase-0`..`phase-3`, `fhir-workbench-phase-a` | Multi-phase epic tracking. Keep as plain (no prefix) for grep-ability. |

--- a/docs/prompts/daily-pm-triage.md
+++ b/docs/prompts/daily-pm-triage.md
@@ -54,13 +54,13 @@ List all open issues. For each, check whether it has:
 
 - exactly one `type:` label (`bug`, `feature`, `tech-debt`, `docs`, `spike`, `epic`)
 - at least one `area:` label (`fhir-explorer`, `react-fhir`, `workbench`, `cql`, `mcp`, `infra`, `auth`, `security`)
-- exactly one `priority:` label (`high`, `medium`, `low`)
+- exactly one `priority:` label (`P0`, `P1`, `P2`, `P3`)
 
 If any are missing, infer them from the title + body using these heuristics:
 
 - **type:** title starting with `fix(...)` / `bug:` / "broken" / "regression" → `type: bug`. Title starting with `feat(...)` / `add` / `support` / `expose` → `type: feature`. `refactor(...)` / "cleanup" / "drop" / "consolidate" → `type: tech-debt`. `docs(...)` / "document" / "README" → `type: docs`. `spike(...)` / "experiment" / "explore" → `type: spike`. "Epic:" / "tracking issue" / "meta issue" → `type: epic`.
 - **area:** scan body for file paths. `apps/demo/` or `apps/fhir-explorer/` → `area: fhir-explorer`. `packages/react-fhir/` → `area: react-fhir`. `packages/cql/` → `area: cql`. `.github/` or CI-related → `area: infra`. Auth / Cognito / SMART / OAuth → `area: auth`. Multi-area allowed.
-- **priority:** bugs default `high`. Spikes / "nice-to-have" / "experimental" default `low`. Everything else `medium`.
+- **priority:** bugs default `P0`. Spikes / "nice-to-have" / "experimental" default `P2`. Explicitly deferred / out-of-current-sprint work is `P3`. Everything else `P1`.
 
 Apply the labels via `mcp__github__issue_write method=update labels=[...]`. Note: this **replaces** the label set, so always include any pre-existing labels you want to keep (status:, origin:, phase-*).
 
@@ -101,11 +101,11 @@ List all open issues with `status: blocked`. For each, check the most recent com
 
 ### 6. Long-open issues without priority signal
 
-List open issues created >90 days ago that have neither `priority: high` nor any `phase-*` label. Add `status: needs-triage` and surface in the report. Do not change the existing priority.
+List open issues created >90 days ago that have neither `priority: P0` nor any `phase-*` label. Add `status: needs-triage` and surface in the report. Do not change the existing priority.
 
 ### 7. Roll-up daily report
 
-Find the open issue titled exactly `PM triage — daily report`. If it exists, **update its body** (do not append a new comment) with the day's results. If it doesn't exist, create it with labels `[type: docs, area: infra, priority: low, origin: bot-filed]` and assign nobody.
+Find the open issue titled exactly `PM triage — daily report`. If it exists, **update its body** (do not append a new comment) with the day's results. If it doesn't exist, create it with labels `[type: docs, area: infra, priority: P3, origin: bot-filed]` and assign nobody.
 
 Body format:
 
@@ -115,7 +115,7 @@ _Last run: YYYY-MM-DD HH:MM UTC. Auto-updated by `.github/workflows/daily-pm-tri
 ## Today
 
 ### Triaged (N issues)
-- #123 — set [type: feature, area: fhir-explorer, priority: medium]
+- #123 — set [type: feature, area: fhir-explorer, priority: P1]
 - ...
 
 ### Titles cleaned (N)

--- a/docs/prompts/daily-qa-pass.md
+++ b/docs/prompts/daily-qa-pass.md
@@ -102,8 +102,8 @@ For each distinct bug:
    - **Title:** plain descriptive sentence, no bracket prefix.
      E.g. `Patient detail crashes on patient with no name.given`
    - **Labels:** `type: bug`, `area: fhir-explorer`, `origin: bot-filed`,
-     and a priority — `priority: high` for crashes, broken navigation,
-     or data loss; `priority: medium` for everything else.
+     and a priority — `priority: P0` for crashes, broken navigation,
+     or data loss; `priority: P1` for everything else.
    - **Body:** use the structure below. The `agent-work-item` issue
      template's fields are good guidance, but file via `mcp__github__issue_write`
      with a free-form body — that's what `live-site-monitor.yml` does too.

--- a/docs/prompts/hourly-engineer-dispatch.md
+++ b/docs/prompts/hourly-engineer-dispatch.md
@@ -65,7 +65,25 @@ For every open PR from a `bot/*` branch with no human review in 7+ days:
 
 Do not close the PR — that's a human's call.
 
-## Step 3 — compute the ready queue
+## Step 3 — compute the sprint-scoped ready queue
+
+The canonical work source is the
+[fhir-place project board](https://github.com/orgs/danielsperoniteam/projects/1),
+scoped to the current sprint iteration. Bots and humans both pull from
+that board sorted by Priority (P0 first). Issues outside the current
+sprint are not eligible for dispatch even if they otherwise look ready.
+
+> **PENDING — requires `read:project` token scope.** The
+> `GITHUB_TOKEN` available to this workflow does not have the project
+> scope, so the project-board GraphQL query is not yet wired in. Until
+> the `PROJECTS_PAT` secret is configured, this step falls back to the
+> all-issues-with-labels behavior described below.
+>
+> **TODO:** replace this fallback once `PROJECTS_PAT` is configured.
+> See the tracking issue
+> [Sprint-aware dispatch + priority label rename + SDLC sync](https://github.com/danielsperoniteam/fhir-place/issues/436).
+
+### Fallback: label-only ready queue
 
 A "ready" issue is **all of**:
 
@@ -79,7 +97,7 @@ A "ready" issue is **all of**:
 - every issue listed in the body under "Blocked by:" or as a
   `blocks`-style sub-issue link is closed
 
-Sort by: `priority: high` → `priority: medium` → `priority: low`,
+Sort by: `priority: P0` → `priority: P1` → `priority: P2` → `priority: P3`,
 then by `created_at` ascending. Take the top 3.
 
 If the queue is empty, jump to Step 5 (update the tracking issue) and
@@ -119,7 +137,7 @@ Compute slugs as `kebab-case(first-50-chars-of-title-after-stripping-prefixes)`.
 
 Find the open issue titled exactly `Engineer dispatch — hourly report`. If
 it does not exist, create it with labels
-`[type: docs, area: infra, priority: low, origin: bot-filed]` and an empty
+`[type: docs, area: infra, priority: P3, origin: bot-filed]` and an empty
 body (this routine populates it).
 
 **Update the body** (do not append a comment — at hourly cadence, comments

--- a/docs/prompts/hourly-uat-validation.md
+++ b/docs/prompts/hourly-uat-validation.md
@@ -270,8 +270,8 @@ bug observations from Step 3c. For each one (cap 5):
      (the daily-pm-triage routine strips them).
    - **Labels:** `type: bug`, `area: fhir-explorer` (or another `area:`
      if the bug is clearly elsewhere), `origin: bot-filed`, and a
-     priority — `priority: high` for crashes, broken navigation, or
-     data loss; `priority: medium` otherwise.
+     priority — `priority: P0` for crashes, broken navigation, or
+     data loss; `priority: P1` otherwise.
    - **Body** (free-form, mirroring `daily-qa-pass.md`):
 
      ```
@@ -319,7 +319,7 @@ Spawn the `health-tech-pm` subagent with this brief:
      (`origin: bot-filed` + `type: feature`). If a near-match exists,
      add a `+1 with new context` comment instead of filing.
   3. File new ideas with: `type: feature`, `area: fhir-explorer` (or
-     other), `priority: low` (these are brainstorms, not committed
+     other), `priority: P3` (these are brainstorms, not committed
      work), `origin: bot-filed`. Body should explain the user, the job,
      the friction observed on staging, and a suggested direction —
      not an implementation. Plain title, no bracket prefix.
@@ -333,7 +333,7 @@ The PM subagent must not comment on PRs — that is the QA agent's lane.
 
 Find the open issue titled exactly `UAT validation — hourly report`. If
 it does not exist, create it with labels
-`[type: docs, area: infra, priority: low, origin: bot-filed]` and an
+`[type: docs, area: infra, priority: P3, origin: bot-filed]` and an
 empty body (this routine populates it).
 
 **Replace the body wholesale** (do not append — at hourly cadence,

--- a/docs/prompts/issue-review.md
+++ b/docs/prompts/issue-review.md
@@ -61,8 +61,8 @@ or PR. Do not change labels — the daily PM triage owns labeling.
    - **What to cut** — the seductive scope that doesn't pay rent.
    - **Open questions** — discovery items, plus the cheapest way to
      answer each.
-   - **Prioritization signal** — your read on `priority:` (high /
-     medium / low) and why. Do **not** apply the label; the daily PM
+   - **Prioritization signal** — your read on `priority:` (`P0` / `P1`
+     / `P2` / `P3`) and why. Do **not** apply the label; the daily PM
      triage handles labels.
 
    Hard caps for the subagent: 250 words, no file edits, no branches,

--- a/docs/sdlc/agents.md
+++ b/docs/sdlc/agents.md
@@ -105,7 +105,7 @@ Priya runs as a subagent of the hourly UAT-validation loop with a
 15-minute walking budget. She uses the live staging build the way a
 real provider/payer/patient would for the JTBDs in
 [`docs/qa-agent.md`](../qa-agent.md) and files at most three new
-`type: feature, priority: low, origin: bot-filed` improvement-idea
+`type: feature, priority: P3, origin: bot-filed` improvement-idea
 issues per run. She does not comment on PRs — that's Sam's lane.
 
 The orchestrator behind the daily backlog hygiene

--- a/docs/sdlc/gaps.md
+++ b/docs/sdlc/gaps.md
@@ -82,7 +82,7 @@ To make the label universal at filing time, these three places change:
 
 | File | Today | Change |
 | --- | --- | --- |
-| `.github/workflows/live-site-monitor.yml` line 154 | `labels: ['type: bug', 'area: fhir-explorer', 'priority: high', 'origin: bot-filed']` | Add `'human-review-needed: low'` for normal Playwright failures; the existing `github-script` adds `'human-review-needed: high'` and `assignees: ['danielsperoniteam']` if the failed test's title matches the patient-safety regex (med/dose/allergy/problem). |
+| `.github/workflows/live-site-monitor.yml` line 154 | `labels: ['type: bug', 'area: fhir-explorer', 'priority: P0', 'origin: bot-filed']` | Add `'human-review-needed: low'` for normal Playwright failures; the existing `github-script` adds `'human-review-needed: high'` and `assignees: ['danielsperoniteam']` if the failed test's title matches the patient-safety regex (med/dose/allergy/problem). |
 | `docs/prompts/daily-qa-pass.md` Step 4 — Labels | `type: bug, area: fhir-explorer, origin: bot-filed, priority: …` | Append `human-review-needed: <level>`, applying the decision table above. For `high`, also pass `assignees: ['danielsperoniteam']` to `mcp__github__issue_write`. |
 | `docs/prompts/hourly-uat-validation.md` Step 4 (out-of-scope bugs) and Step 5 (PM improvement ideas) | same shape | same change as above. PM ideas default `low`. |
 
@@ -213,7 +213,7 @@ the deploy).
 Sketch of the fix: a `revert-on-failure.yml` workflow that, when
 live-site-monitor reports a P0 regression on `main`, opens a
 `revert/<sha>` PR with `git revert <sha>` and labels it
-`priority: high, status: needs-human`. **Do not auto-merge.** A human
+`priority: P0, status: needs-human`. **Do not auto-merge.** A human
 still pulls the trigger.
 
 A bigger version of this fix needs feature flags as substrate — flag

--- a/docs/sdlc/lifecycle.md
+++ b/docs/sdlc/lifecycle.md
@@ -101,7 +101,7 @@ Issues come from four places:
   a real FHIR sandbox, files `type: bug, origin: bot-filed`.
 - **Live site monitor** at 06:30 UTC — fixed Playwright suite against
   the deployed `/` URL, files `type: bug, area: fhir-explorer,
-  priority: high, origin: bot-filed` for each failed test, deduping by
+  priority: P0, origin: bot-filed` for each failed test, deduping by
   title.
 - **Hourly UAT validation** when it spots out-of-scope bugs while
   walking a PR (cap 5 per run); same `bot-filed` shape.
@@ -129,6 +129,23 @@ standard `Closes #N` trailer in a merged PR.
 
 [`docs/prompts/hourly-engineer-dispatch.md`](../prompts/hourly-engineer-dispatch.md)
 
+#### Target model: sprint-scoped ready queue
+
+The canonical work source is the
+[fhir-place project board](https://github.com/orgs/danielsperoniteam/projects/1),
+scoped to the current sprint iteration. Bots and humans both pull from
+the board sorted by Priority (`P0` → `P1` → `P2` → `P3`). Issues outside
+the current sprint are not eligible for dispatch even if they otherwise
+look ready.
+
+> **PENDING — requires `read:project` token scope.** Implementation is
+> blocked on configuring a `PROJECTS_PAT` secret with project read
+> access. Until then, the dispatcher uses the label-only fallback below.
+> Tracking issue:
+> [Sprint-aware dispatch + priority label rename + SDLC sync](https://github.com/danielsperoniteam/fhir-place/issues/436).
+
+#### Bridge: label-only ready predicate
+
 The "ready" predicate is precise:
 
 - exactly one `type:` label
@@ -137,6 +154,9 @@ The "ready" predicate is precise:
 - no `status: blocked / needs-triage / in-progress / needs-human`
 - no assignees
 - every "Blocked by:" / sub-issue link is closed
+
+Sort: `priority: P0` → `priority: P1` → `priority: P2` → `priority: P3`,
+then `created_at` ascending. Take the top 3.
 
 The `status: in-progress` label is the **claim lock**. It's added before
 the subagent is dispatched. The "ready" predicate excludes it, so a

--- a/docs/sdlc/loops.md
+++ b/docs/sdlc/loops.md
@@ -90,10 +90,16 @@ Sequence per run:
 2. **Flag stale bot PRs.** Any `bot/*` PR with no human review in 7+
    days gets a `@codeowner` mention and the linked issue gets
    `status: needs-human`.
-3. **Compute the ready queue.** A "ready" issue has exactly one `type:`,
-   ≥1 `area:`, exactly one `priority:`; no `status: blocked /
-   needs-triage / in-progress / needs-human`; no assignees; all listed
-   blockers closed. Sort by priority then created_at; take the top 3.
+3. **Compute the ready queue.** Target model: pull from the
+   [fhir-place project board](https://github.com/orgs/danielsperoniteam/projects/1)
+   scoped to the current sprint iteration, sorted by Priority
+   (`P0` → `P1` → `P2` → `P3`). **PENDING — requires `read:project`
+   token scope** (see [tracking issue #436](https://github.com/danielsperoniteam/fhir-place/issues/436));
+   until that lands, the dispatcher uses the label-only fallback: a
+   "ready" issue has exactly one `type:`, ≥1 `area:`, exactly one
+   `priority:`; no `status: blocked / needs-triage / in-progress /
+   needs-human`; no assignees; all listed blockers closed. Sort by
+   priority (`P0` first) then `created_at`; take the top 3.
 4. **Claim and dispatch — sequentially, never in parallel.** For each
    issue: add `status: in-progress` (the lock), comment the picked-up
    notice, invoke the `engineer` subagent in worktree isolation,

--- a/scripts/sync-labels.mjs
+++ b/scripts/sync-labels.mjs
@@ -25,7 +25,7 @@ if (!TOKEN) {
 
 const CANONICAL = [
   // type:
-  { name: 'type: bug', color: 'd73a4a', description: 'Defect or regression. Bugs default to priority: high.' },
+  { name: 'type: bug', color: 'd73a4a', description: 'Defect or regression. Bugs default to priority: P0.' },
   { name: 'type: feature', color: 'a2eeef', description: 'New capability or user-visible enhancement.' },
   { name: 'type: tech-debt', color: 'd4c5f9', description: 'Refactor, cleanup, build/perf, or non-functional improvement.' },
   { name: 'type: docs', color: '0075ca', description: 'Documentation only.' },
@@ -41,9 +41,10 @@ const CANONICAL = [
   { name: 'area: auth', color: 'b60205', description: 'Authentication / authorization.' },
   { name: 'area: security', color: 'b60205', description: 'Security-sensitive change or review.' },
   // priority:
-  { name: 'priority: high', color: 'e11d21', description: 'Top of the queue.' },
-  { name: 'priority: medium', color: 'fbca04', description: 'Default priority.' },
-  { name: 'priority: low', color: '0e8a16', description: 'Nice-to-have.' },
+  { name: 'priority: P0', color: 'e11d21', description: 'Do now — top of the queue.' },
+  { name: 'priority: P1', color: 'fbca04', description: 'Default priority.' },
+  { name: 'priority: P2', color: '0e8a16', description: 'Nice-to-have.' },
+  { name: 'priority: P3', color: 'BFD4F2', description: 'Deferred — someday / out of current sprint.' },
   // status:
   { name: 'status: blocked', color: '000000', description: 'Cannot progress until a referenced blocker resolves.' },
   { name: 'status: needs-triage', color: 'cccccc', description: 'No type/area/priority set, or PM agent unsure — needs human review.' },


### PR DESCRIPTION
Tracking issue: #436

## Summary

This PR is two coherent changes preparing for the sprint-scoped project-board model that `README.md` § Sprint board and the new "Where work lives" block in `CLAUDE.md` already describe:

1. **Priority label vocabulary rename.** Every dispatcher, triage prompt, workflow filer, and SDLC doc that used `priority: high/medium/low` now uses `priority: P0/P1/P2`. A new `priority: P3` is added for explicit deferral — out-of-current-sprint work, "someday" — distinct from "no priority."
2. **SDLC docs describe the sprint-scoped ready queue as the target model** for engineer dispatch, with the project-board filter flagged **PENDING — requires `read:project` token scope** the current `GITHUB_TOKEN` lacks. Until a `PROJECTS_PAT` secret is configured, the dispatcher falls back to the existing label-only ready predicate (sorted P0 → P3 then created_at). The actual project-board GraphQL implementation comes in a separate follow-up PR.

## Files touched

- **Code:** `scripts/sync-labels.mjs` (rename three labels in place, add `priority: P3` with color `BFD4F2`, update `type: bug` description), `.github/workflows/on-failure-issue.yml`, `.github/workflows/live-site-monitor.yml`.
- **Prompts:** `docs/prompts/hourly-engineer-dispatch.md` (Step 3 expanded to describe the sprint-scoped target with PENDING note), `docs/prompts/hourly-uat-validation.md`, `docs/prompts/daily-pm-triage.md`, `docs/prompts/daily-qa-pass.md`, `docs/prompts/issue-review.md`.
- **SDLC docs:** `docs/sdlc/lifecycle.md` (new "Target model: sprint-scoped ready queue" subsection in stage 3), `docs/sdlc/loops.md`, `docs/sdlc/gaps.md`, `docs/sdlc/agents.md`.
- **Contributing:** `CONTRIBUTING.md` (label vocabulary table now lists `P0/P1/P2/P3` with `P3` explicitly called out as the deferral bucket).

## Post-merge step (Sam runs this)

The live GitHub labels are **not** renamed in this PR. After merge, Sam runs `gh label edit` to atomically rename the existing three labels and create `priority: P3`. `gh label edit --name <old> --new-name <new>` transfers existing issue-label associations atomically — no orphaned issues.

```
gh label edit "priority: high"   --name "priority: P0" --description "Do now — top of the queue."
gh label edit "priority: medium" --name "priority: P1" --description "Default priority."
gh label edit "priority: low"    --name "priority: P2" --description "Nice-to-have."
gh label create "priority: P3"   --color BFD4F2       --description "Deferred — someday / out of current sprint."
```

After that, `scripts/sync-labels.mjs` is idempotent — the next run reconciles cleanly.

## What's not in this PR

- Live label rename (Sam's manual post-merge step above).
- Actual project-board GraphQL filtering — sub-task #3 of the tracking issue, blocked on token scope.
- Sprint-awareness expansion in `.claude/agents/health-tech-pm.md` — sub-task #5 of the tracking issue.
- `README.md` and `CLAUDE.md` — already updated by Daniel on `main`.
- `.claude/agents/qa-engineer.md` "P0" reference — that's clinical-safety P0, already correct, intentionally not touched.

## Test plan

N/A — no user-visible change. Documentation, label-vocabulary, and bot-filer label-string updates only. Verified locally:

- [x] `git grep "priority: high\\|priority: medium\\|priority: low"` returns zero matches.
- [x] No secret patterns in diff.
- [x] Blast radius: 13 files, 107 lines (within caps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)