### PR TITLE
feat(ci): auto-queue staging-targeted PRs once they're non-draft

### DIFF
--- a/.github/workflows/auto-queue-staging-prs.yml
+++ b/.github/workflows/auto-queue-staging-prs.yml
@@ -1,0 +1,52 @@
+# Arms auto-merge on any non-draft pull request targeting `staging`.
+#
+# Why: Staging's ruleset requires 0 approving reviews, so a PR can land
+# through the merge queue on green CI alone. But entering the queue
+# still requires someone to click "Enable auto-merge" or run
+# `gh pr merge --auto`. This workflow does that automatically — so the
+# only human action on the staging side is **marking the PR ready**
+# (or opening it ready-for-review). The queue handles everything else.
+#
+# Triggers:
+#   - pull_request: opened (non-draft) or ready_for_review or reopened
+#
+# Skips:
+#   - PRs that are still draft (those aren't ready to merge)
+#   - PRs not targeting `staging` (main-bound PRs go through their own
+#     human-approval path)
+#   - PRs from forks (the GITHUB_TOKEN can't act on fork PR refs the
+#     same way; the maintainer should arm manually after review)
+#
+# Auth: default GITHUB_TOKEN with `pull-requests: write` is enough to
+# enable auto-merge. No PAT needed.
+
+name: Auto-queue staging PRs
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: auto-queue-staging-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  arm:
+    if: >-
+      github.event.pull_request.base.ref == 'staging' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Enable auto-merge for #${{ github.event.pull_request.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --auto


### PR DESCRIPTION
## Summary

Adds `.github/workflows/auto-queue-staging-prs.yml`. It listens for `pull_request: [opened, ready_for_review, reopened]` and — if the PR is non-draft, targets `staging`, and isn't from a fork — calls `gh pr merge --auto`. The merge queue takes it from there.

## Why

Right now the staging flow has one manual step that shouldn't be manual: someone has to click "Enable auto-merge" or run `gh pr merge --auto` to put the PR in the queue. Staging's ruleset already requires 0 approving reviews (test + e2e are the gate), so the human input is purely procedural — the queue would otherwise do the right thing.

After this lands, the staging-side flow becomes:

1. Open a PR against `staging` (ready or draft)
2. Mark it ready (or it was opened ready)
3. The new workflow arms auto-merge
4. Test + e2e run; queue picks it up; squash-merges; `/staging/` deploys
5. `promote-staging.yml` updates the open `staging → main` promotion PR

Only step 2 is human input on the staging side. Step 5's promotion-PR approval is the production gate, and `main` keeps its CODEOWNER + 1 approval requirement — that's where the human review actually happens.

## Out of scope / known limits

- **Fork PRs** are skipped — the default `GITHUB_TOKEN` doesn't reliably enable auto-merge on cross-repository PRs. Maintainers can arm manually after a review pass.
- **Drafts** are skipped (by design). Authors mark ready when they're ready to ship.
- This doesn't touch the main-side flow. PRs against `main` still need explicit human approval per the main ruleset (1 approving CODEOWNER review).

## Test plan

- [ ] After merge, open a no-op PR against `staging` (e.g. typo fix in a comment) — confirm the workflow fires and the PR shows "Auto-merge enabled" / enters the queue.
- [ ] Open a draft against `staging` — confirm the workflow doesn't act on it until you mark ready.
- [ ] Open a PR against `main` — confirm the workflow doesn't act on it at all.

## Screenshots

N/A — workflow YAML only.