### PR TITLE
feat(uat): 5-state UAT label machine with automated transitions

### DIFF
--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -202,19 +202,34 @@ these as embedded in issue bodies — do not repeat that mistake.
     steps for your change, the change is not ready — exit
     `needs-human` instead of opening the PR.
 
-11. **Request the preview deploy.** Apply the `uat: requested` label to
-    the PR. A downstream workflow watches for that label and pushes
-    your branch's build into the `/staging/` slot for UAT. Do not push
-    to `staging` yourself — branch discipline (rule 1) forbids it, and
-    the preview-deploy workflow serializes requests so two PRs don't
-    fight for the slot.
+11. **Apply the initial UAT label.** Two cases:
+    - **`uat: skip`** — the PR's UAT section reads `N/A — no
+      user-visible change` (pure infra / CI / docs / internal
+      refactor of unexported code). Apply `uat: skip` and you're done
+      with this step.
+    - **`uat: unable`** — the PR has real UAT steps. Apply
+      `uat: unable` to mark "opened but not yet on staging." The
+      label transitions to `uat: requested` after a CODEOWNER
+      approves the PR and `stack-approved-prs.yml` rebuilds staging
+      with it included; then the hourly UAT walker sets
+      `uat: complete` or `uat: needs-changes`.
 
-12. **Comment the link.** On the issue:
-    `Opened #<PR> — base: main, ready for review. Requested preview
-    deploy via \`uat: requested\` label; UAT will walk it against
-    https://danielsperoniteam.github.io/fhir-place/staging/ once the
-    deploy lands. PR will merge to main when CI is green and
-    \`uat: passed\` is set.`
+    Never apply `uat: requested` yourself — that label is owned by
+    the stack workflow.
+
+12. **Comment the link.** On the issue. For `uat: unable` PRs:
+    `Opened #<PR> — base: main, ready for review. Labeled \`uat: unable\`
+    (not yet on staging). Approval → \`stack-approved-prs.yml\` rebuilds
+    staging with this PR stacked → label flips to \`uat: requested\` →
+    hourly UAT walker validates against
+    https://danielsperoniteam.github.io/fhir-place/staging/ and sets
+    \`uat: complete\` or \`uat: needs-changes\` per outcome. PR merges
+    to main when CI is green and \`uat: complete\` is set.`
+
+    For `uat: skip` PRs:
+    `Opened #<PR> — base: main, ready for review. Labeled \`uat: skip\`
+    (no user-visible change). UAT walker skips this PR; merges to main
+    on CI green + CODEOWNER approval.`
 
 ## Exit table
 

--- a/.github/workflows/hourly-engineer-dispatch.yml
+++ b/.github/workflows/hourly-engineer-dispatch.yml
@@ -1,4 +1,4 @@
-# Hourly engineer-dispatch routine.
+# Hourly engineer-dispatch routine. :)
 #
 # Picks up to 3 ready issues from the backlog, hands each to the engineer
 # subagent (.claude/agents/engineer.md), opens draft PRs, and updates a

--- a/.github/workflows/stack-approved-prs.yml
+++ b/.github/workflows/stack-approved-prs.yml
@@ -146,6 +146,22 @@ jobs:
             fi
             if git merge --no-edit --no-ff -m "stage: include PR #$NUM" "$REF"; then
               echo "Stacked PR #$NUM"
+              # Transition the PR's UAT state: it's now on staging, awaiting
+              # the hourly UAT walker. Skip when the PR carries `uat: skip`
+              # (no user-visible change → no validation needed). Otherwise
+              # remove any prior `uat: unable` / `uat: needs-changes` /
+              # `uat: complete` so only `uat: requested` is set. Best-
+              # effort; label-missing errors are non-fatal.
+              if gh pr view "$NUM" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | any(. == "uat: skip")' 2>/dev/null | grep -q true; then
+                echo "  PR #$NUM has uat: skip — leaving label as-is"
+              else
+                gh pr edit "$NUM" --repo "$GITHUB_REPOSITORY" \
+                  --remove-label "uat: unable" \
+                  --remove-label "uat: needs-changes" \
+                  --remove-label "uat: complete" 2>/dev/null || true
+                gh pr edit "$NUM" --repo "$GITHUB_REPOSITORY" \
+                  --add-label "uat: requested" 2>/dev/null || true
+              fi
             else
               echo "::warning::PR #$NUM conflicts with staging; skipping. Manual rebase needed."
               git merge --abort

--- a/docs/prompts/hourly-uat-validation.md
+++ b/docs/prompts/hourly-uat-validation.md
@@ -97,6 +97,11 @@ already covered by `live-site-monitor.yml`.
 
 Drop any PR labelled `status: agent-paused`.
 
+**Drop any PR labelled `uat: skip`** — these declare "no user-visible
+change" in their UAT section and don't need validation. Leave the
+label as-is; do not post a comment. The PR will merge on CI green +
+CODEOWNER approval alone.
+
 For each remaining candidate, decide whether its changes are live on
 `/staging/` by checking whether its head SHA is reachable from the
 `staging` branch tip:
@@ -117,17 +122,26 @@ PR's existing comments for one whose body starts with the marker
 than 50 minutes **and** its `sha=<head-sha>` matches the current head
 SHA, skip the PR silently — nothing has changed since the last run.
 
-For each not-on-staging PR that is **not** silently deduped, post:
+For each not-on-staging PR that is **not** silently deduped, post the
+marker comment AND set the `uat: unable` label (removing any other
+`uat:` state). This signals that the PR is not yet validatable:
 
 ```
 <!-- uat-validation:run sha=<head-sha> at=<ISO> reason=not-on-staging -->
 
 UAT validation — <YYYY-MM-DD HH:MM UTC>
 
-PR head `<head-sha-short>` is not yet on the `staging` branch. Engineer
-needs to merge `<head-branch>` into `staging` so its changes deploy to
-`/staging/`; this routine will then validate the UAT items on the next
-hourly run. Run: <workflow run URL>
+PR head `<head-sha-short>` is not yet on the `staging` branch. PR needs
+CODEOWNER approval first; then `stack-approved-prs.yml` will rebuild
+staging with it stacked, and this routine will validate the UAT items
+on the next hourly run. Run: <workflow run URL>
+```
+
+Then transition labels (best-effort):
+
+```
+gh pr edit <N> --remove-label "uat: requested" --remove-label "uat: complete" --remove-label "uat: needs-changes"
+gh pr edit <N> --add-label    "uat: unable"
 ```
 
 Sort the on-staging survivors by oldest `updated_at` first and take
@@ -240,6 +254,30 @@ Rules for the checklist:
   both ends if needed.
 - Never include screenshots in the comment body. Reference the workflow
   run URL where artifacts are uploaded.
+
+### 3d.1 — set the outcome label
+
+After posting the checklist comment, transition the PR's `uat:` label
+based on what was walked. Remove all other `uat:` labels first
+(except `uat: skip` — never overwrite that, see Step 2):
+
+| Outcome | Label to set |
+| --- | --- |
+| Every checked UAT item passed AND no checklist box was left empty | `uat: complete` |
+| Any UAT item failed (a `[ ]` line in the "UAT items walked on staging" section with a note) | `uat: needs-changes` |
+| The PR declares `N/A — no user-visible change` and the engineer agent missed labelling `uat: skip` on open | `uat: skip` (also note in the comment "applied uat: skip retroactively") |
+| Subagent failed mid-walk (see 3e bail-out) | Leave existing label as-is; do not move to `needs-changes` on a failed walk |
+
+Best-effort commands; label-missing errors are non-fatal:
+
+```
+gh pr edit <N> --remove-label "uat: unable" --remove-label "uat: requested" --remove-label "uat: needs-changes" --remove-label "uat: complete"
+gh pr edit <N> --add-label    "uat: complete"   # or "uat: needs-changes"
+```
+
+The `uat: needs-changes` label is what `pr-fixup-dispatch.md` watches
+for to pick up the next fix — leaving it set is the handoff. The
+`uat: complete` label is the merge gate signal for Daniel.
 
 ### 3e. Bail-out conditions
 

--- a/docs/prompts/pr-fixup-dispatch.md
+++ b/docs/prompts/pr-fixup-dispatch.md
@@ -65,15 +65,20 @@ A PR is **fixup-eligible** when all of these hold:
 - does **not** have `status: in-progress` (already being worked)
 - does **not** have `status: agent-paused`
 - has at least one of:
+  - **`uat: needs-changes`** label — UAT validation found a failing
+    checklist item on `/staging/` and the hourly UAT walker flagged it
   - **Red CI** — latest CI run on the head_sha has `conclusion: failure`
   - **Unresolved review threads** — GraphQL query on `pullRequest.reviewThreads`
     returns at least one node with `isResolved: false`
 
 Sort by:
 
-1. Priority of the linked issue (via the `Closes #N` line in the PR body):
+1. **`uat: needs-changes` trigger first** — these PRs have already
+   been validated once and a regression slipped through; fixing them
+   restores a green pipeline faster than starting fresh work
+2. Priority of the linked issue (via the `Closes #N` line in the PR body):
    `P0` → `P1` → `P2` → `P3`
-2. `updated_at` ascending (oldest first — work the stalest)
+3. `updated_at` ascending (oldest first — work the stalest)
 
 Take the top **one**. If empty, jump to Step 5 (update tracking issue)
 and exit cleanly.
@@ -100,9 +105,10 @@ Pick the **action** based on what made the PR fixup-eligible:
 
 | Trigger | Action |
 | --- | --- |
+| `uat: needs-changes` | Find the latest `<!-- uat-validation:run … -->` comment on the PR. Extract the failing checklist items (lines starting with `[ ]` plus the one-line note below each). Dispatch the `engineer` subagent with `{pr_number, head_ref, action: "fix-uat", failing_items}`. The subagent reads the items, applies the smallest fix that addresses them, runs the contract, pushes to the existing branch. After the push, remove `uat: needs-changes` from the PR — the next stack rebuild + hourly UAT walk will re-evaluate and set `uat: complete` / `uat: needs-changes` / `uat: unable` per outcome. |
 | Red CI only | Dispatch the `engineer` subagent with `{pr_number, head_ref, action: "fix-ci"}` and the latest failing-job logs URL. The subagent reads the failing test/typecheck output, applies the smallest fix, runs the contract, pushes. |
 | Unresolved threads only | Read `docs/prompts/address-comments.md` and execute its Steps 1–6 against the PR. (Don't re-fire the `/address-comments` workflow — that costs another turn and creates a dispatch loop.) |
-| Both | Address comments first (per `docs/prompts/address-comments.md`). If the resulting commit also turns CI green, you're done. If CI is still red after, fall back to the `fix-ci` engineer dispatch. |
+| Mixed triggers | Address them in this order: `uat: needs-changes` → unresolved threads → red CI. The first commit may resolve later triggers — re-check before dispatching the next action. |
 
 In every case the engineer subagent's hard rules apply — branch
 discipline, no force-push, no deny-list paths, blast-radius caps,

--- a/scripts/launchd/com.fhir-place.hourly-engineer-dispatch.plist
+++ b/scripts/launchd/com.fhir-place.hourly-engineer-dispatch.plist
@@ -9,6 +9,11 @@
   array below with a single `<dict><key>Minute</key><integer>30</integer></dict>`
   once Daniel signs off.
 
+  Runs AFTER the pr-fixup dispatcher in each window (pr-fixup at 09:00 /
+  14:00, this at 09:30 / 14:30) so fixes to existing PRs get prioritized
+  over pulling new work from the backlog. The 30-min stagger also keeps
+  the two off the same Claude Max OAuth session simultaneously.
+
   See com.fhir-place.daily-pm-triage.plist for install steps.
 -->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -20,11 +25,11 @@
   <array>
     <dict>
       <key>Hour</key><integer>9</integer>
-      <key>Minute</key><integer>0</integer>
+      <key>Minute</key><integer>30</integer>
     </dict>
     <dict>
       <key>Hour</key><integer>14</integer>
-      <key>Minute</key><integer>0</integer>
+      <key>Minute</key><integer>30</integer>
     </dict>
   </array>
   <key>WorkingDirectory</key><string>__HOME__/src/fhir-place</string>

--- a/scripts/launchd/com.fhir-place.pr-fixup-dispatch.plist
+++ b/scripts/launchd/com.fhir-place.pr-fixup-dispatch.plist
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  PR fixup dispatcher at 09:30 and 14:30 ET (twice daily).
-
-  Staggered 30 minutes after the issue-mode engineer-dispatch (09:00 /
-  14:00) so the issue-mode run finishes first — both share the engineer
-  subagent and the same Claude Max OAuth session, so concurrent runs
-  risk rate-limiting. See `docs/prompts/pr-fixup-dispatch.md` for what
-  it does.
+  PR fixup dispatcher at 09:00 and 14:00 ET (twice daily). Runs
+  BEFORE the issue-mode engineer-dispatch in each window
+  (engineer-dispatch is at 09:30 / 14:30) so red-CI / unresolved-thread
+  / uat: needs-changes PRs are addressed before new work gets pulled
+  from the backlog. The 30-minute stagger keeps both runs off the
+  same Claude Max OAuth session simultaneously (rate-limit avoidance).
+  See `docs/prompts/pr-fixup-dispatch.md` for what it does.
 
   See com.fhir-place.daily-pm-triage.plist for install steps.
 -->
@@ -19,11 +19,11 @@
   <array>
     <dict>
       <key>Hour</key><integer>9</integer>
-      <key>Minute</key><integer>30</integer>
+      <key>Minute</key><integer>0</integer>
     </dict>
     <dict>
       <key>Hour</key><integer>14</integer>
-      <key>Minute</key><integer>30</integer>
+      <key>Minute</key><integer>0</integer>
     </dict>
   </array>
   <key>WorkingDirectory</key><string>__HOME__/src/fhir-place</string>


### PR DESCRIPTION
## Summary

Implements a UAT label state machine on PRs so every PR has a defined
next action — automated or human-assigned. Closes the ambiguity of
PRs sitting with no obvious owner between "engineer pushed it" and
"merged."

## States

| Label                  | Meaning                                                              | Next action                                                                |
|------------------------|----------------------------------------------------------------------|----------------------------------------------------------------------------|
| \`uat: unable\`          | PR opened but not yet on staging (awaiting CODEOWNER approval/stack) | None — flips to \`uat: requested\` once stacked onto staging                  |
| \`uat: requested\`       | PR is on staging, awaiting the UAT walker                            | Hourly UAT walker runs the checklist, transitions to complete / needs-changes |
| \`uat: complete\`        | Walker validated all checklist items                                 | Human (Daniel) merges                                                      |
| \`uat: needs-changes\`   | Walker found a failing checklist item                                | Next \`pr-fixup-dispatch\` run picks it up — **prioritized before new work** |
| \`uat: skip\`            | No user-visible change (docs/CI/scripts only)                        | None — workflows ignore it                                                 |

## Transitions

- **engineer.md (step 11)** applies the initial label on PR open:
  \`uat: skip\` if the PR template's UAT section reads "N/A — no user-visible change", otherwise \`uat: unable\`. Never applies \`uat: requested\` — that's owned by the stack workflow.
- **\`stack-approved-prs.yml\`** swaps \`uat: unable\` → \`uat: requested\` when the PR lands on staging. Respects \`uat: skip\` and leaves it alone.
- **\`hourly-uat-validation.md\` (the UAT walker)** writes the outcome: \`uat: complete\` on pass, \`uat: needs-changes\` on fail. Skips \`uat: skip\` PRs entirely. For PRs not on staging it posts a comment and sets \`uat: unable\`.
- **\`pr-fixup-dispatch.md\`** treats \`uat: needs-changes\` as a fixup trigger and **sorts those PRs first** so a regression gets fixed before any new issue is pulled from the backlog.

## Schedule swap

\`pr-fixup\` now runs at 09:00/14:00 ET (was 09:30/14:30), and \`engineer-dispatch\` runs at 09:30/14:30 (was 09:00/14:00). Rationale: fix existing PRs before pulling new work from the backlog. The 30-min stagger also keeps both runs off the same Claude Max OAuth session simultaneously.

## Test plan

- [x] All 5 \`uat:\` labels exist in the repo with descriptions + colors
- [x] All 17 open PRs bulk-labeled with their correct current state
- [x] Stack workflow respects \`uat: skip\` (verified jq query in script)
- [ ] Observe next scheduled \`stack-approved-prs.yml\` run flip a real \`uat: unable\` PR to \`uat: requested\`
- [ ] Observe next \`pr-fixup-dispatch\` cycle pick up a \`uat: needs-changes\` PR before new work

## Screenshots

N/A — no user-visible change. (Self-applies: this PR will get \`uat: skip\` once engineer.md lands.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)