### PR TITLE
fix(stack-approved-prs): pass GH_TOKEN to rebuild step

### DIFF
--- a/.github/workflows/stack-approved-prs.yml
+++ b/.github/workflows/stack-approved-prs.yml
@@ -123,6 +123,7 @@ jobs:
       - name: Rebuild staging from main + approved PRs
         env:
           PRS: ${{ steps.prs.outputs.prs }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Reset staging to main HEAD. Any prior staging history is
           # discarded — this branch is a deploy artifact, not source of


### PR DESCRIPTION
## Summary

The rebuild step calls \`gh pr view\` and \`gh pr edit\` to transition the UAT label from \`uat: unable\` to \`uat: requested\` after stacking — but neither call has \`GH_TOKEN\` in env, so both fail silently (errors swallowed by \`2>/dev/null\`).

## Repro

Run 25793895224 stacked PR #470 successfully at 10:38:40Z. Log shows "Stacked PR #470" immediately followed by \`##[endgroup]\` 63ms later — not enough time for two gh API calls. #470's label is still \`uat: complete\`, never moved to \`uat: requested\`.

## Fix

Add \`GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}\` to the rebuild step's \`env\` block (the \`prs\` step already has it).

## Test plan

- [ ] After merge, the next stack run flips an `uat: unable` PR's label to `uat: requested`

## Screenshots

N/A — CI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)