### PR TITLE
Human-readable Dosage and Timing renderers

### DIFF
--- a/packages/react-fhir/src/components/renderers.test.tsx
+++ b/packages/react-fhir/src/components/renderers.test.tsx
@@ -447,6 +447,19 @@ describe("Dosage renderer", () => {
     expect(container.textContent).toContain("Route");
   });
 
+  it("labels dose/rate rows with their doseAndRate.type", () => {
+    const d: Dosage = {
+      text: "infusion",
+      doseAndRate: [
+        { type: { text: "ordered" }, doseQuantity: { value: 500, unit: "mg" } },
+        { type: { text: "calculated" }, doseQuantity: { value: 480, unit: "mg" } },
+      ],
+    };
+    const { container } = render(<>{renderer(d, ctx)}</>);
+    expect(container.textContent).toContain("Dose (ordered)");
+    expect(container.textContent).toContain("Dose (calculated)");
+  });
+
   it("surfaces bounds variants and the lifetime max dose", () => {
     const duration: Dosage = {
       text: "course",

--- a/packages/react-fhir/src/components/renderers.test.tsx
+++ b/packages/react-fhir/src/components/renderers.test.tsx
@@ -447,6 +447,28 @@ describe("Dosage renderer", () => {
     expect(container.textContent).toContain("Route");
   });
 
+  it("surfaces bounds variants and the lifetime max dose", () => {
+    const duration: Dosage = {
+      text: "course",
+      timing: { repeat: { boundsDuration: { value: 10, unit: "days" } } },
+      maxDosePerLifetime: { value: 4, unit: "g" },
+    };
+    const a = render(<>{renderer(duration, ctx)}</>);
+    expect(a.container.textContent).toContain("Duration");
+    expect(a.container.textContent).toContain("10");
+    expect(a.container.textContent).toContain("Max / lifetime");
+    expect(a.container.textContent).toContain("4");
+
+    const range: Dosage = {
+      text: "course",
+      timing: { repeat: { boundsRange: { low: { value: 7, unit: "d" }, high: { value: 14, unit: "d" } } } },
+    };
+    const b = render(<>{renderer(range, ctx)}</>);
+    expect(b.container.textContent).toContain("Duration");
+    expect(b.container.textContent).toContain("7");
+    expect(b.container.textContent).toContain("14");
+  });
+
   it("renders an em-dash for an empty dosage", () => {
     const { container } = render(<>{renderer({} as Dosage, ctx)}</>);
     expect(container.textContent).toBe("—");

--- a/packages/react-fhir/src/components/renderers.test.tsx
+++ b/packages/react-fhir/src/components/renderers.test.tsx
@@ -1,4 +1,4 @@
-import type { CodeableConcept, Meta } from "fhir/r4";
+import type { CodeableConcept, Dosage, Meta } from "fhir/r4";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   fireEvent,
@@ -406,5 +406,66 @@ describe("DEFAULT_CODING_PRIORITY", () => {
     expect(paths).toContain("MedicationRequest.medicationCodeableConcept");
     expect(paths).toContain("AllergyIntolerance.code");
     expect(paths).toContain("Immunization.vaccineCode");
+  });
+});
+
+describe("Dosage renderer", () => {
+  const renderer = defaultTypeRenderers.Dosage!;
+  const ctx = { path: "MedicationStatement.dosage", typeCode: "Dosage" };
+
+  it("shows the authored text as the headline and a structured breakdown", () => {
+    const d: Dosage = {
+      text: "1 tab twice daily",
+      timing: { repeat: { frequency: 2, period: 1, periodUnit: "d" } },
+      doseAndRate: [
+        {
+          doseQuantity: {
+            value: 1,
+            unit: "tablet",
+            system: "http://snomed.info/sct",
+            code: "428673006",
+          },
+        },
+      ],
+    };
+    const { container } = render(<>{renderer(d, ctx)}</>);
+    expect(container.textContent).toContain("1 tab twice daily");
+    expect(container.textContent).toContain("Dose");
+    expect(container.textContent).toContain("1 tablet");
+    expect(container.textContent).toContain("Schedule");
+    expect(container.textContent).toContain("2 times per day");
+  });
+
+  it("synthesises a headline when no text is present", () => {
+    const d: Dosage = {
+      route: { text: "oral" },
+      doseAndRate: [{ doseQuantity: { value: 400, unit: "mg" } }],
+      asNeededBoolean: true,
+    };
+    const { container } = render(<>{renderer(d, ctx)}</>);
+    expect(container.textContent).toContain("400 mg oral, as needed");
+    expect(container.textContent).toContain("Route");
+  });
+
+  it("renders an em-dash for an empty dosage", () => {
+    const { container } = render(<>{renderer({} as Dosage, ctx)}</>);
+    expect(container.textContent).toBe("—");
+  });
+});
+
+describe("Timing renderer", () => {
+  const renderer = defaultTypeRenderers.Timing!;
+  const ctx = { path: "ServiceRequest.occurrenceTiming", typeCode: "Timing" };
+
+  it("renders a plain-English summary", () => {
+    const { container } = render(
+      <>{renderer({ repeat: { frequency: 1, period: 8, periodUnit: "h" } }, ctx)}</>,
+    );
+    expect(container.textContent).toBe("once every 8 hours");
+  });
+
+  it("renders an em-dash when empty", () => {
+    const { container } = render(<>{renderer({}, ctx)}</>);
+    expect(container.textContent).toBe("—");
   });
 });

--- a/packages/react-fhir/src/components/renderers.test.tsx
+++ b/packages/react-fhir/src/components/renderers.test.tsx
@@ -447,6 +447,14 @@ describe("Dosage renderer", () => {
     expect(container.textContent).toContain("Route");
   });
 
+  it("shows the dosage step number from Dosage.sequence", () => {
+    const { container } = render(
+      <>{renderer({ sequence: 2, text: "then..." } as Dosage, ctx)}</>,
+    );
+    expect(container.textContent).toContain("Step");
+    expect(container.textContent).toContain("2");
+  });
+
   it("labels dose/rate rows with their doseAndRate.type", () => {
     const d: Dosage = {
       text: "infusion",

--- a/packages/react-fhir/src/components/renderers.tsx
+++ b/packages/react-fhir/src/components/renderers.tsx
@@ -467,6 +467,7 @@ const DosageRenderer: FhirTypeRenderer = (value, ctx) => {
   const headline = d.text ?? formatDosage(d);
   const rows: { label: string; node: ReactNode }[] = [];
 
+  if (d.sequence != null) rows.push({ label: "Step", node: <span>{d.sequence}</span> });
   for (const dr of d.doseAndRate ?? []) {
     const typeText = formatCodeableConcept(dr.type);
     const suffix = typeText ? ` (${typeText})` : "";

--- a/packages/react-fhir/src/components/renderers.tsx
+++ b/packages/react-fhir/src/components/renderers.tsx
@@ -22,6 +22,7 @@ import type { ReactNode } from "react";
 import { Fragment } from "react";
 import {
   formatAddress,
+  formatCodeableConcept,
   formatDosage,
   formatHumanName,
   formatReferenceLabel,
@@ -467,17 +468,19 @@ const DosageRenderer: FhirTypeRenderer = (value, ctx) => {
   const rows: { label: string; node: ReactNode }[] = [];
 
   for (const dr of d.doseAndRate ?? []) {
+    const typeText = formatCodeableConcept(dr.type);
+    const suffix = typeText ? ` (${typeText})` : "";
     if (dr.doseQuantity) {
-      rows.push({ label: "Dose", node: QuantityRenderer(dr.doseQuantity, ctx) });
+      rows.push({ label: `Dose${suffix}`, node: QuantityRenderer(dr.doseQuantity, ctx) });
     } else if (dr.doseRange) {
-      rows.push({ label: "Dose", node: RangeRenderer(dr.doseRange, ctx) });
+      rows.push({ label: `Dose${suffix}`, node: RangeRenderer(dr.doseRange, ctx) });
     }
     if (dr.rateQuantity) {
-      rows.push({ label: "Rate", node: QuantityRenderer(dr.rateQuantity, ctx) });
+      rows.push({ label: `Rate${suffix}`, node: QuantityRenderer(dr.rateQuantity, ctx) });
     } else if (dr.rateRatio) {
-      rows.push({ label: "Rate", node: RatioRenderer(dr.rateRatio, ctx) });
+      rows.push({ label: `Rate${suffix}`, node: RatioRenderer(dr.rateRatio, ctx) });
     } else if (dr.rateRange) {
-      rows.push({ label: "Rate", node: RangeRenderer(dr.rateRange, ctx) });
+      rows.push({ label: `Rate${suffix}`, node: RangeRenderer(dr.rateRange, ctx) });
     }
   }
   const schedule = formatTiming(d.timing);

--- a/packages/react-fhir/src/components/renderers.tsx
+++ b/packages/react-fhir/src/components/renderers.tsx
@@ -482,8 +482,14 @@ const DosageRenderer: FhirTypeRenderer = (value, ctx) => {
   }
   const schedule = formatTiming(d.timing);
   if (schedule) rows.push({ label: "Schedule", node: <span>{schedule}</span> });
-  const bounds = d.timing?.repeat?.boundsPeriod;
-  if (bounds) rows.push({ label: "Duration", node: PeriodRenderer(bounds, ctx) });
+  const repeat = d.timing?.repeat;
+  if (repeat?.boundsPeriod) {
+    rows.push({ label: "Duration", node: PeriodRenderer(repeat.boundsPeriod, ctx) });
+  } else if (repeat?.boundsDuration) {
+    rows.push({ label: "Duration", node: QuantityRenderer(repeat.boundsDuration, ctx) });
+  } else if (repeat?.boundsRange) {
+    rows.push({ label: "Duration", node: RangeRenderer(repeat.boundsRange, ctx) });
+  }
   if (d.route) rows.push({ label: "Route", node: CodeableConceptRenderer(d.route, ctx) });
   if (d.site) rows.push({ label: "Site", node: CodeableConceptRenderer(d.site, ctx) });
   if (d.method) rows.push({ label: "Method", node: CodeableConceptRenderer(d.method, ctx) });
@@ -494,6 +500,9 @@ const DosageRenderer: FhirTypeRenderer = (value, ctx) => {
   if (d.maxDosePerPeriod) rows.push({ label: "Max / period", node: RatioRenderer(d.maxDosePerPeriod, ctx) });
   if (d.maxDosePerAdministration) {
     rows.push({ label: "Max / dose", node: QuantityRenderer(d.maxDosePerAdministration, ctx) });
+  }
+  if (d.maxDosePerLifetime) {
+    rows.push({ label: "Max / lifetime", node: QuantityRenderer(d.maxDosePerLifetime, ctx) });
   }
   for (const ai of d.additionalInstruction ?? []) {
     rows.push({ label: "Also", node: CodeableConceptRenderer(ai, ctx) });

--- a/packages/react-fhir/src/components/renderers.tsx
+++ b/packages/react-fhir/src/components/renderers.tsx
@@ -5,6 +5,7 @@ import type {
   CodeableConcept,
   Coding,
   ContactPoint,
+  Dosage,
   HumanName,
   Identifier,
   Meta,
@@ -15,13 +16,16 @@ import type {
   Ratio,
   Reference,
   Resource,
+  Timing,
 } from "fhir/r4";
 import type { ReactNode } from "react";
 import { Fragment } from "react";
 import {
   formatAddress,
+  formatDosage,
   formatHumanName,
   formatReferenceLabel,
+  formatTiming,
 } from "../structure/format.js";
 import { useReadReference } from "../hooks/queries.js";
 import { CodedValue } from "./codedValue/index.js";
@@ -450,6 +454,73 @@ const AnnotationRenderer: FhirTypeRenderer = (value) => {
   );
 };
 
+const Dash = () => <span className="text-slate-400">—</span>;
+
+const TimingRenderer: FhirTypeRenderer = (value) => {
+  const summary = formatTiming(value as Timing);
+  return summary ? <span>{summary}</span> : <Dash />;
+};
+
+const DosageRenderer: FhirTypeRenderer = (value, ctx) => {
+  const d = value as Dosage;
+  const headline = d.text ?? formatDosage(d);
+  const rows: { label: string; node: ReactNode }[] = [];
+
+  for (const dr of d.doseAndRate ?? []) {
+    if (dr.doseQuantity) {
+      rows.push({ label: "Dose", node: QuantityRenderer(dr.doseQuantity, ctx) });
+    } else if (dr.doseRange) {
+      rows.push({ label: "Dose", node: RangeRenderer(dr.doseRange, ctx) });
+    }
+    if (dr.rateQuantity) {
+      rows.push({ label: "Rate", node: QuantityRenderer(dr.rateQuantity, ctx) });
+    } else if (dr.rateRatio) {
+      rows.push({ label: "Rate", node: RatioRenderer(dr.rateRatio, ctx) });
+    } else if (dr.rateRange) {
+      rows.push({ label: "Rate", node: RangeRenderer(dr.rateRange, ctx) });
+    }
+  }
+  const schedule = formatTiming(d.timing);
+  if (schedule) rows.push({ label: "Schedule", node: <span>{schedule}</span> });
+  const bounds = d.timing?.repeat?.boundsPeriod;
+  if (bounds) rows.push({ label: "Duration", node: PeriodRenderer(bounds, ctx) });
+  if (d.route) rows.push({ label: "Route", node: CodeableConceptRenderer(d.route, ctx) });
+  if (d.site) rows.push({ label: "Site", node: CodeableConceptRenderer(d.site, ctx) });
+  if (d.method) rows.push({ label: "Method", node: CodeableConceptRenderer(d.method, ctx) });
+  if (d.asNeededBoolean) rows.push({ label: "As needed", node: <span>yes</span> });
+  else if (d.asNeededCodeableConcept) {
+    rows.push({ label: "As needed for", node: CodeableConceptRenderer(d.asNeededCodeableConcept, ctx) });
+  }
+  if (d.maxDosePerPeriod) rows.push({ label: "Max / period", node: RatioRenderer(d.maxDosePerPeriod, ctx) });
+  if (d.maxDosePerAdministration) {
+    rows.push({ label: "Max / dose", node: QuantityRenderer(d.maxDosePerAdministration, ctx) });
+  }
+  for (const ai of d.additionalInstruction ?? []) {
+    rows.push({ label: "Also", node: CodeableConceptRenderer(ai, ctx) });
+  }
+  if (d.patientInstruction) {
+    rows.push({ label: "Patient instruction", node: <span>{d.patientInstruction}</span> });
+  }
+
+  if (!headline && rows.length === 0) return <Dash />;
+
+  return (
+    <div className="space-y-1">
+      {headline && <div className="font-medium">{headline}</div>}
+      {rows.length > 0 && (
+        <dl className="grid grid-cols-[minmax(5rem,max-content)_1fr] gap-x-3 gap-y-0.5">
+          {rows.map((r, i) => (
+            <Fragment key={`${r.label}-${i}`}>
+              <dt className="text-xs font-medium text-slate-500">{r.label}</dt>
+              <dd className="text-sm">{r.node}</dd>
+            </Fragment>
+          ))}
+        </dl>
+      )}
+    </div>
+  );
+};
+
 export const defaultTypeRenderers: TypeRenderers = {
   // primitives
   string: Primitive,
@@ -489,4 +560,6 @@ export const defaultTypeRenderers: TypeRenderers = {
   Attachment: AttachmentRenderer,
   Annotation: AnnotationRenderer,
   Meta: MetaRenderer,
+  Timing: TimingRenderer,
+  Dosage: DosageRenderer,
 };

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -265,12 +265,33 @@ describe("formatTiming", () => {
     ).toBe("2024-01-01 → 2024-03-01");
     expect(
       formatTiming({ repeat: { boundsDuration: { value: 14, unit: "days" } } }),
-    ).toBe("over 14 days");
+    ).toBe("for 14 days");
     expect(
       formatTiming({
         repeat: { boundsRange: { low: { value: 7, unit: "d" }, high: { value: 10, unit: "d" } } },
       }),
-    ).toBe("7 d–10 d");
+    ).toBe("for 7 d–10 d");
+  });
+
+  it("appends bounds to a coded cadence", () => {
+    expect(
+      formatTiming({
+        code: {
+          coding: [
+            { system: "http://terminology.hl7.org/CodeSystem/v3-GTSAbbreviation", code: "BID" },
+          ],
+        },
+        repeat: { boundsDuration: { value: 10, unit: "days" } },
+      }),
+    ).toBe("twice daily for 10 days");
+  });
+
+  it("keeps per-occurrence duration alongside a frequency cadence", () => {
+    expect(
+      formatTiming({
+        repeat: { frequency: 3, period: 1, periodUnit: "d", duration: 30, durationUnit: "min" },
+      }),
+    ).toBe("3 times per day over 30 minutes");
   });
 
   it("ignores abbreviation codes from non-v3-GTS systems", () => {

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -226,6 +226,19 @@ describe("formatTiming", () => {
     expect(formatTiming({ repeat: { count: 3, countMax: 5 } })).toBe("for 3–5 doses");
   });
 
+  it("includes Timing.event alongside a repeat phrase", () => {
+    expect(
+      formatTiming({
+        event: ["2024-01-01T08:00:00Z"],
+        repeat: { frequency: 1, period: 1, periodUnit: "d" },
+      }),
+    ).toBe("once per day (at 2024-01-01T08:00:00Z)");
+    // event-only timing renders the timestamps directly
+    expect(formatTiming({ event: ["2024-01-01T08:00:00Z", "2024-01-02T08:00:00Z"] })).toBe(
+      "2024-01-01T08:00:00Z, 2024-01-02T08:00:00Z",
+    );
+  });
+
   it("includes repeat.offset with the when phrase", () => {
     expect(
       formatTiming({ repeat: { when: ["AC"], offset: 30 } }),

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -223,7 +223,7 @@ describe("formatTiming", () => {
     expect(
       formatTiming({ repeat: { frequency: 1, period: 1, periodMax: 2, periodUnit: "d" } }),
     ).toBe("once every 1–2 days");
-    expect(formatTiming({ repeat: { count: 3, countMax: 5 } })).toBe("for 3–5 doses");
+    expect(formatTiming({ repeat: { count: 3, countMax: 5 } })).toBe("for 3–5 occurrences");
   });
 
   it("includes Timing.event alongside a repeat phrase", () => {
@@ -250,7 +250,7 @@ describe("formatTiming", () => {
       formatTiming({
         repeat: { frequency: 1, period: 1, periodUnit: "d", when: ["HS"], count: 5 },
       }),
-    ).toBe("once per day at bedtime for 5 doses");
+    ).toBe("once per day at bedtime for 5 occurrences");
   });
 
   it("prefers code.text over coding display", () => {
@@ -386,6 +386,19 @@ describe("formatDosage", () => {
         timing: { repeat: { frequency: 2, period: 1, periodUnit: "d" } },
       }),
     ).toBe("1 tablet 2 times per day");
+  });
+
+  it("summarises rate-only dosage instructions", () => {
+    expect(
+      formatDosage({
+        doseAndRate: [
+          { rateRatio: { numerator: { value: 100, unit: "mL" }, denominator: { value: 1, unit: "h" } } },
+        ],
+      }),
+    ).toBe("100 mL / 1 h");
+    expect(
+      formatDosage({ doseAndRate: [{ rateQuantity: { value: 50, unit: "mL/h" } }] }),
+    ).toBe("50 mL/h");
   });
 
   it("formats one-sided dose ranges without a dangling dash", () => {

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -240,6 +240,39 @@ describe("formatTiming", () => {
     ).toBe("every other Tuesday");
   });
 
+  it("does not expand abbreviation codes that lack an explicit v3-GTS system", () => {
+    expect(
+      formatTiming({
+        code: { coding: [{ code: "BID" }] },
+        repeat: { frequency: 3, period: 1, periodUnit: "d" },
+      }),
+    ).toBe("3 times per day");
+    // …but a coding whose system *is* v3-GTS still expands.
+    expect(
+      formatTiming({
+        code: {
+          coding: [
+            { system: "http://terminology.hl7.org/CodeSystem/v3-GTSAbbreviation", code: "TID" },
+          ],
+        },
+      }),
+    ).toBe("three times daily");
+  });
+
+  it("renders bounds-only timings instead of an em-dash", () => {
+    expect(
+      formatTiming({ repeat: { boundsPeriod: { start: "2024-01-01", end: "2024-03-01" } } }),
+    ).toBe("2024-01-01 → 2024-03-01");
+    expect(
+      formatTiming({ repeat: { boundsDuration: { value: 14, unit: "days" } } }),
+    ).toBe("over 14 days");
+    expect(
+      formatTiming({
+        repeat: { boundsRange: { low: { value: 7, unit: "d" }, high: { value: 10, unit: "d" } } },
+      }),
+    ).toBe("7 d–10 d");
+  });
+
   it("ignores abbreviation codes from non-v3-GTS systems", () => {
     // A code "BID" from some unrelated terminology must not become "twice daily".
     expect(

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -230,6 +230,29 @@ describe("formatTiming", () => {
     ).toBe("every other Tuesday");
   });
 
+  it("ignores abbreviation codes from non-v3-GTS systems", () => {
+    // A code "BID" from some unrelated terminology must not become "twice daily".
+    expect(
+      formatTiming({
+        code: {
+          coding: [{ system: "http://example.org/other", code: "BID", display: "Bid label" }],
+        },
+        repeat: { frequency: 3, period: 1, periodUnit: "d" },
+      }),
+    ).toBe("Bid label");
+    expect(
+      formatTiming({
+        code: { coding: [{ system: "http://example.org/other", code: "BID" }] },
+        repeat: { frequency: 3, period: 1, periodUnit: "d" },
+      }),
+    ).toBe("3 times per day");
+  });
+
+  it("omits the period clause when periodUnit is missing", () => {
+    expect(formatTiming({ repeat: { frequency: 2 } })).toBe("2 times");
+    expect(formatTiming({ repeat: { frequency: 1, period: 3 } })).toBe("once");
+  });
+
   it("returns '' for empty timing", () => {
     expect(formatTiming(undefined)).toBe("");
     expect(formatTiming({})).toBe("");

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -226,6 +226,12 @@ describe("formatTiming", () => {
     expect(formatTiming({ repeat: { count: 3, countMax: 5 } })).toBe("for 3–5 doses");
   });
 
+  it("includes repeat.offset with the when phrase", () => {
+    expect(
+      formatTiming({ repeat: { when: ["AC"], offset: 30 } }),
+    ).toBe("30 minutes before meals");
+  });
+
   it("appends when / count modifiers", () => {
     expect(
       formatTiming({

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -243,6 +243,10 @@ describe("formatTiming", () => {
     expect(
       formatTiming({ repeat: { when: ["AC"], offset: 30 } }),
     ).toBe("30 minutes before meals");
+    // neutral event codes get a "(+N minutes)" suffix (FHIR default = after)
+    expect(
+      formatTiming({ repeat: { when: ["WAKE"], offset: 30 } }),
+    ).toBe("on waking (+30 minutes)");
   });
 
   it("appends when / count modifiers", () => {

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -294,6 +294,32 @@ describe("formatTiming", () => {
     ).toBe("3 times per day over 30 minutes");
   });
 
+  it("renders durationMax as a range", () => {
+    expect(
+      formatTiming({ repeat: { duration: 20, durationMax: 30, durationUnit: "min" } }),
+    ).toBe("over 20–30 minutes");
+  });
+
+  it("treats a populated Timing.code as the complete schedule (ignoring repeat modifiers)", () => {
+    expect(
+      formatTiming({
+        code: {
+          coding: [
+            { system: "http://terminology.hl7.org/CodeSystem/v3-GTSAbbreviation", code: "TID" },
+          ],
+        },
+        repeat: { when: ["AC"], count: 9, frequency: 5, period: 1, periodUnit: "h" },
+      }),
+    ).toBe("three times daily");
+    // …but bounds[x] is still layered on top.
+    expect(
+      formatTiming({
+        code: { text: "with meals" },
+        repeat: { when: ["PC"], boundsDuration: { value: 5, unit: "days" } },
+      }),
+    ).toBe("with meals for 5 days");
+  });
+
   it("ignores abbreviation codes from non-v3-GTS systems", () => {
     // A code "BID" from some unrelated terminology must not become "twice daily".
     expect(

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -253,6 +253,12 @@ describe("formatTiming", () => {
     expect(formatTiming({ repeat: { frequency: 1, period: 3 } })).toBe("once");
   });
 
+  it("falls back to the raw coding.code when there is no display or text", () => {
+    expect(
+      formatTiming({ code: { coding: [{ system: "http://snomed.info/sct", code: "307468000" }] } }),
+    ).toBe("307468000");
+  });
+
   it("returns '' for empty timing", () => {
     expect(formatTiming(undefined)).toBe("");
     expect(formatTiming({})).toBe("");
@@ -271,6 +277,20 @@ describe("formatDosage", () => {
         timing: { repeat: { frequency: 2, period: 1, periodUnit: "d" } },
       }),
     ).toBe("1 tablet 2 times per day");
+  });
+
+  it("formats one-sided dose ranges without a dangling dash", () => {
+    expect(
+      formatDosage({ doseAndRate: [{ doseRange: { low: { value: 5, unit: "mg" } } }] }),
+    ).toBe("≥ 5 mg");
+    expect(
+      formatDosage({ doseAndRate: [{ doseRange: { high: { value: 10, unit: "mg" } } }] }),
+    ).toBe("≤ 10 mg");
+    expect(
+      formatDosage({
+        doseAndRate: [{ doseRange: { low: { value: 5, unit: "mg" }, high: { value: 10, unit: "mg" } } }],
+      }),
+    ).toBe("5 mg–10 mg");
   });
 
   it("includes route and as-needed", () => {

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -216,6 +216,16 @@ describe("formatTiming", () => {
     );
   });
 
+  it("renders periodMax and countMax as ranges", () => {
+    expect(
+      formatTiming({ repeat: { frequency: 1, period: 4, periodMax: 6, periodUnit: "h" } }),
+    ).toBe("once every 4–6 hours");
+    expect(
+      formatTiming({ repeat: { frequency: 1, period: 1, periodMax: 2, periodUnit: "d" } }),
+    ).toBe("once every 1–2 days");
+    expect(formatTiming({ repeat: { count: 3, countMax: 5 } })).toBe("for 3–5 doses");
+  });
+
   it("appends when / count modifiers", () => {
     expect(
       formatTiming({

--- a/packages/react-fhir/src/structure/format.test.ts
+++ b/packages/react-fhir/src/structure/format.test.ts
@@ -3,10 +3,12 @@ import {
   formatAddress,
   formatCodeableConcept,
   formatCoding,
+  formatDosage,
   formatHumanName,
   formatPeriod,
   formatQuantity,
   formatReferenceLabel,
+  formatTiming,
 } from "./format.js";
 
 describe("formatHumanName", () => {
@@ -186,5 +188,80 @@ describe("formatReferenceLabel", () => {
     expect(
       formatReferenceLabel({ resourceType: "Device", id: "dev-1" } as never),
     ).toBe("Device/dev-1");
+  });
+});
+
+describe("formatTiming", () => {
+  it("uses a known abbreviation code", () => {
+    expect(
+      formatTiming({
+        code: {
+          coding: [
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-GTSAbbreviation",
+              code: "BID",
+            },
+          ],
+        },
+      }),
+    ).toBe("twice daily");
+  });
+
+  it("builds a phrase from frequency + period", () => {
+    expect(formatTiming({ repeat: { frequency: 2, period: 1, periodUnit: "d" } })).toBe(
+      "2 times per day",
+    );
+    expect(formatTiming({ repeat: { frequency: 1, period: 8, periodUnit: "h" } })).toBe(
+      "once every 8 hours",
+    );
+  });
+
+  it("appends when / count modifiers", () => {
+    expect(
+      formatTiming({
+        repeat: { frequency: 1, period: 1, periodUnit: "d", when: ["HS"], count: 5 },
+      }),
+    ).toBe("once per day at bedtime for 5 doses");
+  });
+
+  it("prefers code.text over coding display", () => {
+    expect(
+      formatTiming({ code: { text: "every other Tuesday", coding: [{ display: "x" }] } }),
+    ).toBe("every other Tuesday");
+  });
+
+  it("returns '' for empty timing", () => {
+    expect(formatTiming(undefined)).toBe("");
+    expect(formatTiming({})).toBe("");
+  });
+});
+
+describe("formatDosage", () => {
+  it("returns the authored text verbatim", () => {
+    expect(formatDosage({ text: "1 tab twice daily" })).toBe("1 tab twice daily");
+  });
+
+  it("assembles dose + schedule when text is absent", () => {
+    expect(
+      formatDosage({
+        doseAndRate: [{ doseQuantity: { value: 1, unit: "tablet" } }],
+        timing: { repeat: { frequency: 2, period: 1, periodUnit: "d" } },
+      }),
+    ).toBe("1 tablet 2 times per day");
+  });
+
+  it("includes route and as-needed", () => {
+    expect(
+      formatDosage({
+        doseAndRate: [{ doseQuantity: { value: 400, unit: "mg" } }],
+        route: { text: "oral" },
+        asNeededBoolean: true,
+      }),
+    ).toBe("400 mg oral, as needed");
+  });
+
+  it("returns '' for empty dosage", () => {
+    expect(formatDosage(undefined)).toBe("");
+    expect(formatDosage({})).toBe("");
   });
 });

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -136,11 +136,15 @@ function unitLabel(unit: string | undefined, count: number): string {
  * "3 times per week in the morning". Prefers an explicit `Timing.code`
  * abbreviation, then falls back to building a phrase from `repeat`.
  */
+const V3_GTS_ABBREVIATION_SYSTEM =
+  "http://terminology.hl7.org/CodeSystem/v3-GTSAbbreviation";
+
 export function formatTiming(t: Timing | undefined): string {
   if (!t) return "";
   const code = t.code;
   if (code) {
     for (const c of code.coding ?? []) {
+      if (c.system && c.system !== V3_GTS_ABBREVIATION_SYSTEM) continue;
       const label = c.code ? TIMING_ABBREVIATION_LABELS[c.code] : undefined;
       if (label) return label;
     }
@@ -157,7 +161,9 @@ export function formatTiming(t: Timing | undefined): string {
     const freqStr = r.frequencyMax ? `${freq}–${r.frequencyMax}` : `${freq}`;
     const timesWord =
       freq === 1 && !r.frequencyMax ? "once" : `${freqStr} times`;
-    if (period === 1) {
+    if (!r.periodUnit) {
+      parts.push(timesWord);
+    } else if (period === 1) {
       parts.push(`${timesWord} per ${unitLabel(r.periodUnit, 1)}`);
     } else {
       parts.push(`${timesWord} every ${period} ${unitLabel(r.periodUnit, period)}`);

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -160,12 +160,15 @@ export function formatTiming(t: Timing | undefined): string {
     const freqStr = r.frequencyMax ? `${freq}–${r.frequencyMax}` : `${freq}`;
     const timesWord =
       freq === 1 && !r.frequencyMax ? "once" : `${freqStr} times`;
+    const periodStr = r.periodMax ? `${period}–${r.periodMax}` : `${period}`;
     if (!r.periodUnit) {
       parts.push(timesWord);
-    } else if (period === 1) {
+    } else if (period === 1 && !r.periodMax) {
       parts.push(`${timesWord} per ${unitLabel(r.periodUnit, 1)}`);
     } else {
-      parts.push(`${timesWord} every ${period} ${unitLabel(r.periodUnit, period)}`);
+      parts.push(
+        `${timesWord} every ${periodStr} ${unitLabel(r.periodUnit, r.periodMax ?? period)}`,
+      );
     }
   } else if (r?.duration != null && r.durationUnit) {
     parts.push(`over ${r.duration} ${unitLabel(r.durationUnit, r.duration)}`);
@@ -175,7 +178,12 @@ export function formatTiming(t: Timing | undefined): string {
   }
   if (r?.timeOfDay?.length) parts.push(`at ${r.timeOfDay.join(", ")}`);
   if (r?.dayOfWeek?.length) parts.push(`on ${r.dayOfWeek.join(", ")}`);
-  if (r?.count != null) parts.push(`for ${r.count} dose${r.count === 1 ? "" : "s"}`);
+  if (r?.count != null || r?.countMax != null) {
+    const count = r.count ?? 1;
+    const countStr = r.countMax ? `${count}–${r.countMax}` : `${count}`;
+    const plural = (r.countMax ?? count) === 1 ? "" : "s";
+    parts.push(`for ${countStr} dose${plural}`);
+  }
   const phrase = parts.join(" ").trim();
   if (phrase) return phrase;
   if (t.event?.length) return t.event.join(", ");

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -2,10 +2,12 @@ import type {
   Address,
   CodeableConcept,
   Coding,
+  Dosage,
   HumanName,
   Period,
   Quantity,
   Resource,
+  Timing,
 } from "fhir/r4";
 
 /**
@@ -70,6 +72,137 @@ export function formatPeriod(p: Period | undefined): string {
   const start = p.start ?? "…";
   const end = p.end ?? "…";
   return `${start} → ${end}`;
+}
+
+const PERIOD_UNIT_LABELS: Record<string, string> = {
+  s: "second",
+  min: "minute",
+  h: "hour",
+  d: "day",
+  wk: "week",
+  mo: "month",
+  a: "year",
+};
+
+/** v3-GTSAbbreviation timing codes that have a clean plain-English reading. */
+const TIMING_ABBREVIATION_LABELS: Record<string, string> = {
+  BID: "twice daily",
+  TID: "three times daily",
+  QID: "four times daily",
+  AM: "in the morning",
+  PM: "in the afternoon",
+  QD: "once daily",
+  QOD: "every other day",
+  QHS: "at bedtime",
+  Q1H: "every hour",
+  Q2H: "every 2 hours",
+  Q3H: "every 3 hours",
+  Q4H: "every 4 hours",
+  Q6H: "every 6 hours",
+  Q8H: "every 8 hours",
+  WK: "weekly",
+  MO: "monthly",
+};
+
+const WHEN_LABELS: Record<string, string> = {
+  MORN: "in the morning",
+  AFT: "in the afternoon",
+  EVE: "in the evening",
+  NIGHT: "at night",
+  HS: "at bedtime",
+  WAKE: "on waking",
+  C: "with meals",
+  CM: "with breakfast",
+  CD: "with lunch",
+  CV: "with dinner",
+  AC: "before meals",
+  ACM: "before breakfast",
+  ACD: "before lunch",
+  ACV: "before dinner",
+  PC: "after meals",
+  PCM: "after breakfast",
+  PCD: "after lunch",
+  PCV: "after dinner",
+};
+
+function unitLabel(unit: string | undefined, count: number): string {
+  if (!unit) return "";
+  const base = PERIOD_UNIT_LABELS[unit] ?? unit;
+  return count === 1 ? base : `${base}s`;
+}
+
+/**
+ * Plain-English summary of a FHIR Timing — e.g. "twice daily", "every 8 hours",
+ * "3 times per week in the morning". Prefers an explicit `Timing.code`
+ * abbreviation, then falls back to building a phrase from `repeat`.
+ */
+export function formatTiming(t: Timing | undefined): string {
+  if (!t) return "";
+  const code = t.code;
+  if (code) {
+    for (const c of code.coding ?? []) {
+      const label = c.code ? TIMING_ABBREVIATION_LABELS[c.code] : undefined;
+      if (label) return label;
+    }
+    if (code.text) return code.text;
+    const display = code.coding?.find((c) => c.display)?.display;
+    if (display) return display;
+  }
+  const r = t.repeat;
+  if (!r) return t.event?.length ? t.event.join(", ") : "";
+  const parts: string[] = [];
+  if (r.frequency != null || r.period != null) {
+    const freq = r.frequency ?? 1;
+    const period = r.period ?? 1;
+    const freqStr = r.frequencyMax ? `${freq}–${r.frequencyMax}` : `${freq}`;
+    const timesWord =
+      freq === 1 && !r.frequencyMax ? "once" : `${freqStr} times`;
+    if (period === 1) {
+      parts.push(`${timesWord} per ${unitLabel(r.periodUnit, 1)}`);
+    } else {
+      parts.push(`${timesWord} every ${period} ${unitLabel(r.periodUnit, period)}`);
+    }
+  } else if (r.duration != null && r.durationUnit) {
+    parts.push(`over ${r.duration} ${unitLabel(r.durationUnit, r.duration)}`);
+  }
+  if (r.when?.length) {
+    parts.push(r.when.map((w) => WHEN_LABELS[w] ?? w).join(", "));
+  }
+  if (r.timeOfDay?.length) parts.push(`at ${r.timeOfDay.join(", ")}`);
+  if (r.dayOfWeek?.length) parts.push(`on ${r.dayOfWeek.join(", ")}`);
+  if (r.count != null) parts.push(`for ${r.count} dose${r.count === 1 ? "" : "s"}`);
+  return parts.join(" ").trim();
+}
+
+function formatDoseAndRate(dr: NonNullable<Dosage["doseAndRate"]>[number]): string {
+  if (dr.doseQuantity) return formatQuantity(dr.doseQuantity);
+  if (dr.doseRange) {
+    return `${formatQuantity(dr.doseRange.low)}–${formatQuantity(dr.doseRange.high)}`.trim();
+  }
+  return "";
+}
+
+/**
+ * One-line plain-English summary of a FHIR Dosage. Prefers the authored
+ * `text`; otherwise assembles dose + route + schedule + as-needed.
+ */
+export function formatDosage(d: Dosage | undefined): string {
+  if (!d) return "";
+  if (d.text) return d.text;
+  const parts: string[] = [];
+  const dose = d.doseAndRate?.map(formatDoseAndRate).filter(Boolean).join(", ");
+  if (dose) parts.push(dose);
+  const route = formatCodeableConcept(d.route);
+  if (route) parts.push(route);
+  const timing = formatTiming(d.timing);
+  if (timing) parts.push(timing);
+  let summary = parts.join(" ").trim();
+  if (d.asNeededBoolean) summary = summary ? `${summary}, as needed` : "as needed";
+  else if (d.asNeededCodeableConcept) {
+    const why = formatCodeableConcept(d.asNeededCodeableConcept);
+    summary = `${summary ? `${summary}, ` : ""}as needed${why ? ` for ${why}` : ""}`;
+  }
+  return summary;
 }
 
 /**

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -182,10 +182,15 @@ export function formatTiming(t: Timing | undefined): string {
     }
     if (r.when?.length) {
       const whenPhrase = r.when.map((w) => WHEN_LABELS[w] ?? w).join(", ");
-      const offset = r.offset
-        ? `${r.offset} minute${r.offset === 1 ? "" : "s"} `
-        : "";
-      parts.push(`${offset}${whenPhrase}`);
+      if (r.offset) {
+        const mins = `${r.offset} minute${r.offset === 1 ? "" : "s"}`;
+        // AC*/PC* event codes already encode before/after; for neutral codes
+        // FHIR defaults the offset to "after", shown here as "(+N minutes)".
+        const directional = r.when.every((w) => /^(AC|PC)/.test(w));
+        parts.push(directional ? `${mins} ${whenPhrase}` : `${whenPhrase} (+${mins})`);
+      } else {
+        parts.push(whenPhrase);
+      }
     }
     if (r.timeOfDay?.length) parts.push(`at ${r.timeOfDay.join(", ")}`);
     if (r.dayOfWeek?.length) parts.push(`on ${r.dayOfWeek.join(", ")}`);

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -139,38 +139,40 @@ function unitLabel(unit: string | undefined, count: number): string {
 const V3_GTS_ABBREVIATION_SYSTEM =
   "http://terminology.hl7.org/CodeSystem/v3-GTSAbbreviation";
 
+function timingCadence(code: Timing["code"]): string {
+  if (!code) return "";
+  const v3 = code.coding?.find(
+    (c) =>
+      c.system === V3_GTS_ABBREVIATION_SYSTEM && c.code && TIMING_ABBREVIATION_LABELS[c.code],
+  );
+  if (v3) return TIMING_ABBREVIATION_LABELS[v3.code!]!;
+  return code.text ?? code.coding?.find((c) => c.display)?.display ?? "";
+}
+
 export function formatTiming(t: Timing | undefined): string {
   if (!t) return "";
-  const code = t.code;
-  if (code) {
-    for (const c of code.coding ?? []) {
-      if (c.system !== V3_GTS_ABBREVIATION_SYSTEM) continue;
-      const label = c.code ? TIMING_ABBREVIATION_LABELS[c.code] : undefined;
-      if (label) return label;
-    }
-    if (code.text) return code.text;
-    const display = code.coding?.find((c) => c.display)?.display;
-    if (display) return display;
-  }
   const r = t.repeat;
   const parts: string[] = [];
-  if (r?.frequency != null || r?.period != null) {
+
+  // Cadence: an explicit Timing.code wins over a repeat-derived phrase.
+  let cadence = timingCadence(t.code);
+  if (!cadence && (r?.frequency != null || r?.period != null)) {
     const freq = r.frequency ?? 1;
     const period = r.period ?? 1;
     const freqStr = r.frequencyMax ? `${freq}–${r.frequencyMax}` : `${freq}`;
-    const timesWord =
-      freq === 1 && !r.frequencyMax ? "once" : `${freqStr} times`;
+    const timesWord = freq === 1 && !r.frequencyMax ? "once" : `${freqStr} times`;
     const periodStr = r.periodMax ? `${period}–${r.periodMax}` : `${period}`;
     if (!r.periodUnit) {
-      parts.push(timesWord);
+      cadence = timesWord;
     } else if (period === 1 && !r.periodMax) {
-      parts.push(`${timesWord} per ${unitLabel(r.periodUnit, 1)}`);
+      cadence = `${timesWord} per ${unitLabel(r.periodUnit, 1)}`;
     } else {
-      parts.push(
-        `${timesWord} every ${periodStr} ${unitLabel(r.periodUnit, r.periodMax ?? period)}`,
-      );
+      cadence = `${timesWord} every ${periodStr} ${unitLabel(r.periodUnit, r.periodMax ?? period)}`;
     }
-  } else if (r?.duration != null && r.durationUnit) {
+  }
+  if (cadence) parts.push(cadence);
+
+  if (r?.duration != null && r.durationUnit) {
     parts.push(`over ${r.duration} ${unitLabel(r.durationUnit, r.duration)}`);
   }
   if (r?.when?.length) {
@@ -184,16 +186,15 @@ export function formatTiming(t: Timing | undefined): string {
     const plural = (r.countMax ?? count) === 1 ? "" : "s";
     parts.push(`for ${countStr} dose${plural}`);
   }
-  if (!parts.length && r) {
-    if (r.boundsPeriod) parts.push(formatPeriod(r.boundsPeriod));
-    else if (r.boundsRange) parts.push(formatRange(r.boundsRange));
-    else if (r.boundsDuration) parts.push(`over ${formatQuantity(r.boundsDuration)}`);
-  }
+  if (r?.boundsPeriod) parts.push(formatPeriod(r.boundsPeriod));
+  else if (r?.boundsRange) parts.push(`for ${formatRange(r.boundsRange)}`);
+  else if (r?.boundsDuration) parts.push(`for ${formatQuantity(r.boundsDuration)}`);
+
   const phrase = parts.join(" ").trim();
   if (phrase) return phrase;
   if (t.event?.length) return t.event.join(", ");
   // Last resort: surface the raw code so coded-only timings aren't lost.
-  return code?.coding?.find((c) => c.code)?.code ?? "";
+  return t.code?.coding?.find((c) => c.code)?.code ?? "";
 }
 
 function formatRange(r: { low?: Quantity; high?: Quantity } | undefined): string {

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -199,10 +199,13 @@ export function formatTiming(t: Timing | undefined): string {
   if (r?.boundsPeriod) parts.push(formatPeriod(r.boundsPeriod));
   else if (r?.boundsRange) parts.push(`for ${formatRange(r.boundsRange)}`);
   else if (r?.boundsDuration) parts.push(`for ${formatQuantity(r.boundsDuration)}`);
+  if (t.event?.length) {
+    const events = t.event.join(", ");
+    parts.push(parts.length ? `(at ${events})` : events);
+  }
 
   const phrase = parts.join(" ").trim();
   if (phrase) return phrase;
-  if (t.event?.length) return t.event.join(", ");
   // Last resort: surface the raw code so coded-only timings aren't lost.
   return t.code?.coding?.find((c) => c.code)?.code ?? "";
 }

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -154,37 +154,43 @@ export function formatTiming(t: Timing | undefined): string {
   const r = t.repeat;
   const parts: string[] = [];
 
-  // Cadence: an explicit Timing.code wins over a repeat-derived phrase.
-  let cadence = timingCadence(t.code);
-  if (!cadence && (r?.frequency != null || r?.period != null)) {
-    const freq = r.frequency ?? 1;
-    const period = r.period ?? 1;
-    const freqStr = r.frequencyMax ? `${freq}–${r.frequencyMax}` : `${freq}`;
-    const timesWord = freq === 1 && !r.frequencyMax ? "once" : `${freqStr} times`;
-    const periodStr = r.periodMax ? `${period}–${r.periodMax}` : `${period}`;
-    if (!r.periodUnit) {
-      cadence = timesWord;
-    } else if (period === 1 && !r.periodMax) {
-      cadence = `${timesWord} per ${unitLabel(r.periodUnit, 1)}`;
-    } else {
-      cadence = `${timesWord} every ${periodStr} ${unitLabel(r.periodUnit, r.periodMax ?? period)}`;
+  // A populated Timing.code is the complete schedule statement; only
+  // repeat.bounds[x] is layered on top of it (per the FHIR spec).
+  const codeCadence = timingCadence(t.code);
+  if (codeCadence) {
+    parts.push(codeCadence);
+  } else if (r) {
+    if (r.frequency != null || r.period != null) {
+      const freq = r.frequency ?? 1;
+      const period = r.period ?? 1;
+      const freqStr = r.frequencyMax ? `${freq}–${r.frequencyMax}` : `${freq}`;
+      const timesWord = freq === 1 && !r.frequencyMax ? "once" : `${freqStr} times`;
+      const periodStr = r.periodMax ? `${period}–${r.periodMax}` : `${period}`;
+      if (!r.periodUnit) {
+        parts.push(timesWord);
+      } else if (period === 1 && !r.periodMax) {
+        parts.push(`${timesWord} per ${unitLabel(r.periodUnit, 1)}`);
+      } else {
+        parts.push(
+          `${timesWord} every ${periodStr} ${unitLabel(r.periodUnit, r.periodMax ?? period)}`,
+        );
+      }
     }
-  }
-  if (cadence) parts.push(cadence);
-
-  if (r?.duration != null && r.durationUnit) {
-    parts.push(`over ${r.duration} ${unitLabel(r.durationUnit, r.duration)}`);
-  }
-  if (r?.when?.length) {
-    parts.push(r.when.map((w) => WHEN_LABELS[w] ?? w).join(", "));
-  }
-  if (r?.timeOfDay?.length) parts.push(`at ${r.timeOfDay.join(", ")}`);
-  if (r?.dayOfWeek?.length) parts.push(`on ${r.dayOfWeek.join(", ")}`);
-  if (r?.count != null || r?.countMax != null) {
-    const count = r.count ?? 1;
-    const countStr = r.countMax ? `${count}–${r.countMax}` : `${count}`;
-    const plural = (r.countMax ?? count) === 1 ? "" : "s";
-    parts.push(`for ${countStr} dose${plural}`);
+    if (r.duration != null && r.durationUnit) {
+      const durStr = r.durationMax ? `${r.duration}–${r.durationMax}` : `${r.duration}`;
+      parts.push(`over ${durStr} ${unitLabel(r.durationUnit, r.durationMax ?? r.duration)}`);
+    }
+    if (r.when?.length) {
+      parts.push(r.when.map((w) => WHEN_LABELS[w] ?? w).join(", "));
+    }
+    if (r.timeOfDay?.length) parts.push(`at ${r.timeOfDay.join(", ")}`);
+    if (r.dayOfWeek?.length) parts.push(`on ${r.dayOfWeek.join(", ")}`);
+    if (r.count != null || r.countMax != null) {
+      const count = r.count ?? 1;
+      const countStr = r.countMax ? `${count}–${r.countMax}` : `${count}`;
+      const plural = (r.countMax ?? count) === 1 ? "" : "s";
+      parts.push(`for ${countStr} dose${plural}`);
+    }
   }
   if (r?.boundsPeriod) parts.push(formatPeriod(r.boundsPeriod));
   else if (r?.boundsRange) parts.push(`for ${formatRange(r.boundsRange)}`);

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -193,7 +193,7 @@ export function formatTiming(t: Timing | undefined): string {
       const count = r.count ?? 1;
       const countStr = r.countMax ? `${count}–${r.countMax}` : `${count}`;
       const plural = (r.countMax ?? count) === 1 ? "" : "s";
-      parts.push(`for ${countStr} dose${plural}`);
+      parts.push(`for ${countStr} occurrence${plural}`);
     }
   }
   if (r?.boundsPeriod) parts.push(formatPeriod(r.boundsPeriod));
@@ -220,9 +220,20 @@ function formatRange(r: { low?: Quantity; high?: Quantity } | undefined): string
   return "";
 }
 
+function formatRatio(r: { numerator?: Quantity; denominator?: Quantity } | undefined): string {
+  if (!r) return "";
+  const num = formatQuantity(r.numerator);
+  const denom = formatQuantity(r.denominator);
+  if (num && denom) return `${num} / ${denom}`;
+  return num || denom;
+}
+
 function formatDoseAndRate(dr: NonNullable<Dosage["doseAndRate"]>[number]): string {
   if (dr.doseQuantity) return formatQuantity(dr.doseQuantity);
   if (dr.doseRange) return formatRange(dr.doseRange);
+  if (dr.rateQuantity) return formatQuantity(dr.rateQuantity);
+  if (dr.rateRatio) return formatRatio(dr.rateRatio);
+  if (dr.rateRange) return formatRange(dr.rateRange);
   return "";
 }
 

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -181,7 +181,11 @@ export function formatTiming(t: Timing | undefined): string {
       parts.push(`over ${durStr} ${unitLabel(r.durationUnit, r.durationMax ?? r.duration)}`);
     }
     if (r.when?.length) {
-      parts.push(r.when.map((w) => WHEN_LABELS[w] ?? w).join(", "));
+      const whenPhrase = r.when.map((w) => WHEN_LABELS[w] ?? w).join(", ");
+      const offset = r.offset
+        ? `${r.offset} minute${r.offset === 1 ? "" : "s"} `
+        : "";
+      parts.push(`${offset}${whenPhrase}`);
     }
     if (r.timeOfDay?.length) parts.push(`at ${r.timeOfDay.join(", ")}`);
     if (r.dayOfWeek?.length) parts.push(`on ${r.dayOfWeek.join(", ")}`);

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -144,7 +144,7 @@ export function formatTiming(t: Timing | undefined): string {
   const code = t.code;
   if (code) {
     for (const c of code.coding ?? []) {
-      if (c.system && c.system !== V3_GTS_ABBREVIATION_SYSTEM) continue;
+      if (c.system !== V3_GTS_ABBREVIATION_SYSTEM) continue;
       const label = c.code ? TIMING_ABBREVIATION_LABELS[c.code] : undefined;
       if (label) return label;
     }
@@ -183,6 +183,11 @@ export function formatTiming(t: Timing | undefined): string {
     const countStr = r.countMax ? `${count}–${r.countMax}` : `${count}`;
     const plural = (r.countMax ?? count) === 1 ? "" : "s";
     parts.push(`for ${countStr} dose${plural}`);
+  }
+  if (!parts.length && r) {
+    if (r.boundsPeriod) parts.push(formatPeriod(r.boundsPeriod));
+    else if (r.boundsRange) parts.push(formatRange(r.boundsRange));
+    else if (r.boundsDuration) parts.push(`over ${formatQuantity(r.boundsDuration)}`);
   }
   const phrase = parts.join(" ").trim();
   if (phrase) return phrase;

--- a/packages/react-fhir/src/structure/format.ts
+++ b/packages/react-fhir/src/structure/format.ts
@@ -153,9 +153,8 @@ export function formatTiming(t: Timing | undefined): string {
     if (display) return display;
   }
   const r = t.repeat;
-  if (!r) return t.event?.length ? t.event.join(", ") : "";
   const parts: string[] = [];
-  if (r.frequency != null || r.period != null) {
+  if (r?.frequency != null || r?.period != null) {
     const freq = r.frequency ?? 1;
     const period = r.period ?? 1;
     const freqStr = r.frequencyMax ? `${freq}–${r.frequencyMax}` : `${freq}`;
@@ -168,23 +167,35 @@ export function formatTiming(t: Timing | undefined): string {
     } else {
       parts.push(`${timesWord} every ${period} ${unitLabel(r.periodUnit, period)}`);
     }
-  } else if (r.duration != null && r.durationUnit) {
+  } else if (r?.duration != null && r.durationUnit) {
     parts.push(`over ${r.duration} ${unitLabel(r.durationUnit, r.duration)}`);
   }
-  if (r.when?.length) {
+  if (r?.when?.length) {
     parts.push(r.when.map((w) => WHEN_LABELS[w] ?? w).join(", "));
   }
-  if (r.timeOfDay?.length) parts.push(`at ${r.timeOfDay.join(", ")}`);
-  if (r.dayOfWeek?.length) parts.push(`on ${r.dayOfWeek.join(", ")}`);
-  if (r.count != null) parts.push(`for ${r.count} dose${r.count === 1 ? "" : "s"}`);
-  return parts.join(" ").trim();
+  if (r?.timeOfDay?.length) parts.push(`at ${r.timeOfDay.join(", ")}`);
+  if (r?.dayOfWeek?.length) parts.push(`on ${r.dayOfWeek.join(", ")}`);
+  if (r?.count != null) parts.push(`for ${r.count} dose${r.count === 1 ? "" : "s"}`);
+  const phrase = parts.join(" ").trim();
+  if (phrase) return phrase;
+  if (t.event?.length) return t.event.join(", ");
+  // Last resort: surface the raw code so coded-only timings aren't lost.
+  return code?.coding?.find((c) => c.code)?.code ?? "";
+}
+
+function formatRange(r: { low?: Quantity; high?: Quantity } | undefined): string {
+  if (!r) return "";
+  const low = formatQuantity(r.low);
+  const high = formatQuantity(r.high);
+  if (low && high) return `${low}–${high}`;
+  if (low) return `≥ ${low}`;
+  if (high) return `≤ ${high}`;
+  return "";
 }
 
 function formatDoseAndRate(dr: NonNullable<Dosage["doseAndRate"]>[number]): string {
   if (dr.doseQuantity) return formatQuantity(dr.doseQuantity);
-  if (dr.doseRange) {
-    return `${formatQuantity(dr.doseRange.low)}–${formatQuantity(dr.doseRange.high)}`.trim();
-  }
+  if (dr.doseRange) return formatRange(dr.doseRange);
   return "";
 }
 


### PR DESCRIPTION
## Summary

The `Dosage` value on `MedicationStatement` (and `MedicationRequest.dosageInstruction`) was being dumped as a raw JSON blob in the resource detail view. This adds dedicated renderers so it reads like a medication order:

- **`Dosage` renderer** — shows the authored `text` (or a synthesised one-liner) as a headline, followed by a small definition list breaking out dose / rate, schedule, treatment duration, route, site, method, "as needed", max-dose limits, additional + patient instructions. Reuses the existing Quantity / Range / Ratio / CodeableConcept renderers for the inner values.
- **`Timing` renderer** — plain-English schedule phrases ("twice daily", "once every 8 hours", "3 times per day in the morning for 5 doses"). Honours `Timing.code` v3-GTSAbbreviation codes (BID/TID/QID/…) before falling back to `repeat`.
- New pure helpers `formatTiming` / `formatDosage` in `structure/format.ts`, alongside the existing `formatQuantity` / `formatPeriod` etc., so other surfaces (tables, pickers) can render the same summary.

Example: the screenshot case `{ text: "1 tab twice daily", timing.repeat: { frequency: 2, period: 1, periodUnit: "d" }, doseAndRate: [{ doseQuantity: { value: 1, unit: "tablet", ... } }] }` now renders as:

> **1 tab twice daily**
> Dose — 1 tablet
> Schedule — 2 times per day

## Tests

- `packages/react-fhir/src/structure/format.test.ts` — `formatTiming` / `formatDosage` cases (abbreviation codes, frequency/period phrasing, when/count modifiers, route + as-needed, empties).
- `packages/react-fhir/src/components/renderers.test.tsx` — `Dosage` renderer (text headline + structured rows, synthesised headline, em-dash for empty) and `Timing` renderer.
- Full `@fhir-place/react-fhir` suite: 459 passing. `tsc` build clean.

## Screenshots

N/A in this environment — Playwright browser install is blocked (apt 403 in the sandbox), so I couldn't capture the demo page. The change is exercised by the unit tests above; a follow-up screenshot pass on the demo `MedicationStatement` detail page would be worthwhile before release.

https://claude.ai/code/session_016tAKAjz6XLJVyaLPvQ9TJw

---
_Generated by [Claude Code](https://claude.ai/code/session_016tAKAjz6XLJVyaLPvQ9TJw)_