### PR TITLE
docs(sdlc): ADR 0007 — testing and hardening SDLC infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm check:readme-goal-task
+      - run: pnpm test:scripts
       # Build the library first so the demo app can resolve its .d.ts files
       # during typecheck (demo depends on @fhir-place/react-fhir via workspace).
       - run: pnpm --filter @fhir-place/react-fhir build

--- a/.github/workflows/stack-approved-prs.yml
+++ b/.github/workflows/stack-approved-prs.yml
@@ -34,8 +34,8 @@ on:
     branches: [main]
 
 permissions:
-  contents: write       # force-push staging
-  pull-requests: write  # edit `uat:` labels after stacking
+  contents: write # force-push staging
+  pull-requests: write # edit `uat:` labels after stacking
 
 concurrency:
   group: stack-approved-prs
@@ -148,23 +148,11 @@ jobs:
             if git merge --no-edit --no-ff -m "stage: include PR #$NUM" "$REF"; then
               echo "Stacked PR #$NUM"
               # Transition the PR's UAT state: it's now on staging, awaiting
-              # the hourly UAT walker. Skip when the PR carries `uat: skip`
-              # (no user-visible change → no validation needed). Otherwise
-              # remove any prior `uat: unable` / `uat: needs-changes` /
-              # `uat: complete` so only `uat: requested` is set.
-              LABELS=$(gh pr view "$NUM" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name]')
-              if echo "$LABELS" | jq -e 'index("uat: skip") != null' >/dev/null; then
-                echo "  PR #$NUM has uat: skip — leaving label as-is"
-              else
-                for LABEL in "uat: unable" "uat: needs-changes" "uat: complete"; do
-                  if echo "$LABELS" | jq -e --arg label "$LABEL" 'index($label) != null' >/dev/null; then
-                    gh pr edit "$NUM" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL"
-                  fi
-                done
-                if echo "$LABELS" | jq -e 'index("uat: requested") == null' >/dev/null; then
-                  gh pr edit "$NUM" --repo "$GITHUB_REPOSITORY" --add-label "uat: requested"
-                fi
-              fi
+              # the hourly UAT walker. The script handles the `uat: skip`
+              # short-circuit and the requested/stale label cleanup. It is
+              # runtime-agnostic — same invocation works from GHA, launchd,
+              # tmux, or a cloud webhook receiver.
+              node scripts/staging/transition-uat-label.mjs "$NUM"
             else
               echo "::warning::PR #$NUM conflicts with staging; skipping. Manual rebase needed."
               git merge --abort

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage
 .env.local
 .DS_Store
 *.log
+logs/
 playwright-report
 test-results
 *.tsbuildinfo

--- a/docs/decisions/0007-testing-sdlc-infrastructure.md
+++ b/docs/decisions/0007-testing-sdlc-infrastructure.md
@@ -1,9 +1,11 @@
 # 0007 Testing and Hardening SDLC Infrastructure
 
 ## Status
+
 Accepted
 
 ## Context
+
 The SDLC pipeline is itself code: 22 workflows under `.github/workflows/`,
 a handful of bash blocks embedded in YAML, and prompt files in
 `docs/prompts/` that drive Claude routines. It has no static checks, no
@@ -19,7 +21,7 @@ in the wrong state until a human notices.
 
 1. `stack-approved-prs.yml` was missing `pull-requests: write`. Every
    `gh pr edit` returned 403; output was swallowed by `2>/dev/null ||
-   true`. PRs stacked onto staging but labels never flipped. Fixed in
+true`. PRs stacked onto staging but labels never flipped. Fixed in
    #545.[^1]
 2. The same workflow was missing `GH_TOKEN` on the rebuild step.
    Identical silent-failure pattern. Fixed in #517.
@@ -74,6 +76,26 @@ two pieces that hide bugs today. Both are pure functions hiding inside
 bash. Extract them to scripts under `scripts/sdlc/` with a Vitest unit
 suite. Bug #4 (label clobber) becomes a failing test, then a passing
 one.
+
+First shipped slice: `stack-approved-prs.yml` delegates UAT label
+transitioning to `scripts/staging/transition-uat-label.mjs`, covered by
+`node:test` via `pnpm test:scripts`. The script preserves
+`uat: complete`, `uat: needs-changes`, and `uat: skip` across staging
+rebuilds. Only PRs without a durable UAT state are moved into
+`uat: requested`.
+
+The default transition is configurable in
+`scripts/staging/uat-policy.json`. Normal mode is:
+
+```json
+{
+  "stackedPrUatDefault": "request"
+}
+```
+
+For a short "ship fast, do not queue UAT cards by default" period,
+change that value to `"skip"`. In that mode, stacked PRs without a
+durable UAT state get `uat: skip` instead of `uat: requested`.
 
 ### Layer 3: end-to-end smoke against a test-PR fixture
 
@@ -212,7 +234,8 @@ Each issue is sized to one PR and labelled `type: tech-debt` (mostly),
 `area: infra`, with a `human-review-needed:` level per
 `docs/sdlc/gaps.md`.
 
-[^1]: Receipts. PRs #545 and #517 carry the post-mortems for bugs #1
+[^1]:
+    Receipts. PRs #545 and #517 carry the post-mortems for bugs #1
     and #2. Bug #3 is visible in the timeline of any PR opened before
     #545 that received an approval after it merged: the workflow run
     was attached to the PR's head SHA, not main. Bug #4 is reproducible

--- a/docs/decisions/0007-testing-sdlc-infrastructure.md
+++ b/docs/decisions/0007-testing-sdlc-infrastructure.md
@@ -36,7 +36,9 @@ in the wrong state until a human notices.
    for every PR/issue write. The MCP server is only configured inside
    the workflow runner. After we moved the walker to a local launchd
    schedule, it began bailing each hour ("can't run cleanly without
-   MCP"). Cron is alive, producing no work.
+   MCP"). Cron is alive, producing no work. Resolution: migrate the
+   prompt to `gh` (see Decision below); `scripts/sync-labels.mjs` and
+   `scripts/staging/transition-uat-label.mjs` are the prior art.
 
 Common root: the machinery that builds and validates code has no
 machinery built and validating it. The blast radius is wide:
@@ -75,17 +77,23 @@ one.
 
 ### Layer 3: end-to-end smoke against a test-PR fixture
 
-A nightly workflow that:
+Two variants:
 
-1. Opens a throwaway PR against a sacrificial branch in this repo.
-2. Approves it via a bot identity.
-3. Asserts the expected label transitions land within N seconds and
-   that `staging` includes the PR's head.
-4. Closes the PR, cleans up.
+**3a. Local sim (per-PR, cheap).** A script that drives the SDLC
+state transitions sequentially via `gh` against a sacrificial PR, then
+invokes the extracted `scripts/sdlc/` and `scripts/staging/` modules
+in the order the workflow would. No webhook wait, no run minutes,
+cleans its own fixtures. Runs on every PR touching
+`.github/workflows/`. Catches state-machine bugs in seconds.
 
-This is the only layer that catches the "PR-ref carries a stale
-workflow" class of bug, since the failure is structural to GitHub's
-event model and only visible end-to-end.
+**3b. Nightly fixture (real event delivery).** Opens a throwaway PR,
+approves via a bot identity, asserts label transitions and `staging`
+inclusion within N seconds, cleans up. Only layer that catches bug #3
+(stale workflow on PR ref); 3a does not.
+
+Tradeoff: 3a is fast and free; 3b is slow, costs minutes, adds moving
+parts. Ship 3a first; treat 3b as a nightly safety net.
+**Judgment call:** if 3a holds and bug #3 stays rare, drop 3b.
 
 ### What we are not doing in this ADR
 
@@ -95,9 +103,11 @@ event model and only visible end-to-end.
   "move state out of labels." A proper state machine is its own
   decision with its own ADR if labels prove insufficient.
 - **No prompt-engine abstraction for the MCP-vs-`gh` coupling.**
-  The fix for bug #5 is to pick one: either configure MCP in the
-  local launchd plist, or rewrite the prompt to use `gh` everywhere.
-  Both are small; one of them ships, in a follow-up issue.
+  Decision: `gh` everywhere. `scripts/sync-labels.mjs` and
+  `scripts/staging/transition-uat-label.mjs` already follow this
+  pattern and have worked well. Bug #5 closes by migrating
+  `hourly-uat-validation.md` and any remaining `mcp__github__*` call
+  sites in `docs/prompts/` to `gh`. Tracked in #575.
 - **No "test every workflow" mandate.** Cover the five workflows
   that touch labels or `staging`. The other 17 are read-only or
   diagnostic; they fail loudly enough.
@@ -113,6 +123,12 @@ Positive:
   pipeline test. The pipeline tests itself.
 - Future workflow changes get a fast feedback loop. Iteration speed
   on the SDLC machinery goes up, not down.
+- The layer-2 extracts under `scripts/sdlc/` and the custom
+  permission/silent-failure lint from layer 1 are runtime-agnostic by
+  construction. They run the same under GitHub Actions, local
+  launchd, a webhook-driven server, or a cloud instance. That falls
+  out of the design rather than being a separate goal, but it matters
+  for where the runtime is heading (see "Out of scope / future").
 
 Negative:
 
@@ -136,6 +152,58 @@ Out of scope / future:
   blob on the PR or into a side table.
 - A reusable lint for the silent-failure idiom may want to live as a
   published action so other repos can adopt it. Out of scope here.
+- **Runtime is going to shift.** Today the SDLC automation runs in two
+  places: GitHub Actions for some workflows, and macOS launchd locally
+  for engineer dispatch, pr-fixup, and the UAT walker (moved off GHA
+  this week so the local Claude Max OAuth subscription bills instead
+  of an API key). Directionally we expect: GitHub webhooks delivered
+  to a server we own, initially still on the local machine driving
+  tmux, eventually on cloud instances. The hardening here is
+  deliberately friendly to that path. Tests assert behavior of the
+  extracted scripts, not the surrounding runner; scripts are
+  invokable from cron, launchd, a GHA step, or a webhook handler
+  without modification. Concrete principle: **prompts and scripts
+  must be invokable as standalone executables.** They cannot assume a
+  surrounding GHA environment with `mcp__github__*` tools wired up,
+  cannot assume `GITHUB_TOKEN` is auto-injected, and cannot assume a
+  specific working directory. Bug #5 is the cautionary example: a
+  prompt written against `mcp__github__*` that bailed silently the
+  moment its runtime changed. New prompts and scripts should use
+  `gh` (or an equivalent runtime-agnostic client) and read their
+  config from explicit env vars or flags.
+- **Multi-runtime, multi-model.** We use both Codex (OpenAI) and
+  Claude as agent runtimes and will continue to. Prompts and the
+  scripts that invoke them should not assume one model or one CLI.
+  Where a script shells out to an agent, the binary and any
+  model-specific flags belong in env vars or a config file, not
+  hardcoded.
+
+## GitHub-side configuration as code
+
+Future direction. Layers 1-3 ship first.
+
+Pipeline behavior also lives in GitHub's UI: branch protection /
+rulesets on `main` and `staging`, the project board, repo settings,
+merge queue. Drift there is invisible to everything in this ADR.
+
+Already in repo: `CODEOWNERS` and the label set
+(`scripts/sync-labels.mjs`). The rest is UI-configured.
+
+Patterns: (1) Terraform `integrations/github` provider, strongest
+drift detection, overkill for one repo; (2) `safe-settings` (GitHub's
+Probot-based app, reconciles `.github/settings.yml` on a schedule);
+(3) the original Probot Settings app, same shape but stale.
+
+**Judgment call:** option 2. Covers branch protection, labels, and
+most repo settings; reads YAML from the repo; one app to install.
+
+Realistic scope: in - branch protection, rulesets, repo settings,
+merge queue, label set; maybe - project board fields (ProjectV2 API
+works but is awkward); out - project board automations (replace with
+workflow adds or accept drift).
+
+Tracked as a follow-up: research first (survey + recommendation),
+prototype only if obvious.
 
 ## Follow-ups
 

--- a/docs/decisions/0007-testing-sdlc-infrastructure.md
+++ b/docs/decisions/0007-testing-sdlc-infrastructure.md
@@ -1,0 +1,153 @@
+# 0007 Testing and Hardening SDLC Infrastructure
+
+## Status
+Accepted
+
+## Context
+The SDLC pipeline is itself code: 22 workflows under `.github/workflows/`,
+a handful of bash blocks embedded in YAML, and prompt files in
+`docs/prompts/` that drive Claude routines. It has no static checks, no
+unit tests, no smoke tests, and several silent-failure idioms
+(`2>/dev/null || true`, missing `permissions:` blocks, missing env vars).
+When the pipeline breaks, we find out hours later by manually grepping
+the GitHub events API.
+
+Five distinct failures landed on one day. All share the same shape: a
+permissions or environment gap that produces a 4xx, output redirected to
+`/dev/null`, the rest of the workflow continuing happily, and PR labels
+in the wrong state until a human notices.
+
+1. `stack-approved-prs.yml` was missing `pull-requests: write`. Every
+   `gh pr edit` returned 403; output was swallowed by `2>/dev/null ||
+   true`. PRs stacked onto staging but labels never flipped. Fixed in
+   #545.[^1]
+2. The same workflow was missing `GH_TOKEN` on the rebuild step.
+   Identical silent-failure pattern. Fixed in #517.
+3. `pull_request_review` runs the workflow from the PR's head ref. PRs
+   that predate a workflow change carry the old version of the file.
+   Approving such a PR fired the broken workflow even after the fix
+   merged to `main`.
+4. The stack workflow unconditionally strips `uat: complete` /
+   `uat: needs-changes` and re-adds `uat: requested` on every rebuild.
+   A PR walked at 03:23 ("complete") got reset to "requested" at 10:12
+   when another PR landed. PRs can't stabilize at `uat: complete` in a
+   busy approval flow. Not yet fixed.
+5. `docs/prompts/hourly-uat-validation.md` uses `mcp__github__*` tools
+   for every PR/issue write. The MCP server is only configured inside
+   the workflow runner. After we moved the walker to a local launchd
+   schedule, it began bailing each hour ("can't run cleanly without
+   MCP"). Cron is alive, producing no work.
+
+Common root: the machinery that builds and validates code has no
+machinery built and validating it. The blast radius is wide:
+`dispatch-engineer-on-issue.yml`, `on-failure-issue.yml`,
+`hourly-engineer-dispatch.yml`, `pr-review.yml`, and
+`stack-approved-prs.yml` all manipulate labels or `staging`. A silent
+failure in any of them produces work that looks correct from the
+outside.
+
+## Decision
+
+Treat SDLC infrastructure as production code. Apply three layers of
+hardening; pick the cheapest layer that catches a given class of bug.
+
+### Layer 1: static checks on every PR
+
+- **`actionlint`** as a required CI step. Catches the YAML-shape bugs
+  (missing keys, unknown actions, wrong event filters).
+- **`shellcheck`** on the embedded bash inside workflows
+  (`actionlint` shells out to `shellcheck` already; turn the strict
+  flags on).
+- A small repo-local lint that scans workflow files for known
+  silent-failure idioms: `2>/dev/null || true`, calls to
+  `gh pr edit` / `gh issue edit` / `gh api` without a matching
+  `permissions:` block declaring the right scope, and bash steps
+  without `set -euo pipefail`.
+
+### Layer 2: unit tests on extracted logic
+
+The label-transition logic in `stack-approved-prs.yml` and the
+on-staging precondition check in `hourly-uat-validation.yml` are the
+two pieces that hide bugs today. Both are pure functions hiding inside
+bash. Extract them to scripts under `scripts/sdlc/` with a Vitest unit
+suite. Bug #4 (label clobber) becomes a failing test, then a passing
+one.
+
+### Layer 3: end-to-end smoke against a test-PR fixture
+
+A nightly workflow that:
+
+1. Opens a throwaway PR against a sacrificial branch in this repo.
+2. Approves it via a bot identity.
+3. Asserts the expected label transitions land within N seconds and
+   that `staging` includes the PR's head.
+4. Closes the PR, cleans up.
+
+This is the only layer that catches the "PR-ref carries a stale
+workflow" class of bug, since the failure is structural to GitHub's
+event model and only visible end-to-end.
+
+### What we are not doing in this ADR
+
+- **No state machine in code.** Labels are still the state. The
+  walker-clobber bug (bug #4) is a race; the fix is "preserve
+  `uat: complete` and `uat: needs-changes` across rebuilds," not
+  "move state out of labels." A proper state machine is its own
+  decision with its own ADR if labels prove insufficient.
+- **No prompt-engine abstraction for the MCP-vs-`gh` coupling.**
+  The fix for bug #5 is to pick one: either configure MCP in the
+  local launchd plist, or rewrite the prompt to use `gh` everywhere.
+  Both are small; one of them ships, in a follow-up issue.
+- **No "test every workflow" mandate.** Cover the five workflows
+  that touch labels or `staging`. The other 17 are read-only or
+  diagnostic; they fail loudly enough.
+
+## Consequences
+
+Positive:
+
+- Three of the five bugs above (#1, #2, #4) would have been caught by
+  layer 1 or 2 before merge. Bug #3 is caught by layer 3. Bug #5 is
+  caught by an environment-parity test in the local-walker harness.
+- Engineers and agents stop relying on "is staging green?" as the
+  pipeline test. The pipeline tests itself.
+- Future workflow changes get a fast feedback loop. Iteration speed
+  on the SDLC machinery goes up, not down.
+
+Negative:
+
+- More CI minutes. Layer 1 is cheap; layer 3 (a real PR cycle) costs
+  on the order of a minute per nightly run.
+- More scripts to maintain. The pure-function extracts under
+  `scripts/sdlc/` are real code with real test coverage; they grow
+  with the workflows.
+- Workflow iteration is slower in absolute terms: a change to
+  `stack-approved-prs.yml` now needs a unit-test update and an
+  `actionlint` pass. That's the trade.
+- The smoke fixture is a new piece of moving infrastructure
+  (sacrificial branch, bot identity, cleanup logic). It can break in
+  its own ways. The runbook for the smoke test is itself a follow-up.
+
+Out of scope / future:
+
+- Labels-as-state-machine vs. state-in-code is a real question.
+  Layer 2 hides it for now (the transition logic is testable wherever
+  the state lives), but a future ADR may move state into a small JSON
+  blob on the PR or into a side table.
+- A reusable lint for the silent-failure idiom may want to live as a
+  published action so other repos can adopt it. Out of scope here.
+
+## Follow-ups
+
+Filed as separate issues; see the PR description for the linked set.
+Each issue is sized to one PR and labelled `type: tech-debt` (mostly),
+`area: infra`, with a `human-review-needed:` level per
+`docs/sdlc/gaps.md`.
+
+[^1]: Receipts. PRs #545 and #517 carry the post-mortems for bugs #1
+    and #2. Bug #3 is visible in the timeline of any PR opened before
+    #545 that received an approval after it merged: the workflow run
+    was attached to the PR's head SHA, not main. Bug #4 is reproducible
+    today: walk any PR to `uat: complete`, then push to a sibling PR,
+    then re-check the first PR's labels. Bug #5 is visible in the
+    local launchd `~/Library/Logs/uat-walker.log` from 06:15Z onward.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "release": "pnpm --filter @fhir-place/react-fhir build && changeset publish",
-    "check:readme-goal-task": "node scripts/check-readme-goal-task.mjs"
+    "check:readme-goal-task": "node scripts/check-readme-goal-task.mjs",
+    "test:scripts": "node --test 'scripts/**/*.test.mjs'"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/scripts/staging/transition-uat-label.mjs
+++ b/scripts/staging/transition-uat-label.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+// Transition a PR's `uat:` label after it has been stacked onto staging.
+//
+// Semantics:
+//
+//   1. If the PR carries `uat: skip` → no-op. The PR has no user-visible
+//      change and doesn't need UAT walking; leave any state as-is.
+//   2. If the PR carries `uat: complete` or `uat: needs-changes` → no-op.
+//      These are durable UAT outcomes and staging rebuilds must not clobber
+//      them back to requested.
+//   3. Otherwise follow scripts/staging/uat-policy.json:
+//      - "request": remove `uat: unable`, then add `uat: requested`.
+//      - "skip": remove `uat: unable` / `uat: requested`, then add `uat: skip`.
+//
+// The script is idempotent: running it twice on the same PR with the same
+// label state produces the same result and no extra API writes.
+//
+// Runtime-agnostic. Works under:
+//   - GitHub Actions (where the workflow used to inline this)
+//   - Local launchd / tmux drivers
+//   - A cloud webhook receiver
+//   - Codex or Claude as the invoking agent runtime
+//
+// Hard rules to keep that promise:
+//   - No `@actions/*` imports. No `actions/github-script`.
+//   - No GHA workflow-command escape codes (`::group::`, `::warning::`).
+//   - All GitHub API access goes through the `gh` CLI, which authenticates
+//     from `GH_TOKEN` or `GITHUB_TOKEN` (equivalent) or a logged-in user.
+//   - No reliance on `GITHUB_WORKSPACE`, `GITHUB_ACTIONS`, or runner paths.
+//
+// Usage:
+//
+//   node scripts/staging/transition-uat-label.mjs <pr-number> [--repo owner/name] [--policy path] [--dry-run]
+//
+// Required:
+//   <pr-number>             positional, integer PR number
+//
+// Optional:
+//   --repo owner/name       defaults to $GITHUB_REPOSITORY
+//   --policy path           defaults to scripts/staging/uat-policy.json
+//   --dry-run               log intended changes without writing
+//
+// Env (any one is enough for gh auth):
+//   GH_TOKEN | GITHUB_TOKEN    token with `pull-requests: write` scope
+//   GITHUB_REPOSITORY          fallback for --repo
+//   UAT_POLICY_PATH            fallback for --policy
+//
+// Exit codes:
+//   0  success (including no-op skip cases)
+//   1  bad arguments / missing repo
+//   2  gh CLI failure (network, auth, PR not found, label edit failed)
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const SKIP_LABEL = "uat: skip";
+const REQUESTED_LABEL = "uat: requested";
+const COMPLETE_LABEL = "uat: complete";
+const NEEDS_CHANGES_LABEL = "uat: needs-changes";
+const UNABLE_LABEL = "uat: unable";
+const DEFAULT_POLICY_URL = new URL("./uat-policy.json", import.meta.url);
+const VALID_DEFAULTS = new Set(["request", "skip"]);
+
+function parseArgs(argv) {
+  const args = { prNumber: null, repo: null, policyPath: null, dryRun: false };
+  const rest = [];
+  const readValue = (flag, index) => {
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for ${flag}`);
+    }
+    return value;
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--repo") {
+      args.repo = readValue(a, i);
+      i++;
+    } else if (a === "--policy") {
+      args.policyPath = readValue(a, i);
+      i++;
+    } else if (a === "--dry-run") {
+      args.dryRun = true;
+    } else if (a === "--help" || a === "-h") {
+      args.help = true;
+    } else if (a.startsWith("--")) {
+      throw new Error(`Unknown flag: ${a}`);
+    } else {
+      rest.push(a);
+    }
+  }
+  if (rest.length > 0) args.prNumber = rest[0];
+  return args;
+}
+
+function usage() {
+  return `Usage: transition-uat-label.mjs <pr-number> [--repo owner/name] [--policy path] [--dry-run]`;
+}
+
+export function loadPolicy(policyPath = null) {
+  const source =
+    policyPath || process.env.UAT_POLICY_PATH || DEFAULT_POLICY_URL;
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(source, "utf8"));
+  } catch (err) {
+    const msg = `Failed to read UAT policy from ${source}: ${err.message}`;
+    const wrapped = new Error(msg);
+    wrapped.exitCode = 1;
+    throw wrapped;
+  }
+
+  const stackedPrUatDefault = parsed.stackedPrUatDefault || "request";
+  if (!VALID_DEFAULTS.has(stackedPrUatDefault)) {
+    const wrapped = new Error(
+      `Invalid stackedPrUatDefault "${stackedPrUatDefault}". Expected "request" or "skip".`
+    );
+    wrapped.exitCode = 1;
+    throw wrapped;
+  }
+
+  return { stackedPrUatDefault };
+}
+
+function gh(args, { capture = true } = {}) {
+  // Always go through `gh`. It authenticates equally from GH_TOKEN,
+  // GITHUB_TOKEN, or a user login — that's why we use it instead of raw
+  // fetch with a hand-rolled bearer.
+  try {
+    const out = execFileSync("gh", args, {
+      encoding: "utf8",
+      stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    });
+    return capture ? out : "";
+  } catch (err) {
+    // execFileSync throws an Error with .stderr / .status when gh exits non-zero
+    const stderr = err.stderr ? err.stderr.toString() : "";
+    const code = err.status ?? "unknown";
+    const cmd = ["gh", ...args].join(" ");
+    const msg = `gh failed (exit ${code}): ${cmd}\n${stderr.trim()}`;
+    const wrapped = new Error(msg);
+    wrapped.exitCode = 2;
+    throw wrapped;
+  }
+}
+
+function getLabels(repo, prNumber) {
+  const raw = gh([
+    "pr",
+    "view",
+    String(prNumber),
+    "--repo",
+    repo,
+    "--json",
+    "labels",
+    "--jq",
+    "[.labels[].name]",
+  ]);
+  return JSON.parse(raw.trim() || "[]");
+}
+
+function removeLabel(repo, prNumber, label, dryRun) {
+  if (dryRun) {
+    console.log(`dry-run: would remove "${label}" from PR #${prNumber}`);
+    return;
+  }
+  gh(["pr", "edit", String(prNumber), "--repo", repo, "--remove-label", label]);
+  console.log(`removed "${label}" from PR #${prNumber}`);
+}
+
+function addLabel(repo, prNumber, label, dryRun) {
+  if (dryRun) {
+    console.log(`dry-run: would add "${label}" to PR #${prNumber}`);
+    return;
+  }
+  gh(["pr", "edit", String(prNumber), "--repo", repo, "--add-label", label]);
+  console.log(`added "${label}" to PR #${prNumber}`);
+}
+
+export function transition({
+  repo,
+  prNumber,
+  policy = { stackedPrUatDefault: "request" },
+  dryRun = false,
+  getLabelsFn = getLabels,
+  removeLabelFn = removeLabel,
+  addLabelFn = addLabel,
+}) {
+  // Returned for callers (e.g. tests) and printed at the end for humans.
+  const result = {
+    repo,
+    prNumber,
+    policy,
+    dryRun,
+    skipped: false,
+    preserved: null,
+    removed: [],
+    added: null,
+  };
+
+  const labels = getLabelsFn(repo, prNumber);
+
+  if (labels.includes(SKIP_LABEL)) {
+    result.skipped = true;
+    console.log(`PR #${prNumber} has "${SKIP_LABEL}" — no transition needed`);
+    return result;
+  }
+
+  const durable = [COMPLETE_LABEL, NEEDS_CHANGES_LABEL].find((label) =>
+    labels.includes(label)
+  );
+  if (durable) {
+    result.preserved = durable;
+    console.log(`PR #${prNumber} has "${durable}" — no transition needed`);
+    return result;
+  }
+
+  if (policy.stackedPrUatDefault === "skip") {
+    for (const stale of [UNABLE_LABEL, REQUESTED_LABEL]) {
+      if (labels.includes(stale)) {
+        removeLabelFn(repo, prNumber, stale, dryRun);
+        result.removed.push(stale);
+      }
+    }
+    addLabelFn(repo, prNumber, SKIP_LABEL, dryRun);
+    result.added = SKIP_LABEL;
+    return result;
+  }
+
+  if (labels.includes(UNABLE_LABEL)) {
+    removeLabelFn(repo, prNumber, UNABLE_LABEL, dryRun);
+    result.removed.push(UNABLE_LABEL);
+  }
+
+  if (!labels.includes(REQUESTED_LABEL)) {
+    addLabelFn(repo, prNumber, REQUESTED_LABEL, dryRun);
+    result.added = REQUESTED_LABEL;
+  } else {
+    console.log(`PR #${prNumber} already has "${REQUESTED_LABEL}"`);
+  }
+
+  return result;
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(err.message);
+    console.error(usage());
+    process.exit(1);
+  }
+
+  if (args.help) {
+    console.log(usage());
+    process.exit(0);
+  }
+
+  if (!args.prNumber || !/^\d+$/.test(args.prNumber)) {
+    console.error("Missing or invalid <pr-number>");
+    console.error(usage());
+    process.exit(1);
+  }
+
+  const repo = args.repo || process.env.GITHUB_REPOSITORY;
+  if (!repo) {
+    console.error(
+      "Repo not specified. Pass --repo owner/name or set GITHUB_REPOSITORY."
+    );
+    process.exit(1);
+  }
+
+  try {
+    const policy = loadPolicy(args.policyPath);
+    transition({
+      repo,
+      prNumber: args.prNumber,
+      policy,
+      dryRun: args.dryRun,
+    });
+  } catch (err) {
+    console.error(err.message);
+    process.exit(err.exitCode ?? 2);
+  }
+}
+
+// Run main() when invoked as a script; allow import for tests.
+const isDirectInvocation = import.meta.url === `file://${process.argv[1]}`;
+if (isDirectInvocation) {
+  main();
+}

--- a/scripts/staging/transition-uat-label.test.mjs
+++ b/scripts/staging/transition-uat-label.test.mjs
@@ -1,0 +1,194 @@
+// Tests for transition-uat-label.mjs
+//
+// Run with:
+//   node --test scripts/staging/transition-uat-label.test.mjs
+//
+// Uses built-in node:test — no test framework dependency, no network. The
+// tested module exposes `transition()` with injectable getLabels/removeLabel/
+// addLabel hooks so we never shell out to `gh` during tests.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadPolicy, transition } from "./transition-uat-label.mjs";
+
+function harness(initialLabels) {
+  const calls = { removed: [], added: [], reads: 0 };
+  return {
+    calls,
+    getLabelsFn: () => {
+      calls.reads++;
+      return [...initialLabels];
+    },
+    removeLabelFn: (_repo, _pr, label) => {
+      calls.removed.push(label);
+    },
+    addLabelFn: (_repo, _pr, label) => {
+      calls.added.push(label);
+    },
+  };
+}
+
+test("uat: skip is a no-op (no reads, no writes after first read)", () => {
+  const h = harness(["uat: skip", "uat: complete"]);
+  const result = transition({
+    repo: "owner/repo",
+    prNumber: "1",
+    ...h,
+  });
+  assert.equal(result.skipped, true);
+  assert.deepEqual(result.removed, []);
+  assert.equal(result.added, null);
+  assert.deepEqual(h.calls.removed, []);
+  assert.deepEqual(h.calls.added, []);
+});
+
+test('preserves durable "uat: complete" on staging rebuild', () => {
+  const h = harness(["uat: complete"]);
+  const result = transition({
+    repo: "owner/repo",
+    prNumber: "2",
+    ...h,
+  });
+  assert.equal(result.preserved, "uat: complete");
+  assert.deepEqual(result.removed, []);
+  assert.equal(result.added, null);
+  assert.deepEqual(h.calls.removed, []);
+  assert.deepEqual(h.calls.added, []);
+});
+
+test('preserves durable "uat: needs-changes" on staging rebuild', () => {
+  const h = harness(["uat: needs-changes", "area: infra"]);
+  const result = transition({
+    repo: "owner/repo",
+    prNumber: "3",
+    ...h,
+  });
+  assert.equal(result.preserved, "uat: needs-changes");
+  assert.deepEqual(result.removed, []);
+  assert.equal(result.added, null);
+  assert.deepEqual(h.calls.removed, []);
+  assert.deepEqual(h.calls.added, []);
+});
+
+test('normal policy removes stale "uat: unable" and adds "uat: requested"', () => {
+  const h = harness(["uat: unable"]);
+  const result = transition({
+    repo: "owner/repo",
+    prNumber: "4",
+    ...h,
+  });
+  assert.deepEqual(result.removed, ["uat: unable"]);
+  assert.equal(result.added, "uat: requested");
+});
+
+test("durable outcomes win even when multiple UAT labels are present", () => {
+  const h = harness(["uat: complete", "uat: needs-changes", "uat: unable"]);
+  const result = transition({
+    repo: "owner/repo",
+    prNumber: "5",
+    ...h,
+  });
+  assert.equal(result.preserved, "uat: complete");
+  assert.deepEqual(result.removed, []);
+  assert.equal(result.added, null);
+});
+
+test('PR with no uat labels: adds "uat: requested" only', () => {
+  const h = harness(["type: bug", "priority: P1"]);
+  const result = transition({
+    repo: "owner/repo",
+    prNumber: "6",
+    ...h,
+  });
+  assert.deepEqual(result.removed, []);
+  assert.equal(result.added, "uat: requested");
+});
+
+test('idempotent: PR already at "uat: requested" → no writes', () => {
+  const h = harness(["uat: requested", "type: feature"]);
+  const result = transition({
+    repo: "owner/repo",
+    prNumber: "7",
+    ...h,
+  });
+  assert.deepEqual(result.removed, []);
+  assert.equal(result.added, null);
+  assert.deepEqual(h.calls.removed, []);
+  assert.deepEqual(h.calls.added, []);
+});
+
+test('"uat: skip" takes precedence even if requested+skip coexist', () => {
+  // Real-world: a maintainer might set skip after a previous requested.
+  // Skip wins — we don't fight the maintainer.
+  const h = harness(["uat: skip", "uat: requested"]);
+  const result = transition({
+    repo: "owner/repo",
+    prNumber: "8",
+    ...h,
+  });
+  assert.equal(result.skipped, true);
+  assert.deepEqual(h.calls.removed, []);
+  assert.deepEqual(h.calls.added, []);
+});
+
+test("dry-run flag is plumbed through to the writer hooks", () => {
+  const seen = { dryRun: null };
+  const result = transition({
+    repo: "owner/repo",
+    prNumber: "9",
+    dryRun: true,
+    getLabelsFn: () => ["uat: unable"],
+    removeLabelFn: (_r, _pr, _label, dryRun) => {
+      seen.dryRun = dryRun;
+    },
+    addLabelFn: (_r, _pr, _label, dryRun) => {
+      seen.dryRun = dryRun;
+    },
+  });
+  assert.equal(seen.dryRun, true);
+  assert.equal(result.dryRun, true);
+});
+
+test('skip policy adds "uat: skip" instead of "uat: requested"', () => {
+  const h = harness(["type: docs"]);
+  const result = transition({
+    repo: "owner/repo",
+    prNumber: "10",
+    policy: { stackedPrUatDefault: "skip" },
+    ...h,
+  });
+  assert.deepEqual(result.removed, []);
+  assert.equal(result.added, "uat: skip");
+  assert.deepEqual(h.calls.added, ["uat: skip"]);
+});
+
+test('skip policy removes existing "uat: requested" before adding "uat: skip"', () => {
+  const h = harness(["uat: requested", "type: feature"]);
+  const result = transition({
+    repo: "owner/repo",
+    prNumber: "11",
+    policy: { stackedPrUatDefault: "skip" },
+    ...h,
+  });
+  assert.deepEqual(result.removed, ["uat: requested"]);
+  assert.equal(result.added, "uat: skip");
+  assert.deepEqual(h.calls.removed, ["uat: requested"]);
+  assert.deepEqual(h.calls.added, ["uat: skip"]);
+});
+
+test("loads stacked PR UAT default from policy file", () => {
+  const dir = mkdtempSync(join(tmpdir(), "uat-policy-"));
+  const path = join(dir, "policy.json");
+  writeFileSync(path, JSON.stringify({ stackedPrUatDefault: "skip" }));
+  assert.deepEqual(loadPolicy(path), { stackedPrUatDefault: "skip" });
+});
+
+test("rejects invalid stacked PR UAT default", () => {
+  const dir = mkdtempSync(join(tmpdir(), "uat-policy-"));
+  const path = join(dir, "policy.json");
+  writeFileSync(path, JSON.stringify({ stackedPrUatDefault: "YOLO" }));
+  assert.throws(() => loadPolicy(path), /Invalid stackedPrUatDefault "YOLO"/);
+});

--- a/scripts/staging/uat-policy.json
+++ b/scripts/staging/uat-policy.json
@@ -1,0 +1,3 @@
+{
+  "stackedPrUatDefault": "request"
+}


### PR DESCRIPTION
## Summary

- Adds ADR `docs/decisions/0007-testing-sdlc-infrastructure.md` for treating SDLC automation as production code: static workflow checks, tested extracted logic, and smoke tests for staging/label flows.
- Extracts the `stack-approved-prs.yml` UAT label transition into `scripts/staging/transition-uat-label.mjs` and covers it with `node:test` via `pnpm test:scripts` in CI.
- Fixes the clobber bug: staging rebuilds now preserve durable `uat: complete`, `uat: needs-changes`, and `uat: skip` labels instead of resetting them to `uat: requested`.
- Adds `scripts/staging/uat-policy.json` so we can temporarily default stacked PRs to `uat: skip` instead of `uat: requested` by changing `stackedPrUatDefault` from `request` to `skip`.
- Ignores local `logs/` output so launchd/runtime logs do not leak into infra PRs.

## Issue coverage

- Addresses #572 by moving the stacker label transition out of workflow YAML and adding script tests.
- Closes #574 by preserving durable UAT verdict labels across staging rebuilds.
- Leaves #570, #571, #573, #575, #579, and #580 as follow-up hardening work.

## Config switch

Default behavior:

```json
{
  "stackedPrUatDefault": "request"
}
```

Fast-shipping behavior:

```json
{
  "stackedPrUatDefault": "skip"
}
```

In `skip` mode, stacked PRs without a durable UAT state get `uat: skip` instead of `uat: requested`, so they do not enter the Ready for UAT project-card path by default.

## Test plan

- [x] `pnpm test:scripts`
- [x] `pnpm check:readme-goal-task`
- [x] `pnpm exec prettier --check docs/decisions/0007-testing-sdlc-infrastructure.md scripts/staging/transition-uat-label.mjs scripts/staging/transition-uat-label.test.mjs scripts/staging/uat-policy.json .github/workflows/stack-approved-prs.yml .github/workflows/ci.yml package.json`
- [x] `git diff --check`
- [x] `node scripts/staging/transition-uat-label.mjs --help`

## UAT on live staging

N/A - no user-visible app change. Validation is the workflow/script test path above plus GitHub Actions on this PR.

## Screenshots

N/A - no user-visible change.
