### PR TITLE
feat(scripts): poll-events daemon for event-triggered prompts

### DIFF
--- a/.github/workflows/hourly-engineer-dispatch.yml
+++ b/.github/workflows/hourly-engineer-dispatch.yml
@@ -1,4 +1,4 @@
-# Hourly engineer-dispatch routine.
+# Hourly engineer-dispatch routine. :)
 #
 # Picks up to 3 ready issues from the backlog, hands each to the engineer
 # subagent (.claude/agents/engineer.md), opens draft PRs, and updates a

--- a/scripts/dispatch-engineer.sh
+++ b/scripts/dispatch-engineer.sh
@@ -1,10 +1,102 @@
 #!/usr/bin/env bash
-# Local engineer-dispatch driver. Originally the only local runner; now
-# a thin alias for scripts/local/engineer-dispatch.sh, which uses the
-# shared scripts/run-prompt-locally.sh runner.
+# Local engineer-dispatch driver. Mirrors the GH Actions workflow at
+# .github/workflows/hourly-engineer-dispatch.yml but invokes claude headlessly.
+# Designed to be fired by launchd; safe to run by hand for testing.
 #
-# Kept for backwards-compat with anyone whose launchd plist or muscle
-# memory points here. New scripts should call scripts/local/ directly.
+# Auth: this driver intentionally does NOT export ANTHROPIC_API_KEY. With no
+# API key in the env, `claude` falls back to its saved OAuth login session and
+# bills against the Claude Max subscription instead of paid API tokens. Run
+# `claude login` once on this machine before installing the launchd job.
+# The GHA workflow keeps using the API key — it has no logged-in user.
+#
+# See docs/decisions/0003-agent-safety-rules.md for the safety model.
+# The engineer subagent (.claude/agents/engineer.md) enforces all hard rules;
+# this script just wraps env, locking, logging, and notification.
 
 set -Eeuo pipefail
-exec "$(dirname "$0")/local/engineer-dispatch.sh" "$@"
+
+REPO_ROOT="${REPO_ROOT:-$HOME/src/fhir-place}"
+LOG_DIR="$REPO_ROOT/logs"
+LOCK_DIR="/tmp/fhir-place-dispatch.lock"
+PAUSE_FILE="$HOME/.fhir-place-pause"
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+LOG_FILE="$LOG_DIR/engineer-dispatch-$RUN_ID.log"
+PHONE="+15082827897"
+
+# launchd does not inherit shell PATH. Cover Apple Silicon, Intel, npm
+# global, pnpm self-install, and ~/.local/bin.
+export PATH="$HOME/Library/pnpm:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+# GitHub PAT from macOS keychain (one-time setup in scripts/dispatch-engineer.README).
+# No ANTHROPIC_API_KEY here on purpose — see auth note in the header comment.
+export GITHUB_TOKEN="$(security find-generic-password -s github-pat-fhir-place -a "$USER" -w 2>/dev/null || true)"
+export GH_TOKEN="$GITHUB_TOKEN"
+
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_FILE") 2>&1
+echo "=== run $RUN_ID ==="
+
+[[ -z "$GITHUB_TOKEN" ]] && { echo "missing GITHUB_TOKEN"; exit 2; }
+
+if [[ -f "$PAUSE_FILE" ]]; then
+  echo "pause file present at $PAUSE_FILE — skipping"; exit 0
+fi
+
+# Single-run lock via mkdir (atomic on POSIX). Stale lock recovery checks
+# whether the recorded PID is still alive.
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  STALE_PID="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+  if [[ -n "$STALE_PID" ]] && ! kill -0 "$STALE_PID" 2>/dev/null; then
+    echo "stale lock from pid $STALE_PID — clearing"
+    rm -rf "$LOCK_DIR"
+    mkdir "$LOCK_DIR"
+  else
+    echo "another dispatch is running (pid ${STALE_PID:-unknown})"; exit 0
+  fi
+fi
+echo $$ > "$LOCK_DIR/pid"
+trap 'rm -rf "$LOCK_DIR"' EXIT
+
+cd "$REPO_ROOT"
+
+# Refuse to run with a dirty primary checkout — likely Daniel mid-edit.
+# The engineer subagent works in worktrees, never the primary checkout.
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "dirty working tree at $REPO_ROOT — skipping"; exit 0
+fi
+
+git fetch origin --prune --tags --quiet
+git worktree prune
+
+# Tool allow-list. Defense in depth: engineer subagent has its own hard
+# rules; this just bounds what a prompt-injected dispatcher can call.
+ALLOWED="Read,Edit,Write,Bash,Grep,Glob,Agent,mcp__github__*"
+
+# Worktrees live at $(dirname $REPO_ROOT)/wt-<N> per engineer.md.
+# claude restricts file ops to cwd by default, so widen the scope.
+WORKTREE_PARENT="$(dirname "$REPO_ROOT")"
+
+set +e
+claude \
+  --print \
+  --add-dir "$WORKTREE_PARENT" \
+  --allowedTools "$ALLOWED" \
+  --dangerously-skip-permissions \
+  <<'PROMPT'
+Read the file at docs/prompts/hourly-engineer-dispatch.md and execute
+the instructions in it. Do not modify the prompt file itself. The MCP
+github tools are configured and the engineer subagent at
+.claude/agents/engineer.md is available for dispatch.
+PROMPT
+RC=$?
+set -e
+
+if [[ $RC -ne 0 ]]; then
+  osascript -e "tell application \"Messages\" to send \"engineer-dispatch failed rc=$RC run=$RUN_ID — see $LOG_FILE\" to participant \"$PHONE\" of (service 1 whose service type is iMessage)" || true
+fi
+
+# Trim old logs (~14 days).
+find "$LOG_DIR" -name 'engineer-dispatch-*.log' -mtime +14 -delete 2>/dev/null || true
+
+echo "=== run $RUN_ID complete (rc=$RC) ==="
+exit "$RC"

--- a/scripts/dispatch-engineer.sh
+++ b/scripts/dispatch-engineer.sh
@@ -1,102 +1,10 @@
 #!/usr/bin/env bash
-# Local engineer-dispatch driver. Mirrors the GH Actions workflow at
-# .github/workflows/hourly-engineer-dispatch.yml but invokes claude headlessly.
-# Designed to be fired by launchd; safe to run by hand for testing.
+# Local engineer-dispatch driver. Originally the only local runner; now
+# a thin alias for scripts/local/engineer-dispatch.sh, which uses the
+# shared scripts/run-prompt-locally.sh runner.
 #
-# Auth: this driver intentionally does NOT export ANTHROPIC_API_KEY. With no
-# API key in the env, `claude` falls back to its saved OAuth login session and
-# bills against the Claude Max subscription instead of paid API tokens. Run
-# `claude login` once on this machine before installing the launchd job.
-# The GHA workflow keeps using the API key — it has no logged-in user.
-#
-# See docs/decisions/0003-agent-safety-rules.md for the safety model.
-# The engineer subagent (.claude/agents/engineer.md) enforces all hard rules;
-# this script just wraps env, locking, logging, and notification.
+# Kept for backwards-compat with anyone whose launchd plist or muscle
+# memory points here. New scripts should call scripts/local/ directly.
 
 set -Eeuo pipefail
-
-REPO_ROOT="${REPO_ROOT:-$HOME/src/fhir-place}"
-LOG_DIR="$REPO_ROOT/logs"
-LOCK_DIR="/tmp/fhir-place-dispatch.lock"
-PAUSE_FILE="$HOME/.fhir-place-pause"
-RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
-LOG_FILE="$LOG_DIR/engineer-dispatch-$RUN_ID.log"
-PHONE="+15082827897"
-
-# launchd does not inherit shell PATH. Cover Apple Silicon, Intel, npm
-# global, pnpm self-install, and ~/.local/bin.
-export PATH="$HOME/Library/pnpm:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
-
-# GitHub PAT from macOS keychain (one-time setup in scripts/dispatch-engineer.README).
-# No ANTHROPIC_API_KEY here on purpose — see auth note in the header comment.
-export GITHUB_TOKEN="$(security find-generic-password -s github-pat-fhir-place -a "$USER" -w 2>/dev/null || true)"
-export GH_TOKEN="$GITHUB_TOKEN"
-
-mkdir -p "$LOG_DIR"
-exec > >(tee -a "$LOG_FILE") 2>&1
-echo "=== run $RUN_ID ==="
-
-[[ -z "$GITHUB_TOKEN" ]] && { echo "missing GITHUB_TOKEN"; exit 2; }
-
-if [[ -f "$PAUSE_FILE" ]]; then
-  echo "pause file present at $PAUSE_FILE — skipping"; exit 0
-fi
-
-# Single-run lock via mkdir (atomic on POSIX). Stale lock recovery checks
-# whether the recorded PID is still alive.
-if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-  STALE_PID="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
-  if [[ -n "$STALE_PID" ]] && ! kill -0 "$STALE_PID" 2>/dev/null; then
-    echo "stale lock from pid $STALE_PID — clearing"
-    rm -rf "$LOCK_DIR"
-    mkdir "$LOCK_DIR"
-  else
-    echo "another dispatch is running (pid ${STALE_PID:-unknown})"; exit 0
-  fi
-fi
-echo $$ > "$LOCK_DIR/pid"
-trap 'rm -rf "$LOCK_DIR"' EXIT
-
-cd "$REPO_ROOT"
-
-# Refuse to run with a dirty primary checkout — likely Daniel mid-edit.
-# The engineer subagent works in worktrees, never the primary checkout.
-if ! git diff --quiet || ! git diff --cached --quiet; then
-  echo "dirty working tree at $REPO_ROOT — skipping"; exit 0
-fi
-
-git fetch origin --prune --tags --quiet
-git worktree prune
-
-# Tool allow-list. Defense in depth: engineer subagent has its own hard
-# rules; this just bounds what a prompt-injected dispatcher can call.
-ALLOWED="Read,Edit,Write,Bash,Grep,Glob,Agent,mcp__github__*"
-
-# Worktrees live at $(dirname $REPO_ROOT)/wt-<N> per engineer.md.
-# claude restricts file ops to cwd by default, so widen the scope.
-WORKTREE_PARENT="$(dirname "$REPO_ROOT")"
-
-set +e
-claude \
-  --print \
-  --add-dir "$WORKTREE_PARENT" \
-  --allowedTools "$ALLOWED" \
-  --dangerously-skip-permissions \
-  <<'PROMPT'
-Read the file at docs/prompts/hourly-engineer-dispatch.md and execute
-the instructions in it. Do not modify the prompt file itself. The MCP
-github tools are configured and the engineer subagent at
-.claude/agents/engineer.md is available for dispatch.
-PROMPT
-RC=$?
-set -e
-
-if [[ $RC -ne 0 ]]; then
-  osascript -e "tell application \"Messages\" to send \"engineer-dispatch failed rc=$RC run=$RUN_ID — see $LOG_FILE\" to participant \"$PHONE\" of (service 1 whose service type is iMessage)" || true
-fi
-
-# Trim old logs (~14 days).
-find "$LOG_DIR" -name 'engineer-dispatch-*.log' -mtime +14 -delete 2>/dev/null || true
-
-echo "=== run $RUN_ID complete (rc=$RC) ==="
-exit "$RC"
+exec "$(dirname "$0")/local/engineer-dispatch.sh" "$@"

--- a/scripts/launchd/com.fhir-place.daily-doc-sync.plist
+++ b/scripts/launchd/com.fhir-place.daily-doc-sync.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Daily docs sync at 06:00 ET. See com.fhir-place.daily-pm-triage.plist for install steps. -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.fhir-place.daily-doc-sync</string>
+  <key>ProgramArguments</key><array><string>__HOME__/src/fhir-place/scripts/local/daily-doc-sync.sh</string></array>
+  <key>StartCalendarInterval</key><dict>
+    <key>Hour</key><integer>6</integer>
+    <key>Minute</key><integer>0</integer>
+  </dict>
+  <key>WorkingDirectory</key><string>__HOME__/src/fhir-place</string>
+  <key>StandardOutPath</key><string>__HOME__/src/fhir-place/logs/launchd-daily-doc-sync.out</string>
+  <key>StandardErrorPath</key><string>__HOME__/src/fhir-place/logs/launchd-daily-doc-sync.err</string>
+  <key>RunAtLoad</key><false/>
+</dict>
+</plist>

--- a/scripts/launchd/com.fhir-place.daily-pm-triage.plist
+++ b/scripts/launchd/com.fhir-place.daily-pm-triage.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Daily PM triage at 07:00 ET. Install:
+
+    cp scripts/launchd/com.fhir-place.daily-pm-triage.plist ~/Library/LaunchAgents/
+    sed -i '' "s#__HOME__#$HOME#g" ~/Library/LaunchAgents/com.fhir-place.daily-pm-triage.plist
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.fhir-place.daily-pm-triage.plist
+    launchctl kickstart -p gui/$(id -u)/com.fhir-place.daily-pm-triage  # one-off test
+
+  To temporarily pause every local runner at once:
+    touch ~/.fhir-place-pause
+
+  To resume:
+    rm ~/.fhir-place-pause
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.fhir-place.daily-pm-triage</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__HOME__/src/fhir-place/scripts/local/daily-pm-triage.sh</string>
+  </array>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>7</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <key>WorkingDirectory</key>
+  <string>__HOME__/src/fhir-place</string>
+
+  <key>StandardOutPath</key>
+  <string>__HOME__/src/fhir-place/logs/launchd-daily-pm-triage.out</string>
+
+  <key>StandardErrorPath</key>
+  <string>__HOME__/src/fhir-place/logs/launchd-daily-pm-triage.err</string>
+
+  <key>RunAtLoad</key>
+  <false/>
+</dict>
+</plist>

--- a/scripts/launchd/com.fhir-place.daily-qa-pass.plist
+++ b/scripts/launchd/com.fhir-place.daily-qa-pass.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Daily QA pass at 05:00 ET. See com.fhir-place.daily-pm-triage.plist for install steps. -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.fhir-place.daily-qa-pass</string>
+  <key>ProgramArguments</key><array><string>__HOME__/src/fhir-place/scripts/local/daily-qa-pass.sh</string></array>
+  <key>StartCalendarInterval</key><dict>
+    <key>Hour</key><integer>5</integer>
+    <key>Minute</key><integer>0</integer>
+  </dict>
+  <key>WorkingDirectory</key><string>__HOME__/src/fhir-place</string>
+  <key>StandardOutPath</key><string>__HOME__/src/fhir-place/logs/launchd-daily-qa-pass.out</string>
+  <key>StandardErrorPath</key><string>__HOME__/src/fhir-place/logs/launchd-daily-qa-pass.err</string>
+  <key>RunAtLoad</key><false/>
+</dict>
+</plist>

--- a/scripts/launchd/com.fhir-place.hourly-engineer-dispatch.plist
+++ b/scripts/launchd/com.fhir-place.hourly-engineer-dispatch.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Engineer dispatch at :05 every hour. See com.fhir-place.daily-pm-triage.plist for install steps. -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.fhir-place.hourly-engineer-dispatch</string>
+  <key>ProgramArguments</key><array><string>__HOME__/src/fhir-place/scripts/local/engineer-dispatch.sh</string></array>
+  <key>StartCalendarInterval</key><dict><key>Minute</key><integer>5</integer></dict>
+  <key>WorkingDirectory</key><string>__HOME__/src/fhir-place</string>
+  <key>StandardOutPath</key><string>__HOME__/src/fhir-place/logs/launchd-engineer-dispatch.out</string>
+  <key>StandardErrorPath</key><string>__HOME__/src/fhir-place/logs/launchd-engineer-dispatch.err</string>
+  <key>RunAtLoad</key><false/>
+</dict>
+</plist>

--- a/scripts/launchd/com.fhir-place.hourly-uat-validation.plist
+++ b/scripts/launchd/com.fhir-place.hourly-uat-validation.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Hourly UAT validation at :15. See com.fhir-place.daily-pm-triage.plist for install steps. -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.fhir-place.hourly-uat-validation</string>
+  <key>ProgramArguments</key><array><string>__HOME__/src/fhir-place/scripts/local/hourly-uat-validation.sh</string></array>
+  <key>StartCalendarInterval</key><dict><key>Minute</key><integer>15</integer></dict>
+  <key>WorkingDirectory</key><string>__HOME__/src/fhir-place</string>
+  <key>StandardOutPath</key><string>__HOME__/src/fhir-place/logs/launchd-uat-validation.out</string>
+  <key>StandardErrorPath</key><string>__HOME__/src/fhir-place/logs/launchd-uat-validation.err</string>
+  <key>RunAtLoad</key><false/>
+</dict>
+</plist>

--- a/scripts/launchd/com.fhir-place.poll-events.plist
+++ b/scripts/launchd/com.fhir-place.poll-events.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Long-running poll-events daemon. Replaces the GHA workflows that
+  trigger on issue_open / pull_request / issue_comment slash commands.
+
+  Install:
+    cp scripts/launchd/com.fhir-place.poll-events.plist ~/Library/LaunchAgents/
+    sed -i '' "s#__HOME__#$HOME#g" ~/Library/LaunchAgents/com.fhir-place.poll-events.plist
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.fhir-place.poll-events.plist
+
+  Verify:
+    launchctl print gui/$(id -u)/com.fhir-place.poll-events
+    tail -f ~/src/fhir-place/logs/poll-events.log
+
+  Pause every local runner (cron and this daemon):
+    touch ~/.fhir-place-pause
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.fhir-place.poll-events</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__HOME__/src/fhir-place/scripts/poll-events.sh</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>__HOME__/src/fhir-place</string>
+
+  <key>StandardOutPath</key>
+  <string>__HOME__/src/fhir-place/logs/launchd-poll-events.out</string>
+
+  <key>StandardErrorPath</key>
+  <string>__HOME__/src/fhir-place/logs/launchd-poll-events.err</string>
+
+  <!-- Keep the daemon alive; restart 60s after exit if it dies. -->
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>60</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+</dict>
+</plist>

--- a/scripts/local/README.md
+++ b/scripts/local/README.md
@@ -24,10 +24,19 @@ just billed against the Claude Max subscription.
   staging" checklist against `/staging/`, sets `uat: passed` /
   `uat: failed` labels. Runs at :15.
 
-The event-triggered prompts (PR review on open / ready, issue review
-on new issue, `/dispatch-engineer` and `/resolve-conflicts` slash
-commands) need a polling daemon rather than a cron job — see the
-follow-up `poll-events.sh` (forthcoming).
+Event-triggered prompts are dispatched by the polling daemon at
+[`../poll-events.sh`](../poll-events.sh). It polls GitHub every
+60s and fires the per-event drivers in this directory:
+
+- `event-issue-review.sh <issue-number>` — new issue opened
+- `event-pr-review.sh <pr-number>` — non-draft PR without a bot review
+- `event-dispatch-engineer.sh <issue-number>` — `/dispatch-engineer` comment
+- `event-resolve-conflicts.sh <pr-number>` — `/resolve-conflicts` comment
+
+The poll daemon has its own launchd plist:
+`scripts/launchd/com.fhir-place.poll-events.plist`. Install it the
+same way as the cron plists; it runs as `KeepAlive: true` so it
+restarts if it crashes.
 
 ## One-time setup
 
@@ -97,7 +106,7 @@ log in.
 | Billing | Claude Max subscription | per-token API spend |
 | Always-on | needs your machine awake | always |
 | Logs | `$REPO_ROOT/logs/*.log` | Actions tab |
-| Trigger | launchd cron + (forthcoming) poll daemon | GitHub events directly |
+| Trigger | launchd cron + `poll-events.sh` daemon | GitHub events directly |
 | Security | runs as you, with your secrets in keychain | runs in sandboxed runner with repo secrets |
 
 The pattern is: when a workflow is steady and predictable (the cron

--- a/scripts/local/README.md
+++ b/scripts/local/README.md
@@ -1,0 +1,106 @@
+# Local agent automation
+
+This directory contains shell drivers that run the SDLC prompts locally
+on your machine (via `claude --print` with the OAuth session from
+`claude login`) rather than on GitHub Actions (which uses the paid
+`ANTHROPIC_API_KEY`). Same prompts, same agents, same safety rules —
+just billed against the Claude Max subscription.
+
+## Pieces
+
+- [`../run-prompt-locally.sh`](../run-prompt-locally.sh) — the shared
+  runner. Handles lock, log, pause file, dirty-tree refusal, iMessage
+  notification on failure, and `--add-dir` for the worktree parent.
+  Never sets `ANTHROPIC_API_KEY`, so `claude` falls back to OAuth.
+- `engineer-dispatch.sh` — picks up to 3 ready issues per run, hands
+  each to the engineer subagent in a worktree. Runs hourly.
+- `daily-pm-triage.sh` — labels new issues, closes duplicates,
+  re-checks blocked items. Runs 07:00 ET.
+- `daily-qa-pass.sh` — exploratory Playwright walk of the demo, files
+  bot bugs. Runs 05:00 ET.
+- `daily-doc-sync.sh` — keeps the in-repo doc-sync wiki + redacted
+  prompts in sync. Runs 06:00 ET.
+- `hourly-uat-validation.sh` — walks each open PR's "UAT on live
+  staging" checklist against `/staging/`, sets `uat: passed` /
+  `uat: failed` labels. Runs at :15.
+
+The event-triggered prompts (PR review on open / ready, issue review
+on new issue, `/dispatch-engineer` and `/resolve-conflicts` slash
+commands) need a polling daemon rather than a cron job — see the
+follow-up `poll-events.sh` (forthcoming).
+
+## One-time setup
+
+1. **Repo lives at `~/src/fhir-place`.** Other paths require setting
+   `REPO_ROOT` in the launchd plist or your shell.
+
+2. **Log in to Claude.** Run `claude login` once. The OAuth session
+   gets stored in `~/.config/claude` (or platform equivalent). Without
+   this, the drivers will exit early because `claude --print` can't
+   authenticate.
+
+3. **Stash a GitHub PAT in the keychain.** Create a fine-grained PAT
+   at <https://github.com/settings/personal-access-tokens> with the
+   permissions each prompt needs (typically: repo read/write, issues
+   read/write, pull requests read/write). Save it as:
+
+   ```bash
+   security add-generic-password \
+     -s github-pat-fhir-place \
+     -a "$USER" \
+     -w '<your-PAT>'
+   ```
+
+   The runner reads this in via `security find-generic-password`
+   automatically.
+
+4. **Install the launchd plists.** For each driver you want on a
+   schedule:
+
+   ```bash
+   cp scripts/launchd/com.fhir-place.daily-pm-triage.plist ~/Library/LaunchAgents/
+   sed -i '' "s#__HOME__#$HOME#g" ~/Library/LaunchAgents/com.fhir-place.daily-pm-triage.plist
+   launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.fhir-place.daily-pm-triage.plist
+   ```
+
+   Repeat for `daily-qa-pass`, `daily-doc-sync`, `hourly-engineer-dispatch`,
+   `hourly-uat-validation` as desired.
+
+5. **Disable the corresponding GHA workflow.** Once a local driver is
+   stable, rename its GHA counterpart (`mv foo.yml foo.yml.disabled`)
+   or add `if: false` at the job level. Keeping the YAML around makes
+   it easy to flip back to GHA-only if the local machine is down.
+
+## Pause switch
+
+Touch `~/.fhir-place-pause` to skip every local runner on its next
+trigger. Remove the file to resume. The pause file is also respected
+by the existing `dispatch-engineer.sh` shim.
+
+## Smoke test
+
+```bash
+# Run a driver by hand to verify it works without waiting for the cron
+~/src/fhir-place/scripts/local/daily-pm-triage.sh
+# tail the log it just wrote
+ls -t ~/src/fhir-place/logs/daily-pm-triage-*.log | head -1 | xargs tail -50
+```
+
+If you get "missing GITHUB_TOKEN", the keychain step didn't take. If
+you get "claude: command not found", install via `npm i -g claude` and
+log in.
+
+## Tradeoffs vs GHA
+
+| | local (this directory) | GHA |
+|---|---|---|
+| Billing | Claude Max subscription | per-token API spend |
+| Always-on | needs your machine awake | always |
+| Logs | `$REPO_ROOT/logs/*.log` | Actions tab |
+| Trigger | launchd cron + (forthcoming) poll daemon | GitHub events directly |
+| Security | runs as you, with your secrets in keychain | runs in sandboxed runner with repo secrets |
+
+The pattern is: when a workflow is steady and predictable (the cron
+ones), local runs are cheap. When a workflow needs to respond to
+real-time GitHub events (slash commands, new PRs), GHA is more
+responsive — until the poll daemon ships.

--- a/scripts/local/daily-doc-sync.sh
+++ b/scripts/local/daily-doc-sync.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Local driver for the daily docs-sync prompt. Replaces the GHA
+# `daily-doc-sync.yml` workflow for local execution.
+# See scripts/run-prompt-locally.sh for the shared runner.
+
+set -Eeuo pipefail
+exec "$(dirname "$0")/../run-prompt-locally.sh" daily-doc-sync \
+  --max-turns 100 \
+  --allowedTools "Read,Edit,Write,Grep,Glob,mcp__github__*,Bash(git:*),Bash(gh:*)"

--- a/scripts/local/daily-pm-triage.sh
+++ b/scripts/local/daily-pm-triage.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Local driver for the daily PM triage prompt. Replaces the GHA
+# `daily-pm-triage.yml` workflow for local execution.
+# See scripts/run-prompt-locally.sh for the shared runner.
+
+set -Eeuo pipefail
+exec "$(dirname "$0")/../run-prompt-locally.sh" daily-pm-triage \
+  --max-turns 80 \
+  --allowedTools "Read,Grep,Glob,mcp__github__*,Bash(gh:*)"

--- a/scripts/local/daily-qa-pass.sh
+++ b/scripts/local/daily-qa-pass.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Local driver for the daily QA pass prompt. Replaces the GHA
+# `daily-qa-pass.yml` workflow for local execution.
+#
+# This one is heavier — it runs the demo app and walks it with
+# Playwright. Allows more tools and a higher turn budget.
+#
+# See scripts/run-prompt-locally.sh for the shared runner.
+
+set -Eeuo pipefail
+exec "$(dirname "$0")/../run-prompt-locally.sh" daily-qa-pass \
+  --max-turns 200 \
+  --allowedTools "Read,Edit,Write,Bash,Grep,Glob,Agent,mcp__github__*"

--- a/scripts/local/engineer-dispatch.sh
+++ b/scripts/local/engineer-dispatch.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Local driver for the engineer-dispatch prompt. Replaces the GHA
+# `hourly-engineer-dispatch.yml` workflow for local execution.
+# See scripts/run-prompt-locally.sh for the shared runner.
+
+set -Eeuo pipefail
+exec "$(dirname "$0")/../run-prompt-locally.sh" hourly-engineer-dispatch \
+  --max-turns 300 \
+  --allowedTools "Read,Edit,Write,Bash,Grep,Glob,Agent,mcp__github__*" \
+  --disallowedTools "AskUserQuestion,ExitPlanMode"

--- a/scripts/local/event-dispatch-engineer.sh
+++ b/scripts/local/event-dispatch-engineer.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Local driver for the dispatch-engineer-on-issue prompt. Fires when
+# poll-events.sh spots a `/dispatch-engineer` comment on an issue from a
+# repo collaborator. Argument: the issue number.
+
+set -Eeuo pipefail
+
+ISSUE="${1:-}"
+if [[ -z "$ISSUE" ]]; then
+  echo "usage: $0 <issue-number>" >&2
+  exit 2
+fi
+
+exec "$(dirname "$0")/../run-prompt-locally.sh" dispatch-engineer-on-issue \
+  --for "issue #$ISSUE" \
+  --max-turns 200 \
+  --allowedTools "Read,Edit,Write,Bash,Grep,Glob,Agent,mcp__github__*"

--- a/scripts/local/event-issue-review.sh
+++ b/scripts/local/event-issue-review.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Local driver for the issue-review prompt. Fires when poll-events.sh
+# spots a newly-opened issue. Argument: the issue number.
+
+set -Eeuo pipefail
+
+ISSUE="${1:-}"
+if [[ -z "$ISSUE" ]]; then
+  echo "usage: $0 <issue-number>" >&2
+  exit 2
+fi
+
+exec "$(dirname "$0")/../run-prompt-locally.sh" issue-review \
+  --for "issue #$ISSUE" \
+  --max-turns 60 \
+  --allowedTools "Read,Grep,Glob,Agent,mcp__github__*"

--- a/scripts/local/event-pr-review.sh
+++ b/scripts/local/event-pr-review.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Local driver for the pr-review prompt. Fires when poll-events.sh
+# spots a non-draft PR without a pr-review:bot marker. Argument: the
+# PR number.
+
+set -Eeuo pipefail
+
+PR="${1:-}"
+if [[ -z "$PR" ]]; then
+  echo "usage: $0 <pr-number>" >&2
+  exit 2
+fi
+
+exec "$(dirname "$0")/../run-prompt-locally.sh" pr-review \
+  --for "PR #$PR" \
+  --max-turns 40 \
+  --allowedTools "Read,Grep,Glob,Agent,mcp__github__*,Bash(gh pr review:*)"

--- a/scripts/local/event-resolve-conflicts.sh
+++ b/scripts/local/event-resolve-conflicts.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Local driver for the pr-resolve-conflicts prompt. Fires when
+# poll-events.sh spots a `/resolve-conflicts` comment on a PR from a
+# repo collaborator. Argument: the PR number.
+
+set -Eeuo pipefail
+
+PR="${1:-}"
+if [[ -z "$PR" ]]; then
+  echo "usage: $0 <pr-number>" >&2
+  exit 2
+fi
+
+exec "$(dirname "$0")/../run-prompt-locally.sh" pr-resolve-conflicts \
+  --for "PR #$PR" \
+  --max-turns 100 \
+  --allowedTools "Read,Edit,Write,Bash,Grep,Glob,mcp__github__*"

--- a/scripts/local/hourly-uat-validation.sh
+++ b/scripts/local/hourly-uat-validation.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Local driver for the hourly UAT validation prompt. Replaces the GHA
+# `hourly-uat-validation.yml` workflow for local execution.
+#
+# Walks each open PR's "UAT on live staging" checklist against the
+# deployed staging URL, sets `uat: passed` / `uat: failed` labels,
+# files out-of-scope bugs.
+#
+# See scripts/run-prompt-locally.sh for the shared runner.
+
+set -Eeuo pipefail
+exec "$(dirname "$0")/../run-prompt-locally.sh" hourly-uat-validation \
+  --max-turns 200 \
+  --allowedTools "Read,Edit,Write,Bash,Grep,Glob,Agent,mcp__github__*"

--- a/scripts/poll-events.sh
+++ b/scripts/poll-events.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Polls GitHub for events that the GHA event-triggered workflows would
+# react to (issue opened, PR opened/ready, /dispatch-engineer comment,
+# /resolve-conflicts comment) and dispatches the corresponding local
+# event driver under scripts/local/.
+#
+# Runs as a long-lived launchd job. State lives in
+# ~/.fhir-place-state/poll-events.json (last-poll timestamp per event
+# stream). Dedup leverages either the prompt's own comment-marker
+# convention (e.g. `<!-- issue-review:pm -->`) or an emoji reaction we
+# add to the triggering comment.
+#
+# Pause: respects ~/.fhir-place-pause (same kill switch as the cron
+# drivers). Touch it to silence everything.
+#
+# Auth: GitHub PAT from macOS keychain (same as the cron drivers). No
+# ANTHROPIC_API_KEY — each dispatched driver runs claude with OAuth.
+
+set -Eeuo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/src/fhir-place}"
+REPO="${REPO:-danielsperoniteam/fhir-place}"
+PAUSE_FILE="${PAUSE_FILE:-$HOME/.fhir-place-pause}"
+STATE_DIR="${STATE_DIR:-$HOME/.fhir-place-state}"
+STATE_FILE="$STATE_DIR/poll-events.json"
+LOG_DIR="${LOG_DIR:-$REPO_ROOT/logs}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-60}"
+PHONE="${PHONE:-+15082827897}"
+
+export PATH="$HOME/Library/pnpm:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+export GITHUB_TOKEN="${GITHUB_TOKEN:-$(security find-generic-password -s github-pat-fhir-place -a "$USER" -w 2>/dev/null || true)}"
+export GH_TOKEN="$GITHUB_TOKEN"
+
+if [[ -z "$GITHUB_TOKEN" ]]; then
+  echo "missing GITHUB_TOKEN" >&2
+  exit 2
+fi
+
+mkdir -p "$LOG_DIR" "$STATE_DIR"
+LOG_FILE="$LOG_DIR/poll-events.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+# Single-instance lock — only one poll daemon at a time.
+LOCK_DIR="/tmp/fhir-place-poll-events.lock"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  STALE_PID="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+  if [[ -n "$STALE_PID" ]] && ! kill -0 "$STALE_PID" 2>/dev/null; then
+    rm -rf "$LOCK_DIR"
+    mkdir "$LOCK_DIR"
+  else
+    echo "another poll-events daemon is running (pid ${STALE_PID:-?})"
+    exit 0
+  fi
+fi
+echo $$ > "$LOCK_DIR/pid"
+trap 'rm -rf "$LOCK_DIR"' EXIT
+
+# Bootstrap watermarks: first run defaults each stream to "now minus
+# 10 minutes" so we don't replay history. Subsequent runs read the
+# file.
+if [[ ! -f "$STATE_FILE" ]]; then
+  TEN_MIN_AGO=$(date -u -v-10M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+                || date -u --date='10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+  jq -n --arg t "$TEN_MIN_AGO" '{
+    issues_opened: $t,
+    prs_ready: $t,
+    comments: $t
+  }' > "$STATE_FILE"
+  echo "Initialized state at $STATE_FILE (watermarks = $TEN_MIN_AGO)"
+fi
+
+# A collaborator's repo association — used to gate slash commands so
+# random commenters can't trigger expensive runs.
+is_collaborator() {
+  local assoc="$1"
+  case "$assoc" in
+    OWNER|MEMBER|COLLABORATOR) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Mark a comment as handled by adding a checkmark reaction. Idempotent;
+# if we've already reacted, GitHub returns the same reaction.
+mark_handled() {
+  local comment_id="$1"
+  gh api -X POST "repos/$REPO/issues/comments/$comment_id/reactions" \
+    -f content=eyes >/dev/null 2>&1 || true
+}
+
+# Check if a comment already has our eyes reaction (= we already
+# handled this slash command).
+already_handled() {
+  local comment_id="$1"
+  local me
+  me=$(gh api user --jq '.login' 2>/dev/null || echo "")
+  gh api "repos/$REPO/issues/comments/$comment_id/reactions" \
+    --jq "[.[] | select(.content == \"eyes\" and .user.login == \"$me\")] | length" \
+    2>/dev/null | grep -q '^[1-9]'
+}
+
+# Has the issue-review prompt already left its marker on this issue?
+issue_already_reviewed() {
+  local issue="$1"
+  gh api "repos/$REPO/issues/$issue/comments" \
+    --jq '[.[] | select(.body | contains("<!-- issue-review:"))] | length' \
+    2>/dev/null | grep -q '^[1-9]'
+}
+
+# Has the pr-review prompt already left its review on this PR?
+pr_already_reviewed() {
+  local pr="$1"
+  gh api "repos/$REPO/pulls/$pr/reviews" \
+    --jq '[.[] | select(.body | contains("<!-- pr-review:bot -->"))] | length' \
+    2>/dev/null | grep -q '^[1-9]'
+}
+
+dispatch_async() {
+  # Fire-and-forget the driver. The driver's own lock prevents
+  # double-runs; we just want the poll loop to stay responsive.
+  local script="$1"
+  shift
+  ( "$script" "$@" & ) >/dev/null 2>&1
+  echo "→ dispatched: $script $*"
+}
+
+poll_once() {
+  local now_iso
+  now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  if [[ -f "$PAUSE_FILE" ]]; then
+    return
+  fi
+
+  local prev
+  prev=$(cat "$STATE_FILE")
+
+  local issues_since prs_since comments_since
+  issues_since=$(echo "$prev" | jq -r '.issues_opened')
+  prs_since=$(echo "$prev" | jq -r '.prs_ready')
+  comments_since=$(echo "$prev" | jq -r '.comments')
+
+  # --- 1. New issues opened → fire issue-review ---
+  local new_issues
+  new_issues=$(gh api "repos/$REPO/issues?since=$issues_since&state=open&sort=created&direction=asc&per_page=20" \
+    --jq '[.[] | select(.pull_request == null) | {number, created_at, user: .user.login}]' \
+    2>/dev/null || echo '[]')
+  echo "$new_issues" | jq -c '.[]' | while read -r row; do
+    local num user
+    num=$(echo "$row" | jq -r '.number')
+    user=$(echo "$row" | jq -r '.user')
+    if issue_already_reviewed "$num"; then
+      echo "skip issue-review #$num (already reviewed)"
+      continue
+    fi
+    echo "issue #$num opened by $user → issue-review"
+    dispatch_async "$REPO_ROOT/scripts/local/event-issue-review.sh" "$num"
+  done
+
+  # --- 2. PRs with non-draft state, no bot review yet → pr-review ---
+  # Cheap heuristic: list open PRs updated since last poll, draft=false,
+  # then skip those already-reviewed.
+  local prs
+  prs=$(gh api "repos/$REPO/pulls?state=open&sort=updated&direction=desc&per_page=30" \
+    --jq "[.[] | select(.draft == false and .updated_at > \"$prs_since\") | {number, head_user: .user.login, updated_at}]" \
+    2>/dev/null || echo '[]')
+  echo "$prs" | jq -c '.[]' | while read -r row; do
+    local num
+    num=$(echo "$row" | jq -r '.number')
+    if pr_already_reviewed "$num"; then
+      continue
+    fi
+    echo "PR #$num non-draft, no bot review → pr-review"
+    dispatch_async "$REPO_ROOT/scripts/local/event-pr-review.sh" "$num"
+  done
+
+  # --- 3. Slash commands in issue / PR comments ---
+  # We poll the comments endpoint with a since= filter, filter by body
+  # contents, gate on author_association, then react to mark handled.
+  local comments
+  comments=$(gh api "repos/$REPO/issues/comments?since=$comments_since&sort=created&direction=asc&per_page=30" \
+    --jq '[.[] | {id, body, author_association, user: .user.login, html_url, issue_url}]' \
+    2>/dev/null || echo '[]')
+  echo "$comments" | jq -c '.[]' | while read -r row; do
+    local cid body assoc url issue_url num
+    cid=$(echo "$row" | jq -r '.id')
+    body=$(echo "$row" | jq -r '.body')
+    assoc=$(echo "$row" | jq -r '.author_association')
+    url=$(echo "$row" | jq -r '.html_url')
+    issue_url=$(echo "$row" | jq -r '.issue_url')
+    num=$(basename "$issue_url")
+
+    if ! is_collaborator "$assoc"; then
+      continue
+    fi
+
+    if echo "$body" | grep -qE '(^|[[:space:]])/dispatch-engineer([[:space:]]|$)'; then
+      # /dispatch-engineer is issue-only per the workflow's docs.
+      if echo "$url" | grep -q '/issues/'; then
+        if already_handled "$cid"; then continue; fi
+        echo "/dispatch-engineer on issue #$num (comment $cid) → engineer dispatch"
+        mark_handled "$cid"
+        dispatch_async "$REPO_ROOT/scripts/local/event-dispatch-engineer.sh" "$num"
+      fi
+    fi
+
+    if echo "$body" | grep -qE '(^|[[:space:]])/resolve-conflicts([[:space:]]|$)'; then
+      # /resolve-conflicts is PR-only.
+      if echo "$url" | grep -q '/pull/'; then
+        if already_handled "$cid"; then continue; fi
+        echo "/resolve-conflicts on PR #$num (comment $cid) → conflict resolver"
+        mark_handled "$cid"
+        dispatch_async "$REPO_ROOT/scripts/local/event-resolve-conflicts.sh" "$num"
+      fi
+    fi
+  done
+
+  # Update watermarks to `now`. Slightly racy (a comment posted between
+  # `now_iso` capture and the GH query won't be picked up until the next
+  # poll), which is fine at 60s cadence.
+  jq -n --arg issues "$now_iso" --arg prs "$now_iso" --arg comments "$now_iso" '{
+    issues_opened: $issues,
+    prs_ready: $prs,
+    comments: $comments
+  }' > "$STATE_FILE"
+}
+
+echo "=== poll-events daemon started (interval=${POLL_INTERVAL_SECONDS}s) ==="
+while true; do
+  if ! poll_once; then
+    echo "::warning::poll iteration failed; will retry"
+  fi
+  sleep "$POLL_INTERVAL_SECONDS"
+done

--- a/scripts/run-prompt-locally.sh
+++ b/scripts/run-prompt-locally.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Generic local prompt runner. Invokes `claude --print` headlessly with a
+# prompt file from docs/prompts/, falling back to the saved OAuth session
+# (Claude Max subscription) rather than ANTHROPIC_API_KEY.
+#
+# Usage:
+#   scripts/run-prompt-locally.sh <prompt-file> [--allowedTools T,U,V] [--max-turns N] [--extra-arg ...]
+#
+# Required env:
+#   GITHUB_TOKEN — fine-grained PAT with the perms the prompt needs.
+#                  (We never set ANTHROPIC_API_KEY on purpose.)
+#
+# Optional env:
+#   REPO_ROOT — defaults to $HOME/src/fhir-place
+#   PAUSE_FILE — defaults to $HOME/.fhir-place-pause (touch to disable all
+#                local runners at once)
+#   LOG_DIR — defaults to $REPO_ROOT/logs
+#   LOCK_NAME — defaults to the prompt's basename; used to namespace the
+#               single-run lock so two different prompts can run at the
+#               same time but two copies of the same prompt cannot
+#
+# Design choices:
+#   - launchd-friendly: explicit PATH, exec >/2 redirect for tee-to-log,
+#     atomic mkdir lock with stale-PID recovery.
+#   - No ANTHROPIC_API_KEY in env so `claude` uses the OAuth session from
+#     `claude login`. Bill against the Max subscription, not API tokens.
+#   - Errors notify via iMessage on failure (best-effort; never blocks
+#     exit).
+#   - Logs auto-trim to ~14 days.
+#
+# See scripts/local/*.sh for per-prompt drivers that call this.
+
+set -Eeuo pipefail
+
+PROMPT_FILE="${1:-}"
+if [[ -z "$PROMPT_FILE" ]]; then
+  echo "usage: $0 <prompt-file> [--allowedTools ...] [--max-turns N] [--extra-arg ...]" >&2
+  exit 2
+fi
+shift
+
+REPO_ROOT="${REPO_ROOT:-$HOME/src/fhir-place}"
+LOG_DIR="${LOG_DIR:-$REPO_ROOT/logs}"
+PAUSE_FILE="${PAUSE_FILE:-$HOME/.fhir-place-pause}"
+PHONE="${PHONE:-+15082827897}"
+
+# Path: launchd does not inherit shell PATH. Cover Apple Silicon, Intel,
+# npm global, pnpm self-install, and ~/.local/bin.
+export PATH="$HOME/Library/pnpm:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+# Pause file is the global kill switch — every local runner respects it.
+if [[ -f "$PAUSE_FILE" ]]; then
+  echo "pause file present at $PAUSE_FILE — skipping run for $PROMPT_FILE"
+  exit 0
+fi
+
+# GitHub PAT from macOS keychain. Same keychain entry the engineer-dispatch
+# driver uses, so a single one-time setup covers every prompt.
+export GITHUB_TOKEN="${GITHUB_TOKEN:-$(security find-generic-password -s github-pat-fhir-place -a "$USER" -w 2>/dev/null || true)}"
+export GH_TOKEN="$GITHUB_TOKEN"
+
+if [[ -z "$GITHUB_TOKEN" ]]; then
+  echo "missing GITHUB_TOKEN (try: security add-generic-password -s github-pat-fhir-place -a \"$USER\" -w '<your-PAT>')" >&2
+  exit 2
+fi
+
+PROMPT_BASENAME="$(basename "$PROMPT_FILE" .md)"
+LOCK_NAME="${LOCK_NAME:-$PROMPT_BASENAME}"
+LOCK_DIR="/tmp/fhir-place-${LOCK_NAME}.lock"
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+LOG_FILE="$LOG_DIR/${PROMPT_BASENAME}-${RUN_ID}.log"
+
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_FILE") 2>&1
+echo "=== run $RUN_ID :: $PROMPT_FILE ==="
+
+# Single-run lock per prompt. Atomic on POSIX. Stale-lock recovery checks
+# whether the recorded PID is still alive.
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  STALE_PID="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+  if [[ -n "$STALE_PID" ]] && ! kill -0 "$STALE_PID" 2>/dev/null; then
+    echo "stale lock from pid $STALE_PID — clearing"
+    rm -rf "$LOCK_DIR"
+    mkdir "$LOCK_DIR"
+  else
+    echo "another run is in flight (pid ${STALE_PID:-unknown}) — skipping"
+    exit 0
+  fi
+fi
+echo $$ > "$LOCK_DIR/pid"
+trap 'rm -rf "$LOCK_DIR"' EXIT
+
+cd "$REPO_ROOT"
+
+# Refuse to run with a dirty primary checkout — likely the human is mid-edit.
+# Prompts that need to mutate the tree create worktrees of their own.
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "dirty working tree at $REPO_ROOT — skipping"
+  exit 0
+fi
+
+git fetch origin --prune --tags --quiet
+git worktree prune
+
+# Find the prompt file. Accept either an absolute path, a repo-relative
+# path, or a bare basename (looked up under docs/prompts/).
+RESOLVED_PROMPT=""
+if [[ -f "$PROMPT_FILE" ]]; then
+  RESOLVED_PROMPT="$PROMPT_FILE"
+elif [[ -f "$REPO_ROOT/$PROMPT_FILE" ]]; then
+  RESOLVED_PROMPT="$REPO_ROOT/$PROMPT_FILE"
+elif [[ -f "$REPO_ROOT/docs/prompts/$PROMPT_FILE" ]]; then
+  RESOLVED_PROMPT="$REPO_ROOT/docs/prompts/$PROMPT_FILE"
+elif [[ -f "$REPO_ROOT/docs/prompts/${PROMPT_FILE}.md" ]]; then
+  RESOLVED_PROMPT="$REPO_ROOT/docs/prompts/${PROMPT_FILE}.md"
+else
+  echo "prompt file not found: $PROMPT_FILE" >&2
+  exit 2
+fi
+
+# Worktree-parent so prompts that create worktrees under $(dirname $REPO_ROOT)
+# (engineer-dispatch convention) can edit them.
+WORKTREE_PARENT="$(dirname "$REPO_ROOT")"
+
+# claude refuses to read ANTHROPIC_API_KEY if it isn't set — that's the
+# OAuth fallback path. The launchd plist for this script should not set
+# the API key either. To double-check, explicitly unset here.
+unset ANTHROPIC_API_KEY
+
+echo "prompt: $RESOLVED_PROMPT"
+echo "claude args: $*"
+
+set +e
+claude \
+  --print \
+  --add-dir "$WORKTREE_PARENT" \
+  --dangerously-skip-permissions \
+  "$@" \
+  < "$RESOLVED_PROMPT"
+RC=$?
+set -e
+
+if [[ $RC -ne 0 ]]; then
+  osascript -e "tell application \"Messages\" to send \"$PROMPT_BASENAME failed rc=$RC run=$RUN_ID — see $LOG_FILE\" to participant \"$PHONE\" of (service 1 whose service type is iMessage)" 2>/dev/null || true
+fi
+
+# Trim old logs (~14 days).
+find "$LOG_DIR" -name "${PROMPT_BASENAME}-*.log" -mtime +14 -delete 2>/dev/null || true
+
+echo "=== run $RUN_ID complete (rc=$RC) ==="
+exit "$RC"

--- a/scripts/run-prompt-locally.sh
+++ b/scripts/run-prompt-locally.sh
@@ -34,10 +34,29 @@ set -Eeuo pipefail
 
 PROMPT_FILE="${1:-}"
 if [[ -z "$PROMPT_FILE" ]]; then
-  echo "usage: $0 <prompt-file> [--allowedTools ...] [--max-turns N] [--extra-arg ...]" >&2
+  echo "usage: $0 <prompt-file> [--for <target>] [--allowedTools ...] [--max-turns N] [extra-arg ...]" >&2
   exit 2
 fi
 shift
+
+# Optional --for <target>: prepended as a one-line prologue before the
+# prompt body, telling claude what specific issue/PR this run is for.
+# Used by event-triggered drivers (issue-review, pr-review,
+# dispatch-engineer-on-issue, pr-resolve-conflicts) to scope the run.
+TARGET=""
+CLAUDE_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --for)
+      TARGET="$2"
+      shift 2
+      ;;
+    *)
+      CLAUDE_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
 
 REPO_ROOT="${REPO_ROOT:-$HOME/src/fhir-place}"
 LOG_DIR="${LOG_DIR:-$REPO_ROOT/logs}"
@@ -65,10 +84,14 @@ if [[ -z "$GITHUB_TOKEN" ]]; then
 fi
 
 PROMPT_BASENAME="$(basename "$PROMPT_FILE" .md)"
-LOCK_NAME="${LOCK_NAME:-$PROMPT_BASENAME}"
+# When a target is set (event-triggered run), namespace the lock and log
+# by target too so two event runs against different PRs/issues don't
+# block each other.
+TARGET_SLUG="$(echo "$TARGET" | tr -c 'A-Za-z0-9' '-' | sed 's/-\+/-/g; s/^-//; s/-$//')"
+LOCK_NAME="${LOCK_NAME:-${PROMPT_BASENAME}${TARGET_SLUG:+-$TARGET_SLUG}}"
 LOCK_DIR="/tmp/fhir-place-${LOCK_NAME}.lock"
 RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
-LOG_FILE="$LOG_DIR/${PROMPT_BASENAME}-${RUN_ID}.log"
+LOG_FILE="$LOG_DIR/${PROMPT_BASENAME}${TARGET_SLUG:+-$TARGET_SLUG}-${RUN_ID}.log"
 
 mkdir -p "$LOG_DIR"
 exec > >(tee -a "$LOG_FILE") 2>&1
@@ -128,15 +151,26 @@ WORKTREE_PARENT="$(dirname "$REPO_ROOT")"
 unset ANTHROPIC_API_KEY
 
 echo "prompt: $RESOLVED_PROMPT"
-echo "claude args: $*"
+[[ -n "$TARGET" ]] && echo "target: $TARGET"
+echo "claude args: ${CLAUDE_ARGS[*]:-(none)}"
+
+# Compose stdin: optional prologue line (when --for was set) + the
+# prompt file. The prologue is what tells claude "execute for #N";
+# the prompt body has the per-prompt instructions.
+build_stdin() {
+  if [[ -n "$TARGET" ]]; then
+    echo "Execute the instructions in the prompt below for $TARGET. Do not modify the prompt file itself."
+    echo
+  fi
+  cat "$RESOLVED_PROMPT"
+}
 
 set +e
-claude \
+build_stdin | claude \
   --print \
   --add-dir "$WORKTREE_PARENT" \
   --dangerously-skip-permissions \
-  "$@" \
-  < "$RESOLVED_PROMPT"
+  "${CLAUDE_ARGS[@]}"
 RC=$?
 set -e
 


### PR DESCRIPTION
## Summary

Follow-up to #479. Extends the local-runner pattern to the four event-triggered SDLC prompts (the ones the cron drivers don't cover):

- `issue-review` — new issue opened
- `pr-review` — non-draft PR without a bot review
- `dispatch-engineer-on-issue` — `/dispatch-engineer` comment on issue
- `pr-resolve-conflicts` — `/resolve-conflicts` comment on PR

## How it works

`scripts/poll-events.sh` is a long-lived launchd daemon (`KeepAlive: true`). Every 60s it queries GitHub for:

1. New issues since the last poll → fires `event-issue-review.sh <issue>`
2. Open non-draft PRs updated since last poll → fires `event-pr-review.sh <pr>`
3. Issue comments containing `/dispatch-engineer` from a collaborator → fires `event-dispatch-engineer.sh <issue>`
4. PR comments containing `/resolve-conflicts` from a collaborator → fires `event-resolve-conflicts.sh <pr>`

**Watermark state** is stored at `~/.fhir-place-state/poll-events.json` (per-stream `since` timestamps). First-run defaults to "now minus 10 minutes" so history isn't replayed.

**Dedup** is two-layer:
- Issue/PR review prompts: skip if the prompt's existing `<!-- issue-review:* -->` / `<!-- pr-review:bot -->` marker comment is already on the target.
- Slash commands: add an 👀 (`eyes`) reaction to the triggering comment when we dispatch. Already-reacted comments are skipped.

**Collaborator gate** for slash commands: only `OWNER` / `MEMBER` / `COLLABORATOR` author associations trigger a run. Stops drive-by `/dispatch-engineer` comments from random GH users from burning subscription tokens.

## Changes

- **New** `scripts/poll-events.sh` — the daemon (~230 lines, mostly comment).
- **New** `scripts/local/event-issue-review.sh`, `event-pr-review.sh`, `event-dispatch-engineer.sh`, `event-resolve-conflicts.sh` — thin wrappers, same shape as the cron drivers from #479. Each takes a PR/issue number as arg.
- **New** `scripts/launchd/com.fhir-place.poll-events.plist` — launchd template.
- **Extended** `scripts/run-prompt-locally.sh` — added `--for <target>` flag. When set, a one-line prologue is prepended to the prompt's stdin so claude knows which issue/PR the run is scoped to. Lock and log filenames also get target-namespaced (`issue-review-issue-470-<timestamp>.log`) so concurrent runs against different targets don't block.
- **Updated** `scripts/local/README.md` — documents the event-triggered side.

## Pause / kill switch

Touch `~/.fhir-place-pause` to silence both the cron drivers and this poll daemon at once. `rm` to resume.

## Test plan

1. After merge: install the launchd plist per the template comments.
2. Open a throwaway issue → confirm `poll-events.log` shows `issue #N opened → issue-review` and a fresh `issue-review-issue-N-*.log` appears within 60s.
3. Post `/dispatch-engineer` on a real ready issue → confirm an eyes reaction lands on the comment and the engineer dispatch fires.
4. Approve a PR → confirm `event-pr-review.sh` runs (note: the actual stack-approved-prs and pr-review behaviors are separate; this just confirms the poll daemon picks up the event).
5. Open #470 (which lacks a bot review) and confirm the daemon picks it up on next poll.

## Depends on

#479 — needs `scripts/run-prompt-locally.sh` and `scripts/local/*.sh` already in place. **Merge #479 first**, then merge this on top. (This branch is based on #479's branch, so it'll include those commits if #479 isn't merged first.)

## Out of scope

Disabling the corresponding GHA workflows. After at least one observed local run of each event type, a small follow-up PR can rename `.yml` → `.yml.disabled` for `issue-review.yml`, `pr-review.yml`, `dispatch-engineer-on-issue.yml`, `pr-resolve-conflicts.yml` so we don't double-bill.

## Screenshots

N/A — shell scripts + plist only.