### PR TITLE
fix(poll-events): gate dispatch on created_at, cap concurrency at 3

### DIFF
--- a/scripts/poll-events.sh
+++ b/scripts/poll-events.sh
@@ -26,6 +26,10 @@ STATE_FILE="$STATE_DIR/poll-events.json"
 LOG_DIR="${LOG_DIR:-$REPO_ROOT/logs}"
 POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-60}"
 PHONE="${PHONE:-+15082827897}"
+# Cap on concurrent event drivers. 3 matches the README's collision
+# analysis ("3 concurrent claude --print sessions = MEDIUM risk"). Raise
+# only if the Max plan can absorb it.
+MAX_CONCURRENT="${POLL_EVENTS_MAX_CONCURRENT:-3}"
 
 export PATH="$HOME/Library/pnpm:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 export GITHUB_TOKEN="${GITHUB_TOKEN:-$(security find-generic-password -s github-pat-fhir-place -a "$USER" -w 2>/dev/null || true)}"
@@ -119,6 +123,16 @@ dispatch_async() {
   # double-runs; we just want the poll loop to stay responsive.
   local script="$1"
   shift
+  # Backpressure: never run more than MAX_CONCURRENT event drivers at
+  # once. Count by command pattern because we detach with ( ... & ),
+  # which hides the child from the parent shell's job table.
+  while :; do
+    local count
+    count=$(pgrep -f "$REPO_ROOT/scripts/local/event-" 2>/dev/null | wc -l | tr -d ' ')
+    [[ "$count" -lt "$MAX_CONCURRENT" ]] && break
+    echo "→ concurrency cap reached ($count/$MAX_CONCURRENT); waiting 2s"
+    sleep 2
+  done
   ( "$script" "$@" & ) >/dev/null 2>&1
   echo "→ dispatched: $script $*"
 }
@@ -145,9 +159,17 @@ poll_once() {
     --jq '[.[] | select(.pull_request == null) | {number, created_at, user: .user.login}]' \
     2>/dev/null || echo '[]')
   echo "$new_issues" | jq -c '.[]' | while read -r row; do
-    local num user
+    local num user created_at
     num=$(echo "$row" | jq -r '.number')
     user=$(echo "$row" | jq -r '.user')
+    created_at=$(echo "$row" | jq -r '.created_at')
+    # GitHub's /issues `since=` parameter filters by updated_at, not
+    # created_at — so an old issue with a fresh label change comes back
+    # looking like "new." Gate explicitly on created_at to avoid
+    # re-reviewing stale issues every time someone re-labels them.
+    if [[ ! "$created_at" > "$issues_since" ]]; then
+      continue
+    fi
     if issue_already_reviewed "$num"; then
       echo "skip issue-review #$num (already reviewed)"
       continue


### PR DESCRIPTION
## Summary

Closes #487. Two related bugs in `scripts/poll-events.sh` discovered on first daemon bootstrap (2026-05-12 22:29 ET):

- `/issues?since=` filters by **updated_at**, not created_at. Old issues with a fresh label change qualified as "newly opened" and got dispatched. First run on this repo fired 20 stale issues into `event-issue-review.sh`.
- `dispatch_async` had no concurrency cap. All 20 fired simultaneously, well past the README's "3 concurrent = MEDIUM risk" guideline for the Max rate limit.

## Changes

- New env var `POLL_EVENTS_MAX_CONCURRENT` (default `3`) gates `dispatch_async` with a pgrep-based wait loop. Counts by command pattern because the `( cmd & )` subshell detach hides children from `$!`/jobs.
- Explicit `created_at > issues_since` gate inside the issue loop. Keeps the cheap `/issues` call (no switch to the search API).

## Test plan

- [x] Bash syntax check: `bash -n scripts/poll-events.sh`
- [x] Smoke test against live broken state (20 stale issues + watermark = 2026-05-13T02:33:10Z): only #486 and #487 dispatched (both genuinely created after the watermark). 20 stale ones correctly skipped.
- [x] No comments posted to GitHub during the smoke (runner's dirty-tree guard kept dispatched children from doing work — a happy accident I confirmed via the comments API).
- [ ] Post-merge: re-bootstrap daemon (`launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.fhir-place.poll-events.plist`) and observe a clean idle cycle.

## Screenshots

N/A — no user-visible change. Internal script only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
