### PR TITLE
fix(ci): staging deploys + sync-staging via PR + auto-merge

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -201,6 +201,14 @@ jobs:
 
   deploy:
     needs: build
+    # The github-pages environment is protected to "deploy only from main".
+    # Staging pushes still run the `build` job above (which rebuilds both
+    # the / and /staging/ slots so the artifact is complete) but the
+    # actual deploy must come from main — otherwise this step 422s with
+    # an environment-protection error. Skipping deploy on non-main refs
+    # keeps staging-push runs green and matches the design that main
+    # pushes are what refresh /staging/.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -201,14 +201,11 @@ jobs:
 
   deploy:
     needs: build
-    # The github-pages environment is protected to "deploy only from main".
-    # Staging pushes still run the `build` job above (which rebuilds both
-    # the / and /staging/ slots so the artifact is complete) but the
-    # actual deploy must come from main — otherwise this step 422s with
-    # an environment-protection error. Skipping deploy on non-main refs
-    # keeps staging-push runs green and matches the design that main
-    # pushes are what refresh /staging/.
-    if: github.ref == 'refs/heads/main'
+    # The github-pages environment's deployment-branch-policies allow
+    # both `main` and `staging`. Both pushes can deploy the combined
+    # artifact (with `/` from main and `/staging/` from staging), so
+    # `/staging/` refreshes promptly on any staging-only push instead
+    # of waiting for the next main push to rebuild both slots.
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/sync-staging.yml
+++ b/.github/workflows/sync-staging.yml
@@ -1,17 +1,23 @@
 # Keeps staging up-to-date with main after direct-to-main merges.
 #
 # When someone merges a PR directly into main (skipping staging — e.g.,
-# docs-only or CI-only changes), this workflow fast-forwards or merges
-# main into staging so staging never falls behind.
+# docs-only or CI-only changes), this workflow opens a "chore: sync main
+# into staging" PR and arms it for auto-merge through the merge queue.
+# Staging's ruleset requires 0 approving reviews, so once test + e2e
+# pass on the merge commit the queue lands it without human action.
 #
-# Uses the admin bypass on the staging ruleset to push directly.
+# Why PR-based, not direct push: the staging ruleset blocks all
+# non-bypass direct pushes (including from github-actions[bot]), so a
+# `git push origin staging` from inside a workflow 422s. PRs are the
+# supported path for non-admin actors.
+#
 # Does NOT trigger if the push to main came from the promotion PR
 # (detected by commit message) to avoid infinite loops.
 #
 # If the trivial merge hits conflicts, the workflow invokes Claude to attempt
 # resolution following docs/prompts/pr-resolve-conflicts.md. Only if Claude
-# cannot resolve — or pushes a fix that doesn't actually catch staging up to
-# main — does it escalate to a human.
+# cannot resolve — or the PR doesn't actually catch staging up to main —
+# does it escalate to a human.
 
 name: Sync staging with main
 
@@ -55,14 +61,36 @@ jobs:
           BEHIND=$(git rev-list --count origin/staging..origin/main)
           echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
 
-      - name: Merge main into staging
+      # Create a branch from staging, merge main into it locally, push the
+      # branch, open a PR -> staging, arm auto-merge. Staging's ruleset
+      # requires 0 approving reviews, so once test+e2e pass the merge queue
+      # squashes it. Branch name is deterministic so re-runs update the
+      # same PR instead of opening a new one each push.
+      - name: Open sync PR + arm auto-merge
         if: steps.check.outputs.behind != '0'
         id: merge
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git checkout staging
-          git merge origin/main --no-edit
-          git push origin staging
+          BRANCH="chore/sync-main-into-staging"
+          git checkout -B "$BRANCH" origin/staging
+          if ! git merge origin/main --no-edit --no-ff -m "chore: sync main into staging"; then
+            echo "Trivial merge hit conflicts; will fall through to the Claude resolution path." >&2
+            exit 1
+          fi
+          git push --force-with-lease origin "$BRANCH"
+
+          # Reuse an open PR for this branch if one exists; otherwise open one.
+          PR_NUM=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$BRANCH" --base staging --json number --jq '.[0].number // empty')
+          if [ -z "$PR_NUM" ]; then
+            PR_NUM=$(gh pr create --repo "$GITHUB_REPOSITORY" --base staging --head "$BRANCH" \
+              --title "chore: sync main into staging" \
+              --body "Auto-opened by .github/workflows/sync-staging.yml after a direct-to-main commit. Staging requires 0 approving reviews, so the merge queue will pick this up once test + e2e go green." \
+              | grep -oE '[0-9]+$' | tail -1)
+          fi
+          echo "pr=$PR_NUM" >> "$GITHUB_OUTPUT"
+          gh pr merge "$PR_NUM" --repo "$GITHUB_REPOSITORY" --auto --squash
 
       # --- Conflict path: reset, let Claude resolve, verify, escalate if needed ---
 
@@ -95,28 +123,30 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            A direct push to main triggered the sync-staging workflow, which
-            tried to merge main into staging and hit conflicts.
+            A direct push to main triggered the sync-staging workflow.
+            The trivial `git merge origin/main` into the sync branch hit
+            conflicts. Resolve them on a sync branch and push it; the
+            workflow's next step will open / update the PR and arm
+            auto-merge.
 
             Context:
             - Source branch: main
-            - Target branch: staging (currently checked out at origin/staging,
-              clean working tree)
-            - There is no PR — this is a direct branch sync.
+            - Target branch: staging
+            - Working tree: clean, checked out at origin/staging
+            - Sync branch (you create): chore/sync-main-into-staging
 
             Read docs/prompts/pr-resolve-conflicts.md and follow the
             methodology for resolving conflicts. Adaptations for this
             non-PR context:
 
-            - In Step 1, run `git merge origin/main` (treat main as the
-              base_ref).
+            - In Step 1, run `git checkout -B chore/sync-main-into-staging origin/staging`
+              then `git merge origin/main --no-ff -m "chore: sync main into staging"`.
             - Skip the PR-comment steps (Step 6 and the comment in the
-              needs-human path) — there is no PR. If you find an open
+              needs-human path) — there is no PR yet. If you find an open
               staging→main promotion PR, you may post the summary there;
               otherwise say nothing.
-            - Use commit message:
-              `chore: sync main into staging (auto-resolved conflicts)`
-            - Push to `staging`. NEVER push to main.
+            - When done, `git push --force-with-lease origin chore/sync-main-into-staging`.
+              NEVER push directly to staging or main.
             - If the conflict is genuinely ambiguous or fits the
               needs-human criteria from the prompt, run `git merge --abort`
               and exit non-zero. The workflow will escalate to a human.
@@ -124,19 +154,41 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Verify staging caught up to main
+      - name: Open / update PR after Claude resolution
+        if: steps.check.outputs.behind != '0' && steps.merge.outcome == 'failure' && steps.resolve.outcome == 'success'
+        id: post_resolve_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="chore/sync-main-into-staging"
+          PR_NUM=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$BRANCH" --base staging --json number --jq '.[0].number // empty')
+          if [ -z "$PR_NUM" ]; then
+            PR_NUM=$(gh pr create --repo "$GITHUB_REPOSITORY" --base staging --head "$BRANCH" \
+              --title "chore: sync main into staging (auto-resolved conflicts)" \
+              --body "Auto-opened by .github/workflows/sync-staging.yml after Claude resolved conflicts merging main into staging." \
+              | grep -oE '[0-9]+$' | tail -1)
+          fi
+          gh pr merge "$PR_NUM" --repo "$GITHUB_REPOSITORY" --auto --squash
+
+      - name: Verify sync PR exists
         if: steps.check.outputs.behind != '0' && steps.merge.outcome == 'failure' && steps.resolve.outcome == 'success'
         id: verify
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git fetch origin main staging
-          BEHIND=$(git rev-list --count origin/staging..origin/main)
-          if [ "$BEHIND" != "0" ]; then
-            echo "staging still behind main by $BEHIND commits after Claude run"
+          # Don't verify staging caught up — auto-merge through the queue
+          # takes ~3 min after we exit. Just verify the sync PR exists.
+          BRANCH="chore/sync-main-into-staging"
+          PR_NUM=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$BRANCH" --base staging --json number --jq '.[0].number // empty')
+          if [ -z "$PR_NUM" ]; then
+            echo "No open sync PR after Claude run; escalate."
             exit 1
           fi
+          echo "Sync PR #$PR_NUM is open and armed for auto-merge."
 
-      - name: Escalate if merge failed
+      - name: Escalate if sync flow failed
         if: >-
           steps.check.outputs.behind != '0' &&
           steps.merge.outcome == 'failure' &&

--- a/.github/workflows/sync-staging.yml
+++ b/.github/workflows/sync-staging.yml
@@ -153,31 +153,55 @@ jobs:
               owner, repo, state: 'open', head: `${owner}:staging`, base: 'main'
             });
 
+            const sha = context.sha.substring(0, 8);
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
             const body = [
               '## ⚠️ Staging sync failed',
               '',
-              'A direct-to-main merge could not be automatically synced to staging.',
+              `A direct-to-main merge (${sha}) could not be automatically synced to staging.`,
               'Both the trivial merge and the Claude-assisted conflict resolution',
               'either hit a needs-human case or did not leave staging caught up to main.',
               '',
               '**Action needed:** @danielsperoni please merge main into staging manually:',
               '```bash',
-              'git checkout staging && git merge origin/main',
+              'git checkout staging && git merge origin/main && git push origin staging',
               '```',
               '',
-              '_Failed at ' + new Date().toISOString() + '_'
+              `_Workflow run: ${runUrl} · Failed at ${new Date().toISOString()}_`
             ].join('\n');
 
+            const ESCALATION_TITLE = 'Staging sync failed — manual merge needed';
+
             if (openPRs.length > 0) {
+              // Active promotion PR — annotate it so the reviewer sees the
+              // staging-sync failure inline rather than opening a new ticket.
               await github.rest.issues.createComment({
                 owner, repo,
                 issue_number: openPRs[0].number,
                 body
               });
+              return;
+            }
+
+            // Dedup: if there's already an open escalation issue, comment on
+            // it instead of filing a new one. Avoids accumulating one issue
+            // per direct-to-main commit batch when sync stays broken.
+            const { data: existing } = await github.rest.issues.list({
+              owner, repo, state: 'open', labels: 'status: needs-human,area: infra',
+              per_page: 50
+            });
+            const open = existing.find(i => i.title === ESCALATION_TITLE);
+
+            if (open) {
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: open.number,
+                body: `Another sync failure on the same open issue.\n\n${body}`
+              });
             } else {
               await github.rest.issues.create({
                 owner, repo,
-                title: 'Staging sync failed — manual merge needed',
+                title: ESCALATION_TITLE,
                 body,
                 labels: ['status: needs-human', 'area: infra'],
                 assignees: ['danielsperoni']

--- a/docs/sdlc/lifecycle.md
+++ b/docs/sdlc/lifecycle.md
@@ -4,23 +4,38 @@ The end-to-end journey of one piece of work, from "an issue exists" to
 "the change is live on `main`." Read [`loops.md`](./loops.md) first for
 the cadence; this doc is the path through the loops.
 
-## Deploy model: per-PR preview, direct merge to main
+## Deploy model: long-lived staging branch + batched promotion
 
-`fhir-place` uses a **single-environment-deploy-per-PR** model:
+`fhir-place` uses a **long-lived staging branch** that mirrors what's
+about to be promoted to production:
 
-- Feature branches PR into **`main`**, never an integration branch.
-- Each PR can request a preview deploy onto `/staging/` for UAT (a
-  shared slot — one PR at a time).
-- The PR merges to `main` only after CI is green AND `uat: passed`.
-- `main` is what `/` serves. Each PR-merge is one production deploy.
+- Feature branches PR into **`staging`**, not directly into `main`.
+- `pages.yml` builds and deploys two slots from one artifact:
+  `/` from `main` and `/staging/` from `staging`. Both branches can
+  trigger a deploy (the github-pages environment is configured to
+  allow both).
+- Once a PR (or a batch of PRs) is on `staging` and `/staging/` has
+  refreshed, a human walks the **UAT on live staging** checklist
+  against the live URL.
+- `promote-staging.yml` opens / updates a single **promotion PR**
+  (`staging → main`) that aggregates UAT checklists from every PR
+  merged into staging since the last promotion. Approving and merging
+  the promotion PR is what ships to `/`.
+- `sync-staging.yml` keeps staging caught up to main after direct-to-
+  main commits (CI fixes, doc edits, etc. that bypass the staging
+  branch). It opens a `chore: sync main into staging` PR and arms
+  auto-merge; the queue lands it without human approval because the
+  staging ruleset requires 0 approving reviews.
 
-There is **no rolling integration branch**. There is **no batched
-release train**. The `staging` branch is just the slot the preview
-deploy publishes from — its history is not preserved or promoted.
+The staging branch is **long-lived**: its history is preserved and
+its tip is what `/staging/` serves. There is one shared staging slot,
+not a per-PR preview slot.
 
-This shape is right for `fhir-place` because (a) features are mostly
-independent, (b) one human gates production, and (c) reverting a single
-PR-merge is cheaper than maintaining batched-release infrastructure.
+This shape suits `fhir-place` because (a) batched UAT against the
+real staging URL is cheap and fast, (b) one human gates production
+via the promotion PR, and (c) the engineer agent always knows what
+its PR will be reviewed against (`staging`) without per-PR slot
+contention.
 
 ## The state machine, in one diagram
 
@@ -57,7 +72,7 @@ PR-merge is cheaper than maintaining batched-release infrastructure.
                 │  status: in-progress    │  ← lock label
                 │  bot/issue-<N>-<slug>   │
                 │  branch created off     │
-                │  origin/main            │
+                │  origin/staging         │
                 └──────────────┬──────────┘
                                │
                   engineer subagent runs
@@ -67,40 +82,45 @@ PR-merge is cheaper than maintaining batched-release infrastructure.
                 ┌──────────────┴─────────────┐
                 │                            │
                 ▼                            ▼
-        ┌──────────────┐          ┌────────────────────────┐
-        │  PR opened   │          │ status: needs-human or │
-        │  (ready),    │          │ status: needs-triage   │
-        │  base: main  │          │ + structured comment   │
-        │  Closes #N   │          └────────────────────────┘
-        │  uat:        │
-        │  requested   │
-        └──────┬───────┘
-               │
-       Codex review on PR open. Author addresses P1/P2
-       in a follow-up commit, or replies + resolves.
-               │
-               ▼
-       Preview-deploy workflow (triggered by `uat: requested`)
-       force-publishes the PR's build into the `/staging/` slot
-               │
-               ▼
-       Hourly UAT validation walks the PR's "UAT on live staging"
-       checklist against https://danielsperoniteam.github.io/fhir-place/staging/
-       and sets `uat: passed` or `uat: failed`
-               │
-               ▼
-       PR is mergeable when: CI green + `uat: passed` + Codex addressed
-               │
-               ▼
-       Daniel (or auto-merge, when configured) merges PR → main
-               │
-               ▼
-       pages.yml rebuilds /
-               │
-               ▼
-       Live site monitor (06:30 UTC nightly) runs the fixed
-       Playwright suite against /; failures become new bot-filed
-       issues → next morning's PM triage
+        ┌─────────────────┐        ┌────────────────────────┐
+        │  PR opened      │        │ status: needs-human or │
+        │  (draft or      │        │ status: needs-triage   │
+        │   ready),       │        │ + structured comment   │
+        │  base: staging  │        └────────────────────────┘
+        │  Closes #N      │
+        └────────┬────────┘
+                 │
+       Human review (or PR-review workflow). Author addresses
+       blockers in a follow-up commit, or resolves with reasoning.
+                 │
+                 ▼
+       PR merges into `staging` via merge queue
+       (0 approvals required; test + e2e gate)
+                 │
+                 ▼
+       pages.yml rebuilds /staging/ (and /, both slots
+       always rebuilt so the artifact stays complete)
+                 │
+                 ▼
+       promote-staging.yml opens / updates the
+       `staging → main` promotion PR with aggregated
+       UAT checklists from every included PR
+                 │
+                 ▼
+       Human walks the UAT checklist against
+       https://danielsperoniteam.github.io/fhir-place/staging/
+                 │
+                 ▼
+       Human approves + merges the promotion PR → main
+                 │
+                 ▼
+       pages.yml rebuilds / (and /staging/ stays in sync
+       because both slots rebuild on every deploy)
+                 │
+                 ▼
+       Live site monitor (06:30 UTC nightly) runs the
+       fixed Playwright suite against /; failures become
+       new bot-filed issues → next morning's PM triage
 ```
 
 ## Sprint board column mapping
@@ -112,9 +132,9 @@ The [fhir-place sprint board](https://github.com/orgs/danielsperoniteam/projects
 | **Todo** | 1–2 | New issues, post-triage and not yet picked up. The "ready queue" lives here. |
 | **Blocked** | (sidetrack) | Carries the `status: blocked` label or otherwise stuck on an external dependency. |
 | **In progress** | 3–4 | An engineer (subagent or human) has the claim. `status: in-progress` is on the issue. |
-| **Ready for review** | 5–6 | PR is open, ready-for-review, awaiting Codex / CI / preview deploy. |
-| **Ready for UAT** | 7 | Preview deploy is live on `/staging/`. UAT validation is walking the checklist (or has, with `uat: failed` to address). |
-| **Released** | 8 | PR merged into `main`. `/` has redeployed. Post-deploy regression has run (or will, next nightly). |
+| **Ready for review** | 5–6 | Draft PR is open and either marked ready or still draft awaiting human review. |
+| **Ready for UAT** | 7–8 | PR has merged into `staging`. `/staging/` has been redeployed. Waiting for human UAT against the live staging URL. |
+| **Released** | 9–10 | Promoted from `staging` to `main`. Pages has redeployed the production slot. Post-deploy regression has run (or will, next nightly). |
 
 Transitions are driven by [`project-sync.yml`](../../.github/workflows/project-sync.yml). It listens for issue/PR/label events and moves items between columns. The workflow is the source of truth for column moves; if a state needs to change, change the trigger in the workflow, not the column manually.
 
@@ -176,13 +196,14 @@ second concurrent dispatch run cannot pick the same issue.
 [`.claude/agents/engineer.md`](../../.claude/agents/engineer.md)
 
 Worktree isolation: `git worktree add ../wt-<N> -b bot/issue-<N>-<slug>
-origin/main`. The PR base is **always `main`**.
+origin/staging`. The PR base is **always `staging`** — humans promote
+`staging` → `main` after live UAT.
 
 Outcomes:
 
 | Outcome | Issue label after | Branch |
 | --- | --- | --- |
-| Ready-for-review PR opened, `uat: requested` applied | `status: in-progress` stripped | pushed |
+| Draft / ready-for-review PR opened | `status: in-progress` stripped | pushed |
 | Acceptance criteria ambiguous | `status: needs-triage` | not pushed |
 | Typecheck/tests/e2e/build fail past retry budget | `status: needs-human` | left in place locally |
 | Blast-radius cap exceeded | `status: needs-human` | not pushed |
@@ -191,24 +212,24 @@ Outcomes:
 | Loop heuristic / wall-clock cap | `status: needs-human` | left in place locally |
 | Subagent crashed / silent | `status: needs-human` (added by orchestrator) | unknown |
 
-The orchestrator strips `status: in-progress` after the PR is opened
-and the `uat: requested` label is applied. The subagent comments the
-PR link onto the issue.
+The orchestrator strips `status: in-progress` after the PR is opened.
+The subagent comments the PR link onto the issue.
 
 ### 5. PR opened — what's in it
 
-PRs are opened **ready-for-review (not draft)** with `base: main`. The
-body is mandated to contain, in order:
+PRs are opened with `base: staging`. They may be draft or ready-for-
+review; the engineer subagent opens them as draft by default and the
+author marks ready when checks have settled. The body is mandated to
+contain, in order:
 
 1. `Closes #<N>`
 2. **Summary** — 1–3 bullets, "why" not "what".
 3. **Test plan** — checklist of commands run locally.
-4. **UAT on live staging** — concrete, copy-pasteable steps the QA
-   agent can walk against
+4. **UAT on live staging** — concrete, copy-pasteable steps a human or
+   QA agent can walk against
    `https://danielsperoniteam.github.io/fhir-place/staging/` once the
-   preview-deploy workflow has published the PR's build there. Each
-   step names the route, the action, and the expected observable
-   result.
+   PR has merged into staging and Pages has redeployed. Each step
+   names the route, the action, and the expected observable result.
 
 If the engineer can't articulate UAT steps, that's an exit condition —
 it doesn't open the PR.
@@ -219,63 +240,70 @@ For any user-visible change, screenshots are committed under
 internal-refactor PRs may write `N/A — no user-visible change` in
 that section but must not skip it silently.
 
-### 6. Code review (Codex)
+### 6. Human review
 
-Codex reviews on PR open and on `ready_for_review`. It posts inline
-comments tagged with severity (P1, P2, suggestion). The author (engineer
-agent or human) addresses comments in one of two ways:
+A human (or the PR-review workflow at
+[`.github/workflows/pr-review.yml`](../../.github/workflows/pr-review.yml))
+reviews the diff. The staging ruleset has
+`required_approving_review_count: 0` — review is optional for the merge
+gate but recommended for substantive changes. The PR-review workflow's
+engineer subagent can return `verdict: blocker` to gate merge via
+`REQUEST_CHANGES`; the author addresses the blocker and re-requests.
 
-- **Code change** — push a fix commit to the PR branch. Codex re-reviews
-  on the next push.
-- **Reply + resolve** — when the comment doesn't need a code change
-  (false positive, intentional choice), reply with the reasoning and
-  mark the thread resolved.
+When the PR is marked ready and CI is green (`test` and `e2e`
+required by the staging ruleset), the merge queue picks it up and
+squash-merges into staging.
 
-There is **no human approval gate** at this stage. The staging branch
-ruleset has `required_approving_review_count: 0` — Codex review is
-informational, not a merge gate. CI is the mechanical gate.
+### 7. Merge into `staging`
 
-### 7. Preview deploy + UAT validation
+The merge queue rebuilds the merge commit, re-runs `test` and `e2e`
+against it, and squashes into staging when both pass. The `staging`
+branch is the source of truth for the next deployment of `/staging/`.
 
-The `uat: requested` label triggers a preview-deploy workflow that
-force-publishes the PR's build into the `/staging/` slot. Only one PR
-at a time can hold the slot — the workflow serializes requests.
+`pages.yml` triggers on the push to staging and rebuilds both `/` and
+`/staging/` slots from the latest of each branch, then deploys the
+combined artifact. `/staging/` refreshes within ~3 minutes.
 
-Once `/staging/` is updated, the next hourly UAT validation walks the
-PR's "UAT on live staging" checklist against the live URL. It:
+### 7b. Promotion PR
 
-- Sets `uat: passed` if every checklist item passes
-- Sets `uat: failed` if any item fails (and lists the failing items in
-  a comment)
-- Sets `uat: pending` if the run hasn't reached this PR yet
-- Files out-of-scope bugs (anything broken outside the PR's changed
-  files) as new bot-issues — not added to the PR comment
+`promote-staging.yml` triggers on every push to staging and
+opens / updates a single open `staging → main` promotion PR. Its body
+aggregates the **UAT on live staging** sections from every PR merged
+into staging since the last promotion, giving a reviewer one
+consolidated checklist.
 
-[`docs/prompts/hourly-uat-validation.md`](../prompts/hourly-uat-validation.md) is the prompt; the
-`qa-engineer` subagent does the per-PR walk.
+The PR is assigned to `@danielsperoni`. Items flagged with
+`status: needs-human` are called out at the top of the body. Conflict
+resolution against main is attempted automatically by Claude; if it
+can't resolve cleanly, the workflow escalates.
 
-If `uat: failed`: the author (engineer agent or human) addresses the
-failing items, pushes a fix, re-applies `uat: requested` (or the label
-sticks), and the next UAT run re-evaluates.
+### 8. UAT validation against the live staging build
 
-### 8. Merge to main
+A human (Daniel, typically) walks the UAT checklist on the promotion
+PR against
+`https://danielsperoniteam.github.io/fhir-place/staging/`. The
+hourly UAT-validation workflow can also walk PRs that include a
+`UAT on live staging` block, setting `uat: passed` / `uat: failed`
+labels and filing out-of-scope bugs as new issues.
 
-A PR is mergeable when **all** are true:
+If UAT fails, the human (or engineer subagent in a follow-up) fixes
+the regression in a new PR against staging, and the next promotion PR
+batch includes the fix.
 
-- CI green (`test` and `e2e` required by the main ruleset)
-- `uat: passed` label is set
-- No outstanding "request changes" review
-- No unresolved P1 Codex thread
+### 9. Promotion: `staging` → `main`
 
-Daniel does the merge for v1. Once observation confirms the gates are
-trustworthy, an auto-merge workflow can be added that enqueues PRs
-matching the criteria. Until then, Daniel is the human in the loop —
-but the work he does is mechanical (click merge), not interpretive
-(read the diff, decide).
+Approving and merging the promotion PR fast-forwards `main` to the
+current staging tip. `pages.yml` triggers on the push to main and
+rebuilds both slots; `/` is now serving the promoted code, and
+`/staging/` stays in sync because both slots rebuild on every deploy.
 
-### 9. Post-deploy regression check
+The main ruleset requires `test` and `e2e` to pass on the merge commit,
+plus one approving CODEOWNER review. Daniel is the codeowner; the
+review is also the human's verification that UAT passed.
 
-Live-site-monitor runs at 06:30 UTC the following morning against `/`,
+### 10. Post-deploy regression check
+
+Live-site-monitor runs at 06:30 UTC the next morning against `/`,
 files any new failures as bot-issues, and the cycle starts over with
 PM triage at 07:00.
 
@@ -283,13 +311,32 @@ If a regression is filed, it lands in the "ready" queue once PM triage
 labels it, the engineer dispatch picks it up at the next `:05`, and
 the lifecycle repeats.
 
+## Direct-to-main commits and back-sync
+
+Some commits bypass the staging branch — CI/workflow fixes, doc
+edits, or anything that needs to land on main immediately. After such
+a commit:
+
+- `sync-staging.yml` triggers on the push to main.
+- It creates / reuses `chore/sync-main-into-staging`, merges
+  `origin/main` into it locally, force-with-lease pushes the branch,
+  opens (or reuses) a PR to staging, and arms `gh pr merge --auto`.
+- Because staging requires 0 approving reviews, the queue squash-
+  merges the sync PR once test + e2e are green.
+- If the trivial merge hits conflicts, the workflow invokes Claude
+  to resolve them on the sync branch. Only if Claude can't resolve
+  does it escalate to a human (dedup'd into one open issue).
+
 ## Reverting from main
 
 Sometimes a PR merges to main and a regression surfaces in the next
 nightly check (or sooner). Recovery:
 
-1. Open a revert PR against `main` (`git revert <merge-commit>`).
-2. CI runs. UAT can be requested if the revert is non-trivial.
+1. Open a revert PR against `staging` (`git revert <merge-commit>`),
+   walk through the same staging → promotion → main flow. For urgent
+   reverts that can't wait, open against `main` directly and let
+   `sync-staging.yml` back-sync.
+2. CI runs. Walk the UAT for the revert if it's non-trivial.
 3. Merge the revert. `/` redeploys without the bad change.
 4. The original PR's bot-issue branch can be retried with a fix.
 
@@ -305,14 +352,14 @@ points:
 
 1. **Triggering the kill switch** when something is going sideways
    (label the loop's tracking issue `status: agent-paused`).
-2. **Merging the PR to `main`** once CI is green and `uat: passed`.
-   For v1, Daniel does this manually — the work is mechanical, not
-   interpretive. An auto-merge workflow can replace this once the
-   gates are observably trustworthy.
+2. **Approving + merging the promotion PR** `staging → main` once UAT
+   has been walked. This is the production-deploy gate; it's where the
+   human verifies what they validated on `/staging/` is what's about
+   to ship to `/`.
 3. **Modifying the SDLC itself** — prompts, agent definitions,
    workflows, `CODEOWNERS`. Self-modification is out of scope for every
    agent in the system.
 
 Everything else — triage, branch creation, code, tests, screenshots,
-PR open, code review (Codex), preview deploy, UAT walk, label
-management, bug-filing — is automated.
+PR open, code review, merge to staging, label management, bug-filing,
+back-sync — is automated.


### PR DESCRIPTION
## Summary

Three CI fixes, all addressing the staging branch's deployment + sync story.

### 1. `staging` can now deploy directly to `/staging/`
The github-pages environment was protected to "deploy only from `main`", so staging pushes 422'd on the deploy step. Added `staging` to the environment's deployment-branch-policies via API (the only way short of the browser UI). Now `/staging/` refreshes on every staging push instead of waiting for the next main push.

This PR includes a no-op cleanup in `pages.yml` — the temporary `if: github.ref == 'refs/heads/main'` gate from this branch's first commit is removed in a follow-up commit, since the gate is no longer needed.

### 2. `sync-staging.yml` — open a PR + auto-merge instead of direct push
**This fixes the long-running "staging is N commits behind main" issue.** Previous flow tried `git push origin staging` from `github-actions[bot]`, which 422s — github-actions isn't a bypass actor on the staging ruleset.

Staging's ruleset is at `required_approving_review_count: 0`, so a PR can sail through the merge queue without any human approval as soon as `test` + `e2e` are green. Switch to that:

- Create deterministic branch `chore/sync-main-into-staging` from `origin/staging`
- Merge `origin/main` into it locally
- Force-with-lease push the branch
- Open / reuse the PR
- `gh pr merge --auto --squash`

Claude conflict-resolution path adapted to commit on the sync branch instead of staging directly.

### 3. `sync-staging.yml` — dedup the escalation issue
When the flow genuinely can't proceed (Claude bails on a real conflict, no sync PR materializes), it now updates the open "Staging sync failed" issue instead of filing a new one. Currently we have 5 stale escalation issues (#410, #414, #415, #422, #443) — only #443 is open and should pick up new failures going forward.

## Test plan

- [ ] Merge to main. The merge triggers sync-staging; the workflow should open `chore: sync main into staging`, arm auto-merge, and the queue lands it within ~3 min.
- [ ] That staging push should successfully deploy `/staging/` (no 422 deploy failure).
- [ ] If anything fails, only #443 should pick up a comment — no new issue.

## Out of scope

If the trivial merge AND Claude resolution both fail, a human still has to resolve manually. The dedup just keeps the inbox quiet.

## Screenshots

N/A — workflow YAML / env protection only.