### PR TITLE
Add ResourceEditor guardrail registry

### DIFF
--- a/.changeset/resourceeditor-guardrail-registry.md
+++ b/.changeset/resourceeditor-guardrail-registry.md
@@ -1,0 +1,7 @@
+---
+"@fhir-place/react-fhir": minor
+---
+
+Export a typed ResourceEditor clinical-safety guardrail registry from
+`@fhir-place/react-fhir/structure` so follow-up guardrail tickets can share the
+same resource-type and element-path design.

--- a/packages/react-fhir/src/structure/walker.test.ts
+++ b/packages/react-fhir/src/structure/walker.test.ts
@@ -2,6 +2,7 @@ import type { Patient } from "fhir/r4";
 import { describe, expect, it } from "vitest";
 import { PatientStructureDefinition } from "../../test/fixtures/StructureDefinition-Patient.js";
 import {
+  RESOURCE_EDITOR_CLINICAL_SAFETY_GUARDRAILS,
   directChildren,
   findChoiceVariant,
   findElement,
@@ -175,5 +176,32 @@ describe("isPrimitive", () => {
     expect(isPrimitive("HumanName")).toBe(false);
     expect(isPrimitive("BackboneElement")).toBe(false);
     expect(isPrimitive(undefined)).toBe(false);
+  });
+});
+
+describe("RESOURCE_EDITOR_CLINICAL_SAFETY_GUARDRAILS", () => {
+  it("names the five ResourceEditor follow-up guardrails", () => {
+    expect(RESOURCE_EDITOR_CLINICAL_SAFETY_GUARDRAILS.map((g) => g.id)).toEqual([
+      "required-patient-reference",
+      "observation-valuequantity-ucum",
+      "unsafe-dose-unit-abbreviation",
+      "allergy-criticality-visibility",
+      "patient-context-change",
+    ]);
+  });
+
+  it("keeps patient-reference guardrails aligned on the same element paths", () => {
+    const requiredPatient = RESOURCE_EDITOR_CLINICAL_SAFETY_GUARDRAILS.find(
+      (g) => g.id === "required-patient-reference",
+    );
+    const contextChange = RESOURCE_EDITOR_CLINICAL_SAFETY_GUARDRAILS.find(
+      (g) => g.id === "patient-context-change",
+    );
+
+    expect(requiredPatient?.outcome).toBe("block-save");
+    expect(contextChange?.outcome).toBe("warn");
+    expect(requiredPatient?.elementPaths).toEqual(contextChange?.elementPaths);
+    expect(requiredPatient?.elementPaths).toContain("Observation.subject");
+    expect(requiredPatient?.elementPaths).toContain("AllergyIntolerance.patient");
   });
 });

--- a/packages/react-fhir/src/structure/walker.ts
+++ b/packages/react-fhir/src/structure/walker.ts
@@ -20,6 +20,117 @@ export interface WalkedElement {
   value: unknown;
 }
 
+export type ClinicalSafetyGuardrailId =
+  | "required-patient-reference"
+  | "observation-valuequantity-ucum"
+  | "unsafe-dose-unit-abbreviation"
+  | "allergy-criticality-visibility"
+  | "patient-context-change";
+
+export type ClinicalSafetyGuardrailPhase = "save" | "render" | "edit-context";
+
+export type ClinicalSafetyGuardrailOutcome =
+  | "block-save"
+  | "warn"
+  | "always-display";
+
+export type ClinicalSafetyElementPath = `${Resource["resourceType"]}.${string}`;
+
+export interface ClinicalSafetyGuardrail {
+  id: ClinicalSafetyGuardrailId;
+  phase: ClinicalSafetyGuardrailPhase;
+  outcome: ClinicalSafetyGuardrailOutcome;
+  resourceTypes: readonly Resource["resourceType"][];
+  elementPaths: readonly ClinicalSafetyElementPath[];
+}
+
+// Design registry only: guardrail behavior is implemented by focused follow-up tickets.
+export const RESOURCE_EDITOR_CLINICAL_SAFETY_GUARDRAILS = [
+  {
+    id: "required-patient-reference",
+    phase: "save",
+    outcome: "block-save",
+    resourceTypes: [
+      "AllergyIntolerance",
+      "Condition",
+      "DiagnosticReport",
+      "Encounter",
+      "MedicationAdministration",
+      "MedicationRequest",
+      "MedicationStatement",
+      "Observation",
+      "Procedure",
+    ],
+    elementPaths: [
+      "AllergyIntolerance.patient",
+      "Condition.subject",
+      "DiagnosticReport.subject",
+      "Encounter.subject",
+      "MedicationAdministration.subject",
+      "MedicationRequest.subject",
+      "MedicationStatement.subject",
+      "Observation.subject",
+      "Procedure.subject",
+    ],
+  },
+  {
+    id: "observation-valuequantity-ucum",
+    phase: "save",
+    outcome: "block-save",
+    resourceTypes: ["Observation"],
+    elementPaths: ["Observation.valueQuantity.code"],
+  },
+  {
+    id: "unsafe-dose-unit-abbreviation",
+    phase: "render",
+    outcome: "always-display",
+    resourceTypes: ["MedicationRequest", "MedicationAdministration", "MedicationStatement"],
+    elementPaths: [
+      "MedicationRequest.dosageInstruction",
+      "MedicationAdministration.dosage",
+      "MedicationStatement.dosage",
+    ],
+  },
+  {
+    id: "allergy-criticality-visibility",
+    phase: "render",
+    outcome: "always-display",
+    resourceTypes: ["AllergyIntolerance"],
+    elementPaths: [
+      "AllergyIntolerance.reaction",
+      "AllergyIntolerance.criticality",
+      "AllergyIntolerance.verificationStatus",
+    ],
+  },
+  {
+    id: "patient-context-change",
+    phase: "edit-context",
+    outcome: "warn",
+    resourceTypes: [
+      "AllergyIntolerance",
+      "Condition",
+      "DiagnosticReport",
+      "Encounter",
+      "MedicationAdministration",
+      "MedicationRequest",
+      "MedicationStatement",
+      "Observation",
+      "Procedure",
+    ],
+    elementPaths: [
+      "AllergyIntolerance.patient",
+      "Condition.subject",
+      "DiagnosticReport.subject",
+      "Encounter.subject",
+      "MedicationAdministration.subject",
+      "MedicationRequest.subject",
+      "MedicationStatement.subject",
+      "Observation.subject",
+      "Procedure.subject",
+    ],
+  },
+] as const satisfies readonly ClinicalSafetyGuardrail[];
+
 const capitalize = (s: string): string => (s ? s[0]!.toUpperCase() + s.slice(1) : s);
 
 const labelFromPath = (path: string, short?: string): string => {


### PR DESCRIPTION
Closes #433

## Summary

- Carves the broad ResourceEditor clinical-safety work into five focused follow-up issues so each guardrail can ship independently.
- Adds a typed registry for those five guardrails in the StructureDefinition walker layer without implementing save/render behavior in this ticket.
- Keeps the registry covered by unit tests and a changeset for the exported react-fhir API.

## Test plan

- [x] `pnpm -r typecheck`
- [x] `pnpm -r test:run` on Node 22 via `npx -y node@22 /opt/homebrew/bin/pnpm -r test:run` after the local Node 25 runtime failed existing jsdom/MSW tests
- [x] `pnpm --filter @fhir-place/demo e2e` on Node 22 via `npx -y node@22 /opt/homebrew/bin/pnpm --filter @fhir-place/demo e2e`
- [x] `pnpm --filter @fhir-place/react-fhir build` on Node 22 via `npx -y node@22 /opt/homebrew/bin/pnpm --filter @fhir-place/react-fhir build`
- [x] `pnpm --filter @fhir-place/demo build` on Node 22 via `npx -y node@22 /opt/homebrew/bin/pnpm --filter @fhir-place/demo build`

## UAT on live staging

1. Open `https://danielsperoniteam.github.io/fhir-place/staging/` and confirm the Patient list renders without a startup error.
2. Open `https://danielsperoniteam.github.io/fhir-place/staging/fhir/Patient/example` and confirm the patient detail page renders normally.
3. Open `https://danielsperoniteam.github.io/fhir-place/staging/fhir/Observation/new` and confirm the generic create form still renders; no clinical-safety save guardrail should appear yet because this PR only adds the typed registry.

## Screenshots

N/A — no user-visible UI change. This PR adds a typed exported registry only; guardrail UI behavior is deferred to #459, #460, #461, #462, and #463.
