### PR TITLE
docs: link sprint board from README, AGENTS, CLAUDE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # Codex Notes
 
+## Where work lives
+
+- **Project board:** <https://github.com/orgs/danielsperoniteam/projects/1>
+- Two-week sprints. Pull from the current sprint sorted by Priority (P0 first).
+- Issues are still the source of truth; the board is the lens.
+- See `README.md` § Sprint board for the current focus and what's deferred.
+
 ## General
 
 - Keep context small; read only files relevant to the active issue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,12 @@
 # Claude Code Notes
 
+## Where work lives
+
+- **Project board:** <https://github.com/orgs/danielsperoniteam/projects/1>
+- Two-week sprints. Pull from the current sprint sorted by Priority (P0 first).
+- Issues are still the source of truth; the board is the lens.
+- See `README.md` § Sprint board for the current focus and what's deferred.
+
 ## General
 
 - Keep context small; read only files relevant to the active issue.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ See [`apps/goals-tasks/README.md`](apps/goals-tasks/README.md) for the full brea
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | PR workflow, testing, changesets, bump conventions |
 | [`docs/decisions/`](docs/decisions/) | Architecture Decision Records |
 | [Open issues](https://github.com/danielsperoniteam/fhir-place/issues) | Tracked gaps and roadmap items |
+| [Project board](https://github.com/orgs/danielsperoniteam/projects/1) | Sprint board — pull work from the current sprint, sorted by Priority |
+
+## Sprint board
+
+Work is tracked on the [fhir-place project board](https://github.com/orgs/danielsperoniteam/projects/1). Two-week sprints. Pull from the current sprint sorted by Priority (P0 first), assign yourself, move to **In Progress**, open a PR, merge moves to **Done**. Bot dispatchers and human contributors share the same board.
+
+- **Sprint 1 (May 10 – May 24, 2026)** — agent process and SDLC hardening. Get CI green (#319, #320, #323), fix the XSS in the JSON viewer (#360), enforce the staging-only rule mechanically (#425), make the dispatcher's failure modes legible (#429), kill switch wired (#284).
+- **Sprint 2 (May 24 – Jun 7, 2026)** — high-priority bug burndown plus clinical-safety guardrails (#254, #269 carved into 5 issues via #433). Validates that Sprint 1's SDLC changes actually hold under bug-fix volume.
+
+SMART, big new features, and net-new resource-type support are deferred until Sprint 1 SDLC work has stuck for at least one sprint.
+
+The plan was written by the four-agent retro on 2026-05-06 (`docs/retros/2026-05-06-dev-process.md`). Next retro: 2026-05-20.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Adds a Sprint board section to `README.md` linking <https://github.com/orgs/danielsperoniteam/projects/1>.
- Adds a "Where work lives" section to `AGENTS.md` and `CLAUDE.md` so Codex / Claude sessions on other machines find the board.
- Names the source: 2026-05-06 four-agent retro at `docs/retros/2026-05-06-dev-process.md` (untracked locally — separate concern).

Sprint board has 14 issues in Sprint 1 (SDLC hardening, May 10–24) and 15 in Sprint 2 (bug burndown + clinical safety, May 24 – Jun 7). 11 new issues filed (#424–#435) covering retro action items #3, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15. Item #1 was already done as #284.

SMART, big new features, and net-new resource-type support are deferred until Sprint 1 SDLC work has held for at least one sprint.

## Test plan

- [ ] N/A — docs-only change, no user-visible behavior.
- [ ] Confirm board link renders on github.com/danielsperoniteam/fhir-place after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)