### PR TITLE
fix(stack-approved-prs): preserve walker uat verdicts on rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm check:readme-goal-task
+      # Node-script unit tests (e.g. scripts/staging/*.test.mjs). These
+      # cover automation logic that runs inside GitHub Actions and isn't
+      # part of any workspace package, so the standard `pnpm -r test:run`
+      # doesn't reach them.
+      - run: node --test scripts/staging/*.test.mjs
       # Build the library first so the demo app can resolve its .d.ts files
       # during typecheck (demo depends on @fhir-place/react-fhir via workspace).
       - run: pnpm --filter @fhir-place/react-fhir build

--- a/.github/workflows/stack-approved-prs.yml
+++ b/.github/workflows/stack-approved-prs.yml
@@ -147,24 +147,13 @@ jobs:
             fi
             if git merge --no-edit --no-ff -m "stage: include PR #$NUM" "$REF"; then
               echo "Stacked PR #$NUM"
-              # Transition the PR's UAT state: it's now on staging, awaiting
-              # the hourly UAT walker. Skip when the PR carries `uat: skip`
-              # (no user-visible change → no validation needed). Otherwise
-              # remove any prior `uat: unable` / `uat: needs-changes` /
-              # `uat: complete` so only `uat: requested` is set.
-              LABELS=$(gh pr view "$NUM" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name]')
-              if echo "$LABELS" | jq -e 'index("uat: skip") != null' >/dev/null; then
-                echo "  PR #$NUM has uat: skip — leaving label as-is"
-              else
-                for LABEL in "uat: unable" "uat: needs-changes" "uat: complete"; do
-                  if echo "$LABELS" | jq -e --arg label "$LABEL" 'index($label) != null' >/dev/null; then
-                    gh pr edit "$NUM" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL"
-                  fi
-                done
-                if echo "$LABELS" | jq -e 'index("uat: requested") == null' >/dev/null; then
-                  gh pr edit "$NUM" --repo "$GITHUB_REPOSITORY" --add-label "uat: requested"
-                fi
-              fi
+              # Transition the PR's `uat:` label. The script preserves
+              # walker verdicts (`uat: complete`, `uat: needs-changes`)
+              # and the opt-out (`uat: skip`); only new PRs and ones
+              # carrying `uat: unable` move to `uat: requested`. See
+              # `scripts/staging/transition-uat-label.mjs` for the full
+              # state machine and its unit tests.
+              node "$GITHUB_WORKSPACE/scripts/staging/transition-uat-label.mjs" "$NUM"
             else
               echo "::warning::PR #$NUM conflicts with staging; skipping. Manual rebase needed."
               git merge --abort

--- a/scripts/staging/transition-uat-label.mjs
+++ b/scripts/staging/transition-uat-label.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// Transitions a single PR's `uat:` label after it has been successfully
+// stacked onto `staging` by `.github/workflows/stack-approved-prs.yml`.
+//
+// Why this exists as a separate script:
+//
+// The stacking workflow rebuilds `staging` from main every time approvals
+// change, and for every PR re-stacked it used to unconditionally remove
+// `uat: complete` / `uat: needs-changes` and re-add `uat: requested`. That
+// clobbered the walker's verdicts: a PR would settle on `uat: complete`,
+// then the very next staging rebuild (triggered by some other PR's
+// approval) would knock it back to `uat: requested`. PRs could never
+// stabilize at `uat: complete` long enough to merge.
+//
+// State machine — what we set after a successful stack:
+//
+//   (none)            → uat: requested      (first time onto staging)
+//   uat: unable       → uat: requested      (was off-staging, now on)
+//   uat: requested    → uat: requested      (no-op)
+//   uat: complete     → uat: complete       (preserve — walker's verdict)
+//   uat: needs-changes→ uat: needs-changes  (preserve — walker's verdict)
+//   uat: skip         → uat: skip           (preserve — opt-out)
+//
+// The walker (`docs/prompts/hourly-uat-validation.md`) owns the transition
+// out of `uat: requested` and is the only thing allowed to set `complete`
+// or `needs-changes`. This script never sets either of those.
+//
+// Defensive rule: if a PR somehow ends up with multiple `uat:` labels,
+// pick the most "settled" by preference order
+//   uat: skip > uat: complete > uat: needs-changes > uat: requested > uat: unable
+// and remove the rest. Settled wins so we never demote a walker verdict.
+//
+// Required env:
+//   GH_TOKEN              token with `pull-requests: write` (workflow token)
+//   GITHUB_REPOSITORY     "owner/repo"
+//
+// Argv:
+//   PR number (positional). Also accepted as PR_NUMBER env.
+//
+// Exit codes:
+//   0  success (including idempotent no-op)
+//   1  bad input / config
+//   2  gh CLI call failed (the workflow log will show the underlying error)
+
+import { spawnSync } from 'node:child_process';
+
+const UAT_LABELS = [
+  'uat: skip',
+  'uat: complete',
+  'uat: needs-changes',
+  'uat: requested',
+  'uat: unable',
+];
+
+// Highest preference (index 0) wins when a PR somehow has multiple.
+const PREFERENCE = UAT_LABELS;
+
+// Labels we'll PRESERVE without trying to "fix" them on a stack rebuild.
+// `requested` is included because re-asserting it on every rebuild is a
+// pointless API call (and used to be the bug surface).
+const PRESERVE = new Set([
+  'uat: skip',
+  'uat: complete',
+  'uat: needs-changes',
+  'uat: requested',
+]);
+
+/**
+ * Run a `gh` command. Default implementation shells out; tests inject
+ * their own to avoid hitting the real API.
+ *
+ * Throws on non-zero exit so the caller surfaces failures loudly — we
+ * do NOT swallow errors here. A 403 from a permission misconfig should
+ * fail the workflow run, not silently drop labels.
+ */
+export function defaultGhRunner(args) {
+  const res = spawnSync('gh', args, { encoding: 'utf8' });
+  if (res.error) {
+    throw new Error(`gh ${args.join(' ')} failed to launch: ${res.error.message}`);
+  }
+  if (res.status !== 0) {
+    const stderr = (res.stderr || '').trim();
+    throw new Error(`gh ${args.join(' ')} exited ${res.status}: ${stderr}`);
+  }
+  return res.stdout;
+}
+
+/**
+ * Pure: given the current label set, decide which label should be the
+ * single resulting `uat:` label after a successful stack.
+ *
+ * Returns `null` when the PR has no `uat:` labels at all — the caller
+ * should add `uat: requested`.
+ */
+export function pickResultingLabel(currentLabels) {
+  const uat = currentLabels.filter((l) => UAT_LABELS.includes(l));
+  if (uat.length === 0) return null;
+  // Sort by preference index, lowest (most preferred) first.
+  uat.sort((a, b) => PREFERENCE.indexOf(a) - PREFERENCE.indexOf(b));
+  const winner = uat[0];
+  // `uat: unable` is not a stable state after stacking — by definition
+  // the PR is now on staging, so it must transition to `requested`.
+  if (winner === 'uat: unable') return 'uat: requested';
+  return winner;
+}
+
+/**
+ * Compute the minimal set of label-edit actions needed to transition
+ * the PR. Returns an array of { action: 'remove'|'add', label } in the
+ * order they should be applied. Empty array means no work needed.
+ */
+export function planTransition(currentLabels) {
+  const target = pickResultingLabel(currentLabels) ?? 'uat: requested';
+  const currentUat = currentLabels.filter((l) => UAT_LABELS.includes(l));
+  const actions = [];
+
+  // Remove every `uat:` label that isn't the target. If the target is a
+  // PRESERVE label (skip/complete/needs-changes/requested), we leave it
+  // in place and only clean up stragglers. If the target is `requested`
+  // and it's not currently set, we'll add it below.
+  for (const label of currentUat) {
+    if (label !== target) {
+      actions.push({ action: 'remove', label });
+    }
+  }
+
+  if (!currentUat.includes(target)) {
+    actions.push({ action: 'add', label: target });
+  }
+
+  return actions;
+}
+
+async function fetchLabels({ pr, repo, gh }) {
+  const out = gh(['pr', 'view', String(pr), '--repo', repo, '--json', 'labels']);
+  const parsed = JSON.parse(out);
+  if (!Array.isArray(parsed.labels)) {
+    throw new Error(`gh pr view returned unexpected shape: ${out.slice(0, 200)}`);
+  }
+  return parsed.labels.map((l) => l.name);
+}
+
+function applyAction({ pr, repo, gh, action, label }) {
+  const flag = action === 'remove' ? '--remove-label' : '--add-label';
+  gh(['pr', 'edit', String(pr), '--repo', repo, flag, label]);
+}
+
+/**
+ * Main entry point. Exported so tests can call it with an injected gh.
+ */
+export async function transitionUatLabel({ pr, repo, gh = defaultGhRunner, log = console.log }) {
+  if (!pr) throw new Error('PR number is required');
+  if (!repo) throw new Error('GITHUB_REPOSITORY env var is required');
+
+  const labels = await fetchLabels({ pr, repo, gh });
+  const uat = labels.filter((l) => UAT_LABELS.includes(l));
+  log(`PR #${pr}: current uat labels = [${uat.join(', ') || '(none)'}]`);
+
+  const plan = planTransition(labels);
+
+  if (plan.length === 0) {
+    log(`PR #${pr}: no label change needed`);
+    return { changed: false, actions: [] };
+  }
+
+  for (const step of plan) {
+    log(`PR #${pr}: ${step.action} "${step.label}"`);
+    applyAction({ pr, repo, gh, action: step.action, label: step.label });
+  }
+
+  return { changed: true, actions: plan };
+}
+
+// Allow `import` for tests without auto-running main().
+const isDirectRun = import.meta.url === `file://${process.argv[1]}`;
+
+if (isDirectRun) {
+  const pr = process.argv[2] || process.env.PR_NUMBER;
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!process.env.GH_TOKEN) {
+    console.error('GH_TOKEN is required');
+    process.exit(1);
+  }
+  if (!pr) {
+    console.error('Usage: transition-uat-label.mjs <pr-number>   (or set PR_NUMBER)');
+    process.exit(1);
+  }
+  if (!repo) {
+    console.error('GITHUB_REPOSITORY is required');
+    process.exit(1);
+  }
+  transitionUatLabel({ pr, repo }).catch((err) => {
+    console.error(err.message || err);
+    process.exit(2);
+  });
+}

--- a/scripts/staging/transition-uat-label.test.mjs
+++ b/scripts/staging/transition-uat-label.test.mjs
@@ -1,0 +1,258 @@
+// Unit tests for transition-uat-label.mjs. Uses node's built-in
+// `node:test` runner so this has zero install footprint. Run with:
+//
+//   node --test scripts/staging/transition-uat-label.test.mjs
+//
+// The script under test takes its `gh` runner as a parameter, so we
+// inject a stub that records argv lists and returns canned stdout. No
+// network calls happen here.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  pickResultingLabel,
+  planTransition,
+  transitionUatLabel,
+} from './transition-uat-label.mjs';
+
+/**
+ * Builds a mock `gh` runner. `prLabels` is the array of label names that
+ * `gh pr view` should report for the PR. Each call is logged into the
+ * returned `calls` array.
+ */
+function makeGh(prLabels) {
+  const calls = [];
+  let labels = [...prLabels];
+  const gh = (args) => {
+    calls.push(args);
+    if (args[0] === 'pr' && args[1] === 'view') {
+      return JSON.stringify({ labels: labels.map((name) => ({ name })) });
+    }
+    if (args[0] === 'pr' && args[1] === 'edit') {
+      // Reflect mutation so a follow-up `pr view` (if any) would see it.
+      // Not strictly needed for the current script which only views once,
+      // but it keeps the mock honest.
+      const removeIdx = args.indexOf('--remove-label');
+      const addIdx = args.indexOf('--add-label');
+      if (removeIdx >= 0) {
+        const target = args[removeIdx + 1];
+        labels = labels.filter((l) => l !== target);
+      }
+      if (addIdx >= 0) {
+        const target = args[addIdx + 1];
+        if (!labels.includes(target)) labels.push(target);
+      }
+      return '';
+    }
+    throw new Error(`unexpected gh call: ${args.join(' ')}`);
+  };
+  return { gh, calls, getLabels: () => labels };
+}
+
+/** Filter recorded calls down to label-edit operations. */
+function labelEdits(calls) {
+  return calls
+    .filter((args) => args[0] === 'pr' && args[1] === 'edit')
+    .map((args) => {
+      const removeIdx = args.indexOf('--remove-label');
+      const addIdx = args.indexOf('--add-label');
+      if (removeIdx >= 0) return { action: 'remove', label: args[removeIdx + 1] };
+      if (addIdx >= 0) return { action: 'add', label: args[addIdx + 1] };
+      return { action: 'unknown' };
+    });
+}
+
+const REPO = 'danielsperoniteam/fhir-place';
+const PR = 526;
+const silent = () => {};
+
+describe('pickResultingLabel', () => {
+  it('returns null when no uat labels are present', () => {
+    assert.equal(pickResultingLabel([]), null);
+    assert.equal(pickResultingLabel(['bug', 'priority: P1']), null);
+  });
+
+  it('promotes uat: unable to uat: requested (it is no longer "unable" once stacked)', () => {
+    assert.equal(pickResultingLabel(['uat: unable']), 'uat: requested');
+  });
+
+  it('keeps uat: requested', () => {
+    assert.equal(pickResultingLabel(['uat: requested']), 'uat: requested');
+  });
+
+  it('keeps uat: complete', () => {
+    assert.equal(pickResultingLabel(['uat: complete']), 'uat: complete');
+  });
+
+  it('keeps uat: needs-changes', () => {
+    assert.equal(pickResultingLabel(['uat: needs-changes']), 'uat: needs-changes');
+  });
+
+  it('keeps uat: skip', () => {
+    assert.equal(pickResultingLabel(['uat: skip']), 'uat: skip');
+  });
+
+  it('prefers the more-settled label when multiple are present', () => {
+    // skip > complete > needs-changes > requested > unable
+    assert.equal(
+      pickResultingLabel(['uat: complete', 'uat: requested']),
+      'uat: complete',
+    );
+    assert.equal(
+      pickResultingLabel(['uat: needs-changes', 'uat: unable']),
+      'uat: needs-changes',
+    );
+    assert.equal(
+      pickResultingLabel(['uat: skip', 'uat: complete', 'uat: requested']),
+      'uat: skip',
+    );
+  });
+});
+
+describe('planTransition', () => {
+  it('adds uat: requested when no uat label is present', () => {
+    const plan = planTransition(['bug']);
+    assert.deepEqual(plan, [{ action: 'add', label: 'uat: requested' }]);
+  });
+
+  it('flips uat: unable → uat: requested', () => {
+    const plan = planTransition(['uat: unable']);
+    assert.deepEqual(plan, [
+      { action: 'remove', label: 'uat: unable' },
+      { action: 'add', label: 'uat: requested' },
+    ]);
+  });
+
+  it('is a no-op when uat: requested is already set', () => {
+    assert.deepEqual(planTransition(['uat: requested']), []);
+  });
+
+  it('is a no-op when uat: complete is already set (the bug fix)', () => {
+    assert.deepEqual(planTransition(['uat: complete']), []);
+  });
+
+  it('is a no-op when uat: needs-changes is already set', () => {
+    assert.deepEqual(planTransition(['uat: needs-changes']), []);
+  });
+
+  it('is a no-op when uat: skip is already set', () => {
+    assert.deepEqual(planTransition(['uat: skip']), []);
+  });
+
+  it('cleans up stragglers when multiple uat labels are present, keeping the winner', () => {
+    const plan = planTransition(['uat: complete', 'uat: requested', 'bug']);
+    // Winner = uat: complete; the only edit needed is removing the loser.
+    assert.deepEqual(plan, [{ action: 'remove', label: 'uat: requested' }]);
+  });
+});
+
+describe('transitionUatLabel (integration with mock gh)', () => {
+  it('first time stacking → adds uat: requested', async () => {
+    const { gh, calls } = makeGh(['bug', 'priority: P1']);
+    const result = await transitionUatLabel({ pr: PR, repo: REPO, gh, log: silent });
+    assert.equal(result.changed, true);
+    assert.deepEqual(labelEdits(calls), [
+      { action: 'add', label: 'uat: requested' },
+    ]);
+  });
+
+  it('uat: unable → flips to uat: requested', async () => {
+    const { gh, calls } = makeGh(['uat: unable']);
+    const result = await transitionUatLabel({ pr: PR, repo: REPO, gh, log: silent });
+    assert.equal(result.changed, true);
+    assert.deepEqual(labelEdits(calls), [
+      { action: 'remove', label: 'uat: unable' },
+      { action: 'add', label: 'uat: requested' },
+    ]);
+  });
+
+  it('uat: requested → no API calls beyond the view', async () => {
+    const { gh, calls } = makeGh(['uat: requested']);
+    const result = await transitionUatLabel({ pr: PR, repo: REPO, gh, log: silent });
+    assert.equal(result.changed, false);
+    assert.deepEqual(labelEdits(calls), []);
+    // Exactly one gh call total — the initial `pr view`.
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][1], 'view');
+  });
+
+  it('uat: complete is preserved (the clobber bug fix)', async () => {
+    const { gh, calls } = makeGh(['uat: complete']);
+    const result = await transitionUatLabel({ pr: PR, repo: REPO, gh, log: silent });
+    assert.equal(result.changed, false);
+    const edits = labelEdits(calls);
+    // The whole point: nothing removes "uat: complete".
+    assert.equal(
+      edits.some((e) => e.action === 'remove' && e.label === 'uat: complete'),
+      false,
+      'uat: complete must not be removed by a stack rebuild',
+    );
+    assert.deepEqual(edits, []);
+  });
+
+  it('uat: needs-changes is preserved', async () => {
+    const { gh, calls } = makeGh(['uat: needs-changes']);
+    const result = await transitionUatLabel({ pr: PR, repo: REPO, gh, log: silent });
+    assert.equal(result.changed, false);
+    const edits = labelEdits(calls);
+    assert.equal(
+      edits.some((e) => e.action === 'remove' && e.label === 'uat: needs-changes'),
+      false,
+      'uat: needs-changes must not be removed by a stack rebuild',
+    );
+    assert.deepEqual(edits, []);
+  });
+
+  it('uat: skip is preserved', async () => {
+    const { gh, calls } = makeGh(['uat: skip']);
+    const result = await transitionUatLabel({ pr: PR, repo: REPO, gh, log: silent });
+    assert.equal(result.changed, false);
+    assert.deepEqual(labelEdits(calls), []);
+  });
+
+  it('non-uat labels are not touched', async () => {
+    const { gh, calls } = makeGh([
+      'bug',
+      'priority: P1',
+      'area: fhir-explorer',
+      'uat: unable',
+    ]);
+    await transitionUatLabel({ pr: PR, repo: REPO, gh, log: silent });
+    const touched = labelEdits(calls).map((e) => e.label);
+    for (const label of touched) {
+      assert.ok(
+        label.startsWith('uat: '),
+        `transition touched non-uat label "${label}"`,
+      );
+    }
+  });
+
+  it('converges to the most-settled label when a PR has multiple uat labels', async () => {
+    // This shouldn't happen in practice, but the script must not panic
+    // and must not demote a walker verdict to `uat: requested`.
+    const { gh, calls } = makeGh(['uat: complete', 'uat: requested']);
+    const result = await transitionUatLabel({ pr: PR, repo: REPO, gh, log: silent });
+    assert.equal(result.changed, true);
+    assert.deepEqual(labelEdits(calls), [
+      { action: 'remove', label: 'uat: requested' },
+    ]);
+  });
+
+  it('propagates gh failures (no error swallowing)', async () => {
+    // Mock gh that fails on the second call (the label edit). We want a
+    // 403 from "labels can't be edited" to fail the workflow loudly.
+    let callCount = 0;
+    const gh = (args) => {
+      callCount++;
+      if (callCount === 1) {
+        return JSON.stringify({ labels: [{ name: 'uat: unable' }] });
+      }
+      throw new Error('gh: exit 1: HTTP 403: Resource not accessible by integration');
+    };
+    await assert.rejects(
+      () => transitionUatLabel({ pr: PR, repo: REPO, gh, log: silent }),
+      /403/,
+    );
+  });
+});


### PR DESCRIPTION
## What this fixes

The staging-rebuild workflow used to unconditionally remove `uat: complete` and `uat: needs-changes` on every approval-triggered rebuild, then re-add `uat: requested`. That clobbered the UAT walker's verdicts: a PR could never stabilize at `uat: complete` long enough to merge in a busy approval flow.

Example timeline observed on PR #526:

| Step | Label transition | By |
| --- | --- | --- |
| 1 | `uat: unable` (initial) | stack workflow, not on staging yet |
| 2 | `uat: unable` -> `uat: requested` | stack workflow, after first stacking |
| 3 | `uat: requested` -> `uat: complete` | UAT walker, after successful validation |
| 4 | `uat: complete` -> `uat: requested` | stack workflow on next rebuild (clobber) |

This PR makes step 4 a no-op.

## What's in this PR

Three things, one PR. The whole point of the extraction is to give the bug fix a testable surface.

**1. `scripts/staging/transition-uat-label.mjs`** — node ESM script. Pure transition logic + an injectable `gh` runner. Idempotent. No `2>/dev/null || true` — failures surface in the workflow log. Matches the style of `scripts/sync-labels.mjs`.

State machine after a successful stack:

| Current label | Result | Reason |
| --- | --- | --- |
| (none) | `uat: requested` | first time onto staging |
| `uat: unable` | `uat: requested` | PR moved from off-staging to on-staging |
| `uat: requested` | `uat: requested` (no-op) | already correct |
| `uat: complete` | `uat: complete` (preserved) | walker verdict — leave alone |
| `uat: needs-changes` | `uat: needs-changes` (preserved) | walker verdict — leave alone |
| `uat: skip` | `uat: skip` (preserved) | opt-out |

Defensive rule for the rare case where a PR ends up with multiple `uat:` labels: pick the most-settled one by preference order `skip > complete > needs-changes > requested > unable`, then clean up the rest. Settled wins so we never demote a walker verdict.

**2. `scripts/staging/transition-uat-label.test.mjs`** — 23 `node:test` cases covering the state machine, idempotency, the clobber-bug regression, multi-label defense, and an explicit "gh failures must propagate" check. No real GitHub calls — `gh` is injected as a stub.

Local run:

```
$ node --test scripts/staging/transition-uat-label.test.mjs
...
ℹ tests 23
ℹ suites 3
ℹ pass 23
ℹ fail 0
```

Wired into CI as `node --test scripts/staging/*.test.mjs` in `.github/workflows/ci.yml`.

**3. `.github/workflows/stack-approved-prs.yml`** — the 19-line inline bash-and-jq label block collapses to a single `node "$GITHUB_WORKSPACE/scripts/staging/transition-uat-label.mjs" "$NUM"`. The rebuild job still runs on `ubuntu-latest`, still uses the workflow `GITHUB_TOKEN` exposed as `GH_TOKEN`, still preflight-gates on the workflow file matching main's. Net workflow change: -13 lines.

## Diff stats

```
 .github/workflows/ci.yml                      |   5 +
 .github/workflows/stack-approved-prs.yml      |  25 +--   (-13 net)
 scripts/staging/transition-uat-label.mjs      | 196 +++
 scripts/staging/transition-uat-label.test.mjs | 258 +++
```

## Related PRs

PR #545 (`fix(stack-approved-prs): grant pull-requests: write so labels can flip`) merged earlier today. With `pull-requests: write` already in place, label edits from this script will succeed. If the permission ever regresses, the script will now fail loudly rather than silently dropping the edit (no `2>/dev/null || true`) — a better signal.

## Test plan

- [x] All 23 unit tests pass locally (`node --test scripts/staging/transition-uat-label.test.mjs`)
- [x] CI step added to run the tests on every PR
- [ ] After merge: watch the next stack-approved-prs run and confirm a PR currently sitting at `uat: complete` keeps that label across a rebuild (this is the actual production validation)

## UAT

`uat: skip` — pure automation/CI change. The UAT walker can't validate "label transitions don't clobber" by walking the deployed app; that's a backend behaviour observable only through the GitHub API and via the unit tests in this PR.

## Screenshots

N/A — no user-visible change.