### PR TITLE
Render FHIR dates and timestamps in a human-readable form

### DIFF
--- a/.changeset/human-readable-datetimes.md
+++ b/.changeset/human-readable-datetimes.md
@@ -1,0 +1,16 @@
+---
+"@fhir-place/react-fhir": patch
+---
+
+Render FHIR `date` / `dateTime` / `instant` values in a human-readable form.
+
+Adds a `formatDateTime` helper and wires it into the `date`, `dateTime`,
+`instant`, `Period`, `Meta` (lastUpdated) and `Annotation` renderers, so a
+value like `2019-09-07T17:39:34+00:00` shows as `Sep 7, 2019, 5:39 PM` while
+the `<time dateTime>` attribute keeps the precise machine value. Year and
+year-month partials, plus out-of-range values (e.g. `2021-02-31`), fall back
+to the raw string rather than being normalised to a different day.
+
+Also fixes `colorJson` so the JSON pane no longer mangles colons and digits
+inside string values — timestamps were being rewritten from
+`"2021-04-06T03:01:38.604-04:00"` to `"2021-04-06T03: 01: 38.604-04: 00"`.

--- a/apps/demo/e2e/crud.screenshot.spec.ts
+++ b/apps/demo/e2e/crud.screenshot.spec.ts
@@ -52,11 +52,11 @@ test.describe("CRUD flows", () => {
     // Navigated to the detail view of the newly created patient
     await expect(page.getByTestId("resource-view")).toBeVisible();
     // Scope to the rendered ResourceView; the JSON `<details>` block
-    // also includes "1936-08-17" verbatim, which would trip strict-mode
-    // duplicate matching against the formatted `<time>` cell.
+    // also includes "1936-08-17" verbatim, separate from the formatted
+    // `<time>` cell rendered in the structured view.
     const view = page.getByTestId("resource-view");
     await expect(view.getByText("Margaret Hamilton")).toBeVisible();
-    await expect(view.getByText("1936-08-17")).toBeVisible();
+    await expect(view.getByText("Aug 17, 1936")).toBeVisible();
 
     await page.screenshot({
       path: "../../screenshots/07-created-patient.png",

--- a/apps/demo/src/routes/fhir-ui/pages/ResourceDetailPage.test.ts
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceDetailPage.test.ts
@@ -48,6 +48,21 @@ describe("colorJson", () => {
     );
   });
 
+  it("does not mangle colons or digits inside a string value (timestamps)", () => {
+    const line = '    "lastUpdated": "2021-04-06T03:01:38.604-04:00",';
+    const out = colorJson(line);
+    // The timestamp must survive verbatim — no stray "': '" inserted after
+    // the inner colons by the number/boolean colouriser.
+    expect(out).toContain("2021-04-06T03:01:38.604-04:00");
+    expect(out).not.toContain("T03: 01");
+    // Still styled: the key is wrapped, and the value is wrapped as a string
+    // (not split into numeric chunks).
+    expect(out).toContain('style="color:var(--accent-text)">"lastUpdated"');
+    expect(out).toContain(
+      'style="color:var(--success)">"2021-04-06T03:01:38.604-04:00"',
+    );
+  });
+
   it("leaves safe lines untouched aside from token spans", () => {
     const out = colorJson('{');
     // Bare punctuation has no JSON tokens to wrap; it should round-trip.

--- a/apps/demo/src/routes/fhir-ui/pages/ResourceDetailPage.tsx
+++ b/apps/demo/src/routes/fhir-ui/pages/ResourceDetailPage.tsx
@@ -3,6 +3,7 @@ import {
   FhirError,
   HintedDetail,
   ResourceView,
+  formatDateTime,
   getLayoutHint,
   useDeleteResource,
   useResource,
@@ -36,24 +37,35 @@ const HTML_ESCAPES: Record<string, string> = {
 };
 const escapeHtml = (s: string): string => s.replace(/[&<>]/g, (c) => HTML_ESCAPES[c]!);
 
+// Colour bare scalars (numbers, booleans, null) in a *non-string* segment.
+// Never run this over the inside of a JSON string literal — FHIR timestamps
+// like "2021-04-06T03:01:38.604-04:00" carry colons and digits that a naive
+// number/colon pass would otherwise mangle into "2021-04-06T03: 01: 38…".
+function colorJsonScalars(segment: string): string {
+  return segment
+    .replace(/(-?\d+(?:\.\d+)?)/g, `<span style="color:var(--accent)">$1</span>`)
+    .replace(/\b(true|false|null)\b/g, `<span style="color:var(--accent)">$1</span>`);
+}
+
+const JSON_STRING_RE = /"(?:[^"\\]|\\.)*"/g;
+
 export function colorJson(line: string): string {
-  return escapeHtml(line)
-    .replace(
-      /("(?:[^"\\]|\\.)*")(\s*:)/g,
-      `<span style="color:var(--accent-text)">$1</span>$2`,
-    )
-    .replace(
-      /:\s*("(?:[^"\\]|\\.)*")/g,
-      `: <span style="color:var(--success)">$1</span>`,
-    )
-    .replace(
-      /:\s*(true|false|null)/g,
-      `: <span style="color:var(--accent)">$1</span>`,
-    )
-    .replace(
-      /:\s*(-?\d+(?:\.\d+)?)/g,
-      `: <span style="color:var(--accent)">$1</span>`,
-    );
+  const escaped = escapeHtml(line);
+  let out = "";
+  let last = 0;
+  JSON_STRING_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = JSON_STRING_RE.exec(escaped)) !== null) {
+    out += colorJsonScalars(escaped.slice(last, m.index));
+    const str = m[0];
+    const tail = escaped.slice(m.index + str.length);
+    const isKey = /^\s*:/.test(tail);
+    const color = isKey ? "accent-text" : "success";
+    out += `<span style="color:var(--${color})">${str}</span>`;
+    last = m.index + str.length;
+  }
+  out += colorJsonScalars(escaped.slice(last));
+  return out;
 }
 
 export function ResourceDetailPage() {
@@ -319,7 +331,7 @@ export function ResourceDetailPage() {
               >
                 {(data as Resource & { meta?: { versionId?: string; lastUpdated?: string } })
                   .meta?.lastUpdated
-                  ? `Updated ${(data as Resource & { meta?: { lastUpdated?: string } }).meta?.lastUpdated}`
+                  ? `Updated ${formatDateTime((data as Resource & { meta?: { lastUpdated?: string } }).meta?.lastUpdated)}`
                   : null}
               </div>
             </div>

--- a/packages/react-fhir/src/components/ResourceTable.test.tsx
+++ b/packages/react-fhir/src/components/ResourceTable.test.tsx
@@ -438,7 +438,7 @@ describe("ResourceTable", () => {
       );
       const row = screen.getByTestId("resource-row");
       // PeriodRenderer shows start and end
-      expect(within(row).getByText(/2023-03-01/)).toBeInTheDocument();
+      expect(within(row).getByText("Mar 1, 2023")).toBeInTheDocument();
       expect(within(row).queryByText(/"start":/)).not.toBeInTheDocument();
     });
 
@@ -488,7 +488,7 @@ describe("ResourceTable", () => {
         { wrapper: wrap() },
       );
       const row = screen.getByTestId("resource-row");
-      expect(within(row).getByText(/2022-02-01/)).toBeInTheDocument();
+      expect(within(row).getByText("Feb 1, 2022")).toBeInTheDocument();
       expect(within(row).queryByText(/"start":/)).not.toBeInTheDocument();
     });
 
@@ -610,7 +610,7 @@ describe("ResourceTable", () => {
       expect(within(card).getByText("Gender")).toBeInTheDocument();
       expect(within(card).getByText("female")).toBeInTheDocument();
       expect(within(card).getByText("Birth Date")).toBeInTheDocument();
-      expect(within(card).getByText("1815-12-10")).toBeInTheDocument();
+      expect(within(card).getByText("Dec 10, 1815")).toBeInTheDocument();
     });
 
     it("card rows are keyboard-clickable when onRowClick is set", async () => {

--- a/packages/react-fhir/src/components/ResourceView.test.tsx
+++ b/packages/react-fhir/src/components/ResourceView.test.tsx
@@ -50,7 +50,7 @@ describe("ResourceView", () => {
     wrap(<ResourceView resource={patient} structureDefinition={PatientStructureDefinition} />);
     expect(screen.getByText("true")).toBeInTheDocument(); // active
     expect(screen.getByText("female")).toBeInTheDocument(); // gender (code)
-    expect(screen.getByText("1815-12-10")).toBeInTheDocument(); // birthDate
+    expect(screen.getByText("Dec 10, 1815")).toBeInTheDocument(); // birthDate
     // deceasedDateTime via choice type
     expect(screen.getByText(/1852/)).toBeInTheDocument();
   });
@@ -87,7 +87,7 @@ describe("ResourceView", () => {
       />,
     );
     expect(screen.getByText("female")).toBeInTheDocument();
-    expect(screen.getByText("1815-12-10")).toBeInTheDocument();
+    expect(screen.getByText("Dec 10, 1815")).toBeInTheDocument();
     // `name` is not in visibleFields, so the rendered HumanName should be hidden.
     expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument();
   });

--- a/packages/react-fhir/src/components/renderers.test.tsx
+++ b/packages/react-fhir/src/components/renderers.test.tsx
@@ -13,6 +13,7 @@ import {
   defaultTypeRenderers,
   preferredCoding,
 } from "./renderers.js";
+import { formatDateTime } from "../structure/format.js";
 
 // CodeChip uses useCodeLookup → useQuery, so every renderer that may emit a
 // chip needs to render inside a QueryClientProvider. Tests don't configure a
@@ -346,7 +347,10 @@ describe("Meta renderer", () => {
     const summary = container.querySelector("summary");
     expect(summary).not.toBeNull();
     expect(summary!.textContent).toContain("v1");
-    expect(summary!.textContent).toContain("2026-02-10T17:48:37.700+00:00");
+    expect(summary!.textContent).toContain(
+      formatDateTime("2026-02-10T17:48:37.700+00:00"),
+    );
+    expect(summary!.textContent).not.toContain("2026-02-10T17:48:37.700+00:00");
     expect(summary!.textContent).toContain("#wiWDxr1Jk1z1zMIZ");
   });
 

--- a/packages/react-fhir/src/components/renderers.tsx
+++ b/packages/react-fhir/src/components/renderers.tsx
@@ -20,6 +20,7 @@ import type { ReactNode } from "react";
 import { Fragment } from "react";
 import {
   formatAddress,
+  formatDateTime,
   formatHumanName,
   formatReferenceLabel,
 } from "../structure/format.js";
@@ -55,18 +56,13 @@ const Primitive: FhirTypeRenderer = (value) => <span>{String(value)}</span>;
 const Boolean_: FhirTypeRenderer = (value) => (
   <span className="font-mono">{value ? "true" : "false"}</span>
 );
-const Date_: FhirTypeRenderer = (value) => (
-  <time dateTime={String(value)}>{String(value)}</time>
-);
+const Date_: FhirTypeRenderer = (value) => {
+  const s = String(value);
+  return <time dateTime={s}>{formatDateTime(s)}</time>;
+};
 const DateTime_: FhirTypeRenderer = (value) => {
   const s = String(value);
-  let formatted = s;
-  try {
-    formatted = new Date(s).toLocaleString();
-  } catch {
-    // keep raw
-  }
-  return <time dateTime={s}>{formatted}</time>;
+  return <time dateTime={s}>{formatDateTime(s)}</time>;
 };
 const Code_: FhirTypeRenderer = (value) => (
   <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">{String(value)}</code>
@@ -294,9 +290,9 @@ const PeriodRenderer: FhirTypeRenderer = (value) => {
   const p = value as Period;
   return (
     <span>
-      <time>{p.start ?? "…"}</time>
+      {p.start ? <time dateTime={p.start}>{formatDateTime(p.start)}</time> : <span>…</span>}
       <span className="mx-1 text-slate-400">→</span>
-      <time>{p.end ?? "…"}</time>
+      {p.end ? <time dateTime={p.end}>{formatDateTime(p.end)}</time> : <span>…</span>}
     </span>
   );
 };
@@ -361,7 +357,7 @@ const MetaRenderer: FhirTypeRenderer = (value, ctx) => {
   const m = value as Meta;
   const summaryParts = [
     m.versionId && `v${m.versionId}`,
-    m.lastUpdated,
+    m.lastUpdated && formatDateTime(m.lastUpdated),
     m.source,
   ].filter(Boolean);
   const fields: { label: string; node: ReactNode }[] = [];
@@ -371,7 +367,7 @@ const MetaRenderer: FhirTypeRenderer = (value, ctx) => {
   if (m.lastUpdated) {
     fields.push({
       label: "Last Updated",
-      node: <time dateTime={m.lastUpdated}>{m.lastUpdated}</time>,
+      node: <time dateTime={m.lastUpdated}>{formatDateTime(m.lastUpdated)}</time>,
     });
   }
   if (m.source) {
@@ -445,7 +441,11 @@ const AnnotationRenderer: FhirTypeRenderer = (value) => {
         <span className="text-slate-400">{a.authorString}: </span>
       )}
       <span>{a.text}</span>
-      {a.time && <span className="ml-2 text-slate-400">({a.time})</span>}
+      {a.time && (
+        <span className="ml-2 text-slate-400">
+          (<time dateTime={a.time}>{formatDateTime(a.time)}</time>)
+        </span>
+      )}
     </div>
   );
 };

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -157,6 +157,15 @@ describe("formatDateTime", () => {
     );
   });
 
+  it("does not remap low years (0001-0099) onto the 20th century", () => {
+    // `new Date(yy, …)` would map year 99 → 1999; the helper must not.
+    const low = formatDateTime("0099-12-31");
+    expect(low).not.toBe("0099-12-31");
+    expect(low).not.toMatch(/199\d/);
+    expect(low).toMatch(/\b99\b/);
+    expect(formatDateTime("0001-01-01")).not.toBe("0001-01-01");
+  });
+
   it("accepts real-world half- and quarter-hour offsets", () => {
     // India (+05:30), Nepal (+05:45), Chatham Islands (+12:45), and the
     // boundary +14:00 are all valid FHIR offsets.

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -143,6 +143,28 @@ describe("formatDateTime", () => {
     expect(formatDateTime("2021-02-31T00:00:00Z")).toBe("2021-02-31T00:00:00Z");
     expect(formatDateTime("2021-04-06T25:01:00Z")).toBe("2021-04-06T25:01:00Z");
   });
+
+  it("rejects out-of-range timezone offsets", () => {
+    // Hour 14 only valid with :00 minutes; +14:30 is not a real FHIR offset.
+    expect(formatDateTime("2021-01-01T00:00:00+14:30")).toBe(
+      "2021-01-01T00:00:00+14:30",
+    );
+    expect(formatDateTime("2021-01-01T00:00:00+15:00")).toBe(
+      "2021-01-01T00:00:00+15:00",
+    );
+    expect(formatDateTime("2021-01-01T00:00:00+05:75")).toBe(
+      "2021-01-01T00:00:00+05:75",
+    );
+  });
+
+  it("accepts real-world half- and quarter-hour offsets", () => {
+    // India (+05:30), Nepal (+05:45), Chatham Islands (+12:45), and the
+    // boundary +14:00 are all valid FHIR offsets.
+    for (const tz of ["+05:30", "+05:45", "+12:45", "+14:00", "-09:30"]) {
+      const out = formatDateTime(`2021-01-01T00:00:00${tz}`);
+      expect(out).not.toBe(`2021-01-01T00:00:00${tz}`);
+    }
+  });
 });
 
 describe("formatPeriod", () => {

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -144,6 +144,13 @@ describe("formatDateTime", () => {
     expect(formatDateTime("2021-04-06T25:01:00Z")).toBe("2021-04-06T25:01:00Z");
   });
 
+  it("requires seconds and a timezone offset on FHIR date-times", () => {
+    // Per FHIR R4: when a time is present, seconds + tz are required.
+    expect(formatDateTime("2021-01-01T09:30")).toBe("2021-01-01T09:30");
+    expect(formatDateTime("2021-01-01T09:30:00")).toBe("2021-01-01T09:30:00");
+    expect(formatDateTime("2021-01-01T09:30Z")).toBe("2021-01-01T09:30Z");
+  });
+
   it("rejects out-of-range timezone offsets", () => {
     // Hour 14 only valid with :00 minutes; +14:30 is not a real FHIR offset.
     expect(formatDateTime("2021-01-01T00:00:00+14:30")).toBe(

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -157,6 +157,12 @@ describe("formatDateTime", () => {
     );
   });
 
+  it("rejects year 0000 and other out-of-range years", () => {
+    // FHIR date/dateTime years are 0001..9999.
+    expect(formatDateTime("0000-01-01")).toBe("0000-01-01");
+    expect(formatDateTime("0000-01-01T00:00:00Z")).toBe("0000-01-01T00:00:00Z");
+  });
+
   it("does not remap low years (0001-0099) onto the 20th century", () => {
     // `new Date(yy, …)` would map year 99 → 1999; the helper must not.
     const low = formatDateTime("0099-12-31");

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -138,6 +138,11 @@ describe("formatDateTime", () => {
     expect(formatDateTime("2021-02-31")).toBe("2021-02-31");
     expect(formatDateTime("2021-13-01")).toBe("2021-13-01");
   });
+
+  it("does not normalise an out-of-range date-time", () => {
+    expect(formatDateTime("2021-02-31T00:00:00Z")).toBe("2021-02-31T00:00:00Z");
+    expect(formatDateTime("2021-04-06T25:01:00Z")).toBe("2021-04-06T25:01:00Z");
+  });
 });
 
 describe("formatPeriod", () => {

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -133,6 +133,11 @@ describe("formatDateTime", () => {
     expect(formatDateTime(undefined)).toBe("");
     expect(formatDateTime("")).toBe("");
   });
+
+  it("does not normalise an out-of-range full date", () => {
+    expect(formatDateTime("2021-02-31")).toBe("2021-02-31");
+    expect(formatDateTime("2021-13-01")).toBe("2021-13-01");
+  });
 });
 
 describe("formatPeriod", () => {

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -3,6 +3,7 @@ import {
   formatAddress,
   formatCodeableConcept,
   formatCoding,
+  formatDateTime,
   formatHumanName,
   formatPeriod,
   formatQuantity,
@@ -110,12 +111,36 @@ describe("formatQuantity", () => {
   });
 });
 
+describe("formatDateTime", () => {
+  it("returns year and year-month partial dates verbatim", () => {
+    expect(formatDateTime("2019")).toBe("2019");
+    expect(formatDateTime("2019-09")).toBe("2019-09");
+  });
+
+  it("spells out a full calendar date without inventing a time", () => {
+    expect(formatDateTime("2019-09-07")).toBe("Sep 7, 2019");
+  });
+
+  it("renders a date-time with a time component", () => {
+    const out = formatDateTime("2019-09-07T17:39:34+00:00");
+    expect(out).not.toBe("2019-09-07T17:39:34+00:00");
+    expect(out).toContain("2019");
+    expect(out).toMatch(/\d:\d{2}/);
+  });
+
+  it("falls back to the raw string when unparseable", () => {
+    expect(formatDateTime("not-a-date")).toBe("not-a-date");
+    expect(formatDateTime(undefined)).toBe("");
+    expect(formatDateTime("")).toBe("");
+  });
+});
+
 describe("formatPeriod", () => {
   it("renders start → end with ellipsis fallbacks", () => {
     expect(formatPeriod({ start: "2024-01-01", end: "2024-12-31" })).toBe(
-      "2024-01-01 → 2024-12-31",
+      "Jan 1, 2024 → Dec 31, 2024",
     );
-    expect(formatPeriod({ start: "2024-01-01" })).toBe("2024-01-01 → …");
+    expect(formatPeriod({ start: "2024-01-01" })).toBe("Jan 1, 2024 → …");
     expect(formatPeriod({})).toBe("… → …");
     expect(formatPeriod(undefined)).toBe("");
   });

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -73,10 +73,12 @@ function localDate(y: number, mo: number, day: number): Date {
   return d;
 }
 
-// True when `Y-M-D` denotes a real calendar day. `new Date` rolls overflow
-// parts forward (2021-02-31 → Mar 3), so we reject anything that doesn't
-// round-trip rather than silently render a different day.
+// True when `Y-M-D` denotes a real calendar day inside the FHIR-permitted
+// year range (0001-9999). `new Date` rolls overflow parts forward
+// (2021-02-31 → Mar 3) and accepts year 0, so reject anything that doesn't
+// round-trip or that falls outside the spec range.
 function isRealCalendarDay(y: number, mo: number, day: number): boolean {
+  if (y < 1 || y > 9999) return false;
   const d = localDate(y, mo, day);
   return d.getFullYear() === y && d.getMonth() === mo - 1 && d.getDate() === day;
 }

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -75,8 +75,10 @@ function isRealCalendarDay(y: number, mo: number, day: number): boolean {
 
 // FHIR `dateTime` / `instant` with a time component:
 //   YYYY-MM-DDThh:mm[:ss[.sss]][Z|±hh:mm]
+// Timezone offset matches the FHIR R4 spec: hours 00-13 with minutes 00-59,
+// or exactly 14:00 (https://hl7.org/fhir/R4/datatypes.html#dateTime).
 const FHIR_DATE_TIME_RE =
-  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2})?$/;
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?(?:Z|[+-](?:(?:0\d|1[0-3]):[0-5]\d|14:00))?$/;
 
 /**
  * Human-readable rendering of a FHIR `date` / `dateTime` / `instant` value.

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -79,14 +79,20 @@ export function formatDateTime(value: string | undefined): string {
   if (!value) return "";
   if (/^\d{4}(-\d{2})?$/.test(value)) return value;
   if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    const d = new Date(`${value}T00:00:00`);
-    return Number.isNaN(d.getTime())
-      ? value
-      : d.toLocaleDateString(undefined, {
+    const [y, mo, day] = value.split("-").map(Number) as [number, number, number];
+    const d = new Date(y, mo - 1, day);
+    // `new Date` silently rolls over out-of-range parts (2021-02-31 → Mar 3),
+    // so a malformed date would otherwise render as a different day. Only
+    // format when the components round-trip; otherwise keep the raw string.
+    const roundTrips =
+      d.getFullYear() === y && d.getMonth() === mo - 1 && d.getDate() === day;
+    return roundTrips
+      ? d.toLocaleDateString(undefined, {
           year: "numeric",
           month: "short",
           day: "numeric",
-        });
+        })
+      : value;
   }
   const d = new Date(value);
   return Number.isNaN(d.getTime())

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -65,11 +65,19 @@ export function formatQuantity(q: Quantity | undefined): string {
   return `${comparator}${num}${unit ? ` ${unit}` : ""}`.trim();
 }
 
+// Build a local-time Date for the given Y-M-D without the `new Date(yy, …)`
+// 0–99 → 1900–1999 century remap (FHIR permits years 0001 through 9999).
+function localDate(y: number, mo: number, day: number): Date {
+  const d = new Date(2000, 0, 1);
+  d.setFullYear(y, mo - 1, day);
+  return d;
+}
+
 // True when `Y-M-D` denotes a real calendar day. `new Date` rolls overflow
 // parts forward (2021-02-31 → Mar 3), so we reject anything that doesn't
 // round-trip rather than silently render a different day.
 function isRealCalendarDay(y: number, mo: number, day: number): boolean {
-  const d = new Date(y, mo - 1, day);
+  const d = localDate(y, mo, day);
   return d.getFullYear() === y && d.getMonth() === mo - 1 && d.getDate() === day;
 }
 
@@ -97,7 +105,7 @@ export function formatDateTime(value: string | undefined): string {
   if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
     const [y, mo, day] = value.split("-").map(Number) as [number, number, number];
     if (!isRealCalendarDay(y, mo, day)) return value;
-    return new Date(y, mo - 1, day).toLocaleDateString(undefined, {
+    return localDate(y, mo, day).toLocaleDateString(undefined, {
       year: "numeric",
       month: "short",
       day: "numeric",

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -65,6 +65,19 @@ export function formatQuantity(q: Quantity | undefined): string {
   return `${comparator}${num}${unit ? ` ${unit}` : ""}`.trim();
 }
 
+// True when `Y-M-D` denotes a real calendar day. `new Date` rolls overflow
+// parts forward (2021-02-31 → Mar 3), so we reject anything that doesn't
+// round-trip rather than silently render a different day.
+function isRealCalendarDay(y: number, mo: number, day: number): boolean {
+  const d = new Date(y, mo - 1, day);
+  return d.getFullYear() === y && d.getMonth() === mo - 1 && d.getDate() === day;
+}
+
+// FHIR `dateTime` / `instant` with a time component:
+//   YYYY-MM-DDThh:mm[:ss[.sss]][Z|±hh:mm]
+const FHIR_DATE_TIME_RE =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2})?$/;
+
 /**
  * Human-readable rendering of a FHIR `date` / `dateTime` / `instant` value.
  *
@@ -73,26 +86,33 @@ export function formatQuantity(q: Quantity | undefined): string {
  * - `YYYY-MM-DD` becomes e.g. `Sep 7, 2019`.
  * - Values with a time component become e.g. `Sep 7, 2019, 5:39 PM`, rendered
  *   in the runtime's local time zone.
- * - Anything unparseable falls back to the original string.
+ * - Malformed or out-of-range values (e.g. `2021-02-31`) fall back to the
+ *   original string rather than being normalised to a different instant.
  */
 export function formatDateTime(value: string | undefined): string {
   if (!value) return "";
   if (/^\d{4}(-\d{2})?$/.test(value)) return value;
   if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
     const [y, mo, day] = value.split("-").map(Number) as [number, number, number];
-    const d = new Date(y, mo - 1, day);
-    // `new Date` silently rolls over out-of-range parts (2021-02-31 → Mar 3),
-    // so a malformed date would otherwise render as a different day. Only
-    // format when the components round-trip; otherwise keep the raw string.
-    const roundTrips =
-      d.getFullYear() === y && d.getMonth() === mo - 1 && d.getDate() === day;
-    return roundTrips
-      ? d.toLocaleDateString(undefined, {
-          year: "numeric",
-          month: "short",
-          day: "numeric",
-        })
-      : value;
+    if (!isRealCalendarDay(y, mo, day)) return value;
+    return new Date(y, mo - 1, day).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+  const m = FHIR_DATE_TIME_RE.exec(value);
+  if (!m) return value;
+  const [, ys, mos, ds, hs, mins, ss] = m as unknown as string[];
+  const y = Number(ys);
+  const mo = Number(mos);
+  const day = Number(ds);
+  const hour = Number(hs);
+  const minute = Number(mins);
+  const sec = ss === undefined ? 0 : Number(ss);
+  // `new Date` would roll these forward too; validate before trusting it.
+  if (!isRealCalendarDay(y, mo, day) || hour > 23 || minute > 59 || sec > 60) {
+    return value;
   }
   const d = new Date(value);
   return Number.isNaN(d.getTime())

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -83,12 +83,13 @@ function isRealCalendarDay(y: number, mo: number, day: number): boolean {
   return d.getFullYear() === y && d.getMonth() === mo - 1 && d.getDate() === day;
 }
 
-// FHIR `dateTime` / `instant` with a time component:
-//   YYYY-MM-DDThh:mm[:ss[.sss]][Z|±hh:mm]
-// Timezone offset matches the FHIR R4 spec: hours 00-13 with minutes 00-59,
-// or exactly 14:00 (https://hl7.org/fhir/R4/datatypes.html#dateTime).
+// FHIR `dateTime` / `instant` with a time component, per FHIR R4
+// (https://hl7.org/fhir/R4/datatypes.html#dateTime):
+//   YYYY-MM-DDThh:mm:ss[.sss](Z|±hh:mm)
+// Seconds and timezone are required when a time is present; the offset is
+// hours 00-13 with minutes 00-59, or exactly 14:00.
 const FHIR_DATE_TIME_RE =
-  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?(?:Z|[+-](?:(?:0\d|1[0-3]):[0-5]\d|14:00))?$/;
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-](?:(?:0\d|1[0-3]):[0-5]\d|14:00))$/;
 
 /**
  * Human-readable rendering of a FHIR `date` / `dateTime` / `instant` value.
@@ -121,7 +122,7 @@ export function formatDateTime(value: string | undefined): string {
   const day = Number(ds);
   const hour = Number(hs);
   const minute = Number(mins);
-  const sec = ss === undefined ? 0 : Number(ss);
+  const sec = Number(ss);
   // `new Date` would roll these forward too; validate before trusting it.
   if (!isRealCalendarDay(y, mo, day) || hour > 23 || minute > 59 || sec > 60) {
     return value;

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -65,10 +65,45 @@ export function formatQuantity(q: Quantity | undefined): string {
   return `${comparator}${num}${unit ? ` ${unit}` : ""}`.trim();
 }
 
+/**
+ * Human-readable rendering of a FHIR `date` / `dateTime` / `instant` value.
+ *
+ * - Year and year-month partial dates are returned verbatim — there's no day
+ *   to spell out, and `new Date()` would invent one.
+ * - `YYYY-MM-DD` becomes e.g. `Sep 7, 2019`.
+ * - Values with a time component become e.g. `Sep 7, 2019, 5:39 PM`, rendered
+ *   in the runtime's local time zone.
+ * - Anything unparseable falls back to the original string.
+ */
+export function formatDateTime(value: string | undefined): string {
+  if (!value) return "";
+  if (/^\d{4}(-\d{2})?$/.test(value)) return value;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    const d = new Date(`${value}T00:00:00`);
+    return Number.isNaN(d.getTime())
+      ? value
+      : d.toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+        });
+  }
+  const d = new Date(value);
+  return Number.isNaN(d.getTime())
+    ? value
+    : d.toLocaleString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      });
+}
+
 export function formatPeriod(p: Period | undefined): string {
   if (!p) return "";
-  const start = p.start ?? "…";
-  const end = p.end ?? "…";
+  const start = p.start ? formatDateTime(p.start) : "…";
+  const end = p.end ? formatDateTime(p.end) : "…";
   return `${start} → ${end}`;
 }
 


### PR DESCRIPTION
## Summary

- Added a `formatDateTime` helper (`packages/react-fhir/src/structure/format.ts`) that renders FHIR `date` / `dateTime` / `instant` values as `Sep 7, 2019` or `Sep 7, 2019, 5:39 PM` (local time zone). Year / year-month partials and unparseable values pass through unchanged so we never invent a day.
- Wired it into the `date`, `dateTime`/`instant`, `Period`, `Meta` (lastUpdated, in both the summary line and the expandable row) and `Annotation` renderers, and into the resource-detail "Updated …" subtitle. `formatPeriod` now renders both ends through the same helper, so `ReferencePicker` labels get the friendly form too.
- Fixed a JSON-pane bug in `colorJson`: the number/boolean colouriser was running over the inside of string values, so timestamps like `"2021-04-06T03:01:38.604-04:00"` were being rewritten to `"2021-04-06T03: 01: 38.604-04: 00"`. `colorJson` now tokenises string literals first and only colours scalars in non-string segments. (Visible in the screenshot the request came from.)
- `formatDateTime` also rejects malformed/out-of-range inputs per FHIR R4: out-of-range months/days (`2021-02-31`), hours/minutes/seconds, years outside 0001–9999 (so JS's `new Date(yy)` century-remap and bare `year 0` both pass through verbatim), and timezone offsets outside `(0\d|1[0-3]):[0-5]\d` or exactly `14:00`. Seconds and offset are required on date-times.
- Updated existing renderer/table/view tests for the new output; added regression tests for `formatDateTime` (round-trip, year range, tz grammar, required seconds/tz), the updated `formatPeriod`, the `Meta` summary, and the `colorJson` timestamp case.

## Test plan

- [x] `pnpm --filter @fhir-place/react-fhir test` — 456 passing
- [x] `pnpm --filter @fhir-place/demo test:run` — 84 passing
- [x] `pnpm --filter @fhir-place/demo typecheck` and `build` — clean
- [ ] e2e screenshot suite — **could not run in this environment**: Playwright browser download is blocked (403 from the apt mirrors). The text-level e2e spec (`crud.screenshot.spec.ts`) was updated to expect `Aug 17, 1936`; the PNG baselines under `apps/demo/e2e/__screenshots__/` and `screenshots/` still need a follow-up `playwright test --update-snapshots` run + human review of the diff.

## UAT on live staging

Walkthrough for the reviewer once this lands on `/staging/`. Use the HAPI Public test server (`/fhir-ui/settings` → Use). Pick a Patient with recent activity (e.g. one returned by the default list query).

1. **Resource detail subtitle.** Open any Patient detail page. The "Updated …" line under the heading reads e.g. `Updated Feb 9, 2026, 6:37 PM` (local zone), not raw ISO `2026-02-09T18:37:16.662+00:00`. ✅ pass = friendly form; ❌ fail = raw ISO.
2. **`date` field (Patient.birthDate).** The `Date of birth` row renders e.g. `Jan 2, 1980`. ✅ pass = `Mon D, YYYY`; ❌ fail = `1980-01-02`. Note: HAPI's `text.div` narrative renders `02 January 1980` separately — that's not from this PR's renderer.
3. **`dateTime` table cells (Encounter list, "Started" column).** Values render e.g. `Sep 1, 2025, 8:49 AM`. ❌ fail = raw `2025-09-01T08:49:54.682000Z`.
4. **Period rendering.** Find a resource with a `Period` (Encounter detail "Period", AllergyIntolerance "Onset Period" if present). Both ends use the friendly form; missing ends show `…`.
5. **JSON panel does not mangle timestamps.** On any Patient detail, open the JSON view and find `lastUpdated`. ✅ pass: `"2026-02-09T18:37:16.662+00:00"` renders verbatim with the colon-after-`T` and offset intact. ❌ fail: `"2026-02-09T18: 37: 16.662+00: 00"` (the bug this PR fixes).
6. **`Meta` summary (collapsed).** On any detail page, the `Meta` row's collapsed summary shows `v<N> · Feb 9, 2026, 6:37 PM`, not the raw timestamp.
7. **Partial dates pass through.** If you can find a resource with `birthDate: "1980"` or `birthDate: "1980-05"` (rare on HAPI; can be constructed locally), it renders verbatim — we don't invent a day.
8. **Malformed values fall back to raw.** Construct a resource locally with `effectiveDateTime: "2021-02-31"` or `"2021-01-01T09:30"` (no seconds/tz); these render as the raw string rather than a silently shifted day.

## Screenshots

N/A in this PR — screenshot capture/regeneration is blocked here (no browser binaries). Follow-up needed to refresh the e2e baselines and attach before/after frames of the resource detail page. The "smoking gun" the UAT routine flagged on staging (line 6 `lastUpdated` mangled by `colorJson`) is exactly the regression this PR fixes.

## Risks / follow-ups

- Time-zone-dependent rendering: date-only values are stable (`Sep 7, 2019`), but values with a time component render in the runtime's local zone. Tests assert loosely on those.
- e2e screenshot baselines need regeneration (see test plan).

https://claude.ai/code/session_012WqGBZhFq9cUWrNWcGHzXH

---
_Generated by [Claude Code](https://claude.ai/code/session_012WqGBZhFq9cUWrNWcGHzXH)_