### PR TITLE
fix(stack-approved-prs): grant pull-requests: write so labels can flip

### DIFF
--- a/.github/workflows/stack-approved-prs.yml
+++ b/.github/workflows/stack-approved-prs.yml
@@ -151,17 +151,19 @@ jobs:
               # the hourly UAT walker. Skip when the PR carries `uat: skip`
               # (no user-visible change → no validation needed). Otherwise
               # remove any prior `uat: unable` / `uat: needs-changes` /
-              # `uat: complete` so only `uat: requested` is set. Best-
-              # effort; label-missing errors are non-fatal.
-              if gh pr view "$NUM" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | any(. == "uat: skip")' 2>/dev/null | grep -q true; then
+              # `uat: complete` so only `uat: requested` is set.
+              LABELS=$(gh pr view "$NUM" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name]')
+              if echo "$LABELS" | jq -e 'index("uat: skip") != null' >/dev/null; then
                 echo "  PR #$NUM has uat: skip — leaving label as-is"
               else
-                gh pr edit "$NUM" --repo "$GITHUB_REPOSITORY" \
-                  --remove-label "uat: unable" \
-                  --remove-label "uat: needs-changes" \
-                  --remove-label "uat: complete" 2>/dev/null || true
-                gh pr edit "$NUM" --repo "$GITHUB_REPOSITORY" \
-                  --add-label "uat: requested" 2>/dev/null || true
+                for LABEL in "uat: unable" "uat: needs-changes" "uat: complete"; do
+                  if echo "$LABELS" | jq -e --arg label "$LABEL" 'index($label) != null' >/dev/null; then
+                    gh pr edit "$NUM" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL"
+                  fi
+                done
+                if echo "$LABELS" | jq -e 'index("uat: requested") == null' >/dev/null; then
+                  gh pr edit "$NUM" --repo "$GITHUB_REPOSITORY" --add-label "uat: requested"
+                fi
               fi
             else
               echo "::warning::PR #$NUM conflicts with staging; skipping. Manual rebase needed."

--- a/.github/workflows/stack-approved-prs.yml
+++ b/.github/workflows/stack-approved-prs.yml
@@ -34,8 +34,8 @@ on:
     branches: [main]
 
 permissions:
-  contents: write     # force-push staging
-  pull-requests: read
+  contents: write       # force-push staging
+  pull-requests: write  # edit `uat:` labels after stacking
 
 concurrency:
   group: stack-approved-prs


### PR DESCRIPTION
## Summary

The workflow only had \`pull-requests: read\`, but the rebuild step calls \`gh pr edit --remove-label/--add-label\` to transition the UAT state. Without write permission those API calls returned 403; stderr was swallowed by \`2>/dev/null\` and non-zero exit by \`|| true\`, so the failure was silent.

## Proof

Run \`25829353576\` (today 22:10Z) successfully stacked #456, #469, #470, #473, #499, #525 onto staging. Issue events API shows **zero** \`labeled\` / \`unlabeled\` events from \`github-actions[bot]\` on any of those PRs. The label transitions never happened.

\`\`\`
gh api repos/danielsperoniteam/fhir-place/issues/456/events --jq '.[] | select(.event == "labeled" or .event == "unlabeled") | "\(.created_at) [\(.event)] \(.label.name) by \(.actor.login)"'
# 2026-05-11T14:19:02Z [labeled] codex by samsuffolksperoni
# 2026-05-11T14:19:02Z [labeled] codex-automation by samsuffolksperoni  
# 2026-05-13T01:38:50Z [labeled] uat: unable by samsuffolksperoni
# (no bot events post-stacking)
\`\`\`

## Background

Earlier today I thought the bug was a missing \`GH_TOKEN\` env (#517). That was a real bug — but insufficient. Auth needs both the token AND the permission scope.

## Test plan

- [ ] After merge, the next stack run flips one of the currently-stacked PRs' labels from \`uat: unable\` to \`uat: requested\`
- [ ] After that, the UAT walker has work to do (it filters on \`uat: requested\`)

## Screenshots

N/A — CI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)