### PR TITLE
fix(ci): replace claude-code-action with direct claude --print in staging-stack-agent

### DIFF
--- a/.github/workflows/staging-stack-agent.yml
+++ b/.github/workflows/staging-stack-agent.yml
@@ -65,4 +65,5 @@ jobs:
             --print \
             --max-turns 200 \
             --allowedTools "Read,Edit,Write,Bash,Grep,Glob" \
+            --disallowedTools "AskUserQuestion,ExitPlanMode" \
             --dangerously-skip-permissions

--- a/.github/workflows/staging-stack-agent.yml
+++ b/.github/workflows/staging-stack-agent.yml
@@ -17,7 +17,6 @@ permissions:
   contents: write       # force-push staging
   issues: write         # escalation and status comments on PRs
   pull-requests: write  # read PR state and update UAT labels
-  id-token: write       # required by claude-code-action@v1
 
 concurrency:
   group: staging-stack-agent
@@ -51,23 +50,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Resolve staging stack conflicts with Claude Code
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: |
-            The clean-merge staging stacker hit a merge conflict.
-
-            Context:
-            - Conflicted PR: #${{ inputs.conflict_pr }}
-            - Conflicted PR head SHA at dispatch: ${{ inputs.conflict_sha }}
-            - Working directory is checked out on `main` with full git history.
-            - Your output branch is `staging`, which is a deploy artifact.
-            - Do not push to any PR branch, `main`, or `gh-pages`.
-
-            Read `docs/prompts/staging-stack-resolve-conflicts.md` and execute
-            the instructions in it. Do not modify the prompt file itself.
-          claude_args: "--max-turns 200 --allowedTools Read,Edit,Write,Bash,Grep,Glob,mcp__github__* --disallowedTools AskUserQuestion,ExitPlanMode"
-          show_full_output: true
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          printf 'The clean-merge staging stacker hit a merge conflict.\n\nContext:\n- Conflicted PR: #${{ inputs.conflict_pr }}\n- Conflicted PR head SHA at dispatch: ${{ inputs.conflict_sha }}\n- Working directory is checked out on `main` with full git history.\n- Your output branch is `staging`, which is a deploy artifact.\n- Do not push to any PR branch, `main`, or `gh-pages`.\n\n' | cat - docs/prompts/staging-stack-resolve-conflicts.md | \
+          claude \
+            --print \
+            --max-turns 200 \
+            --allowedTools "Read,Edit,Write,Bash,Grep,Glob" \
+            --dangerously-skip-permissions

--- a/docs/automation-overview.html
+++ b/docs/automation-overview.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>fhir-place local automation</title>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #0d1117;
+      color: #e6edf3;
+      margin: 0;
+      padding: 24px;
+    }
+    h1 { font-size: 1.2rem; font-weight: 600; color: #7ee787; margin-bottom: 4px; }
+    p.sub { font-size: 0.85rem; color: #8b949e; margin: 0 0 24px; }
+    .diagram-wrap {
+      background: #161b22;
+      border: 1px solid #30363d;
+      border-radius: 8px;
+      padding: 24px;
+      margin-bottom: 32px;
+    }
+    .diagram-wrap h2 {
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #8b949e;
+      margin: 0 0 16px;
+    }
+    .legend {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin-top: 24px;
+    }
+    .legend-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 0.8rem;
+      color: #8b949e;
+    }
+    .swatch {
+      width: 12px;
+      height: 12px;
+      border-radius: 2px;
+    }
+  </style>
+</head>
+<body>
+
+<h1>fhir-place local automation</h1>
+<p class="sub">How launchd, poll-events, and the claude CLI wire together on the Mac mini.</p>
+
+<div class="diagram-wrap">
+  <h2>Scheduled jobs (launchd → scripts/launchd/)</h2>
+  <div class="mermaid">
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#1f6feb', 'primaryTextColor': '#e6edf3', 'primaryBorderColor': '#388bfd', 'lineColor': '#8b949e', 'secondaryColor': '#161b22', 'tertiaryColor': '#0d1117'}}}%%
+flowchart TD
+    LD[launchd\nmacOS service manager]:::scheduler
+
+    LD -->|"09:30 & 14:30 UTC"| ED[engineer-dispatch.sh]:::script
+    LD -->|"09:00 & 14:00 UTC"| PFD[pr-fixup-dispatch.sh]:::script
+    LD -->|":15 every hour"| UAT[hourly-uat-validation.sh]:::script
+    LD -->|"05:00 UTC daily"| QA[daily-qa-pass.sh]:::script
+    LD -->|"07:00 UTC daily"| PM[daily-pm-triage.sh]:::script
+    LD -->|"06:00 UTC daily"| DS[daily-doc-sync.sh]:::script
+
+    ED -->|via| RUN[run-prompt-locally.sh\ngeneric runner]:::runner
+    PFD -->|via| RUN
+    UAT -->|via| RUN
+    QA -->|via| RUN
+    PM -->|via| RUN
+    DS -->|via| RUN
+
+    RUN -->|reads| PROMPT[docs/prompts/*.md\nprompt files]:::file
+    RUN -->|"claude --print\n(no ANTHROPIC_API_KEY)"| CLAUDE[claude CLI\nOAuth session]:::claude
+    CLAUDE -->|bills against| SUB[Claude Max subscription]:::external
+
+    RUN -->|on failure| IMSG[iMessage alert\n+15082827897]:::notify
+
+    classDef scheduler fill:#1f6feb,stroke:#388bfd,color:#e6edf3
+    classDef script fill:#238636,stroke:#2ea043,color:#e6edf3
+    classDef runner fill:#6e40c9,stroke:#a371f7,color:#e6edf3
+    classDef file fill:#2d333b,stroke:#444c56,color:#8b949e
+    classDef claude fill:#d29922,stroke:#e3b341,color:#0d1117
+    classDef external fill:#161b22,stroke:#388bfd,color:#8b949e,stroke-dasharray:4
+    classDef notify fill:#da3633,stroke:#f85149,color:#e6edf3
+  </div>
+</div>
+
+<div class="diagram-wrap">
+  <h2>Event-driven jobs (poll-events daemon → scripts/local/)</h2>
+  <div class="mermaid">
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#1f6feb', 'primaryTextColor': '#e6edf3', 'primaryBorderColor': '#388bfd', 'lineColor': '#8b949e', 'secondaryColor': '#161b22', 'tertiaryColor': '#0d1117'}}}%%
+flowchart TD
+    LD2[launchd\npoll-events.plist]:::scheduler
+    LD2 -->|"every 60s\nrestart-on-exit"| PE[poll-events.sh\nlong-running daemon]:::daemon
+
+    PE -->|polls| GH[GitHub API\ndanielsperoniteam/fhir-place]:::external
+
+    GH -->|new issues| IR[event-issue-review.sh]:::script
+    GH -->|PR ready for review| PRR[event-pr-review.sh]:::script
+    GH -->|"/dispatch-engineer comment"| DE[event-dispatch-engineer.sh]:::script
+    GH -->|"/resolve-conflicts comment"| RC[event-resolve-conflicts.sh]:::script
+    GH -->|"/address-comments comment"| AC[event-address-comments.sh]:::script
+
+    PE -->|"👀 reaction = ack\n(dedup)"| GH
+    PE -->|"~/.fhir-place-state/\npoll-events.json"| STATE[watermark state\nlast-seen timestamps]:::file
+    PE -->|"MAX_CONCURRENT=3\nbackpressure"| CAP[concurrency cap]:::note
+
+    IR -->|via| RUN2[run-prompt-locally.sh]:::runner
+    PRR -->|via| RUN2
+    DE -->|via| RUN2
+    RC -->|via| RUN2
+    AC -->|via| RUN2
+
+    RUN2 -->|"--for issue/PR #N\nprologue + prompt body"| CLAUDE2[claude CLI\nOAuth session]:::claude
+    CLAUDE2 --> SUB2[Claude Max subscription]:::external
+
+    PE -->|kill switch| KS["~/.fhir-place-pause\n(touch to silence all)"]:::killswitch
+
+    classDef scheduler fill:#1f6feb,stroke:#388bfd,color:#e6edf3
+    classDef daemon fill:#1f6feb,stroke:#388bfd,color:#e6edf3,stroke-width:3px
+    classDef script fill:#238636,stroke:#2ea043,color:#e6edf3
+    classDef runner fill:#6e40c9,stroke:#a371f7,color:#e6edf3
+    classDef file fill:#2d333b,stroke:#444c56,color:#8b949e
+    classDef claude fill:#d29922,stroke:#e3b341,color:#0d1117
+    classDef external fill:#161b22,stroke:#388bfd,color:#8b949e,stroke-dasharray:4
+    classDef note fill:#2d333b,stroke:#444c56,color:#8b949e,stroke-dasharray:2
+    classDef killswitch fill:#da3633,stroke:#f85149,color:#e6edf3
+  </div>
+</div>
+
+<div class="diagram-wrap">
+  <h2>Safety &amp; auth model</h2>
+  <div class="mermaid">
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#1f6feb', 'primaryTextColor': '#e6edf3', 'primaryBorderColor': '#388bfd', 'lineColor': '#8b949e', 'secondaryColor': '#161b22', 'tertiaryColor': '#0d1117'}}}%%
+flowchart LR
+    KC[macOS Keychain\ngithub-pat-fhir-place]:::secure -->|security find-generic-password| ENV[GITHUB_TOKEN\nin process env]:::env
+    OAUTH[~/.claude/\nOAuth credentials]:::secure -->|claude login\none-time setup| CLI[claude CLI\nbills Max sub]:::claude
+
+    ENV --> GH_API[gh / GitHub API calls]:::external
+    CLI --> AI[Anthropic API\nvia subscription]:::external
+
+    PAUSE["~/.fhir-place-pause\nkill switch"]:::killswitch -->|checked by every script| ALL[all runners]:::runner
+    LOCK["/tmp/fhir-place-*.lock\natomic mkdir lock"]:::lock -->|prevents double-runs| ALL
+    DIRTY[git diff check\ndirty tree guard]:::lock -->|skips run if\nworkdir has edits| ALL
+
+    classDef secure fill:#238636,stroke:#2ea043,color:#e6edf3
+    classDef env fill:#2d333b,stroke:#444c56,color:#8b949e
+    classDef claude fill:#d29922,stroke:#e3b341,color:#0d1117
+    classDef external fill:#161b22,stroke:#388bfd,color:#8b949e,stroke-dasharray:4
+    classDef killswitch fill:#da3633,stroke:#f85149,color:#e6edf3
+    classDef lock fill:#6e40c9,stroke:#a371f7,color:#e6edf3
+    classDef runner fill:#6e40c9,stroke:#a371f7,color:#e6edf3
+  </div>
+</div>
+
+<div class="legend">
+  <div class="legend-item"><div class="swatch" style="background:#1f6feb"></div> launchd / daemon</div>
+  <div class="legend-item"><div class="swatch" style="background:#238636"></div> shell script</div>
+  <div class="legend-item"><div class="swatch" style="background:#6e40c9"></div> generic runner / lock</div>
+  <div class="legend-item"><div class="swatch" style="background:#d29922"></div> claude CLI (subscription)</div>
+  <div class="legend-item"><div class="swatch" style="background:#da3633"></div> kill switch / alert</div>
+  <div class="legend-item"><div class="swatch" style="background:#2d333b;border:1px solid #444c56"></div> file / state</div>
+  <div class="legend-item"><div class="swatch" style="background:#161b22;border:1px solid #388bfd"></div> external (GitHub / Anthropic)</div>
+</div>
+
+<script>
+  mermaid.initialize({ startOnLoad: true, theme: 'dark' });
+</script>
+</body>
+</html>

--- a/docs/automation-overview.html
+++ b/docs/automation-overview.html
@@ -1,176 +1,216 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>fhir-place local automation</title>
-  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      background: #0d1117;
-      color: #e6edf3;
-      margin: 0;
-      padding: 24px;
-    }
-    h1 { font-size: 1.2rem; font-weight: 600; color: #7ee787; margin-bottom: 4px; }
-    p.sub { font-size: 0.85rem; color: #8b949e; margin: 0 0 24px; }
-    .diagram-wrap {
-      background: #161b22;
-      border: 1px solid #30363d;
-      border-radius: 8px;
-      padding: 24px;
-      margin-bottom: 32px;
-    }
-    .diagram-wrap h2 {
-      font-size: 0.85rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: #8b949e;
-      margin: 0 0 16px;
-    }
-    .legend {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 16px;
-      margin-top: 24px;
-    }
-    .legend-item {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      font-size: 0.8rem;
-      color: #8b949e;
-    }
-    .swatch {
-      width: 12px;
-      height: 12px;
-      border-radius: 2px;
-    }
-  </style>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>fhir-place local automation</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", monospace; background: #0d1117; color: #e6edf3; padding: 20px; font-size: 13px; }
+  h1 { font-size: 15px; font-weight: 600; color: #7ee787; margin-bottom: 4px; }
+  .subtitle { color: #8b949e; font-size: 12px; margin-bottom: 24px; }
+  .section { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px; margin-bottom: 20px; }
+  .section-title { font-size: 10px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: #8b949e; margin-bottom: 14px; }
+
+  /* flow grid */
+  .flow { display: flex; flex-direction: column; gap: 0; align-items: center; }
+  .flow-row { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; align-items: flex-start; width: 100%; }
+  .arrow { color: #444c56; font-size: 16px; line-height: 1; text-align: center; padding: 2px 0; }
+  .arrow-label { font-size: 10px; color: #8b949e; text-align: center; }
+
+  /* node boxes */
+  .node { border-radius: 6px; padding: 7px 10px; font-size: 11px; line-height: 1.4; text-align: center; min-width: 110px; max-width: 160px; }
+  .node .name { font-weight: 600; }
+  .node .detail { font-size: 10px; opacity: .75; margin-top: 2px; }
+
+  .scheduler { background: #1c2d4a; border: 1px solid #388bfd; color: #79c0ff; }
+  .script    { background: #1a2e1f; border: 1px solid #2ea043; color: #56d364; }
+  .runner    { background: #261d40; border: 1px solid #a371f7; color: #c9a7f7; }
+  .file      { background: #2d333b; border: 1px solid #444c56; color: #8b949e; }
+  .claude    { background: #2d2008; border: 1px solid #e3b341; color: #e3b341; }
+  .external  { background: #161b22; border: 1px dashed #388bfd; color: #8b949e; }
+  .alert     { background: #3a1414; border: 1px solid #f85149; color: #ff7b72; }
+  .safety    { background: #2d1a00; border: 1px solid #d29922; color: #e3b341; }
+  .state     { background: #1e1e2e; border: 1px solid #6e40c9; color: #c9a7f7; }
+
+  /* two-column layout for auth section */
+  .two-col { display: flex; gap: 16px; flex-wrap: wrap; }
+  .col { flex: 1; min-width: 200px; display: flex; flex-direction: column; gap: 0; align-items: center; }
+
+  /* side-by-side for scripts row */
+  .scripts-grid { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; }
+
+  /* small connector line */
+  .vline { width: 1px; height: 14px; background: #444c56; margin: 0 auto; }
+
+  /* legend */
+  .legend { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 16px; padding-top: 12px; border-top: 1px solid #21262d; }
+  .li { display: flex; align-items: center; gap: 6px; font-size: 10px; color: #8b949e; }
+  .swatch { width: 10px; height: 10px; border-radius: 2px; flex-shrink: 0; }
+</style>
 </head>
 <body>
 
 <h1>fhir-place local automation</h1>
-<p class="sub">How launchd, poll-events, and the claude CLI wire together on the Mac mini.</p>
+<p class="subtitle">How launchd, poll-events, and the claude CLI wire together on the Mac mini.</p>
 
-<div class="diagram-wrap">
-  <h2>Scheduled jobs (launchd → scripts/launchd/)</h2>
-  <div class="mermaid">
-%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#1f6feb', 'primaryTextColor': '#e6edf3', 'primaryBorderColor': '#388bfd', 'lineColor': '#8b949e', 'secondaryColor': '#161b22', 'tertiaryColor': '#0d1117'}}}%%
-flowchart TD
-    LD[launchd\nmacOS service manager]:::scheduler
+<!-- SCHEDULED JOBS -->
+<div class="section">
+  <div class="section-title">Scheduled jobs — scripts/launchd/</div>
+  <div class="flow">
 
-    LD -->|"09:30 & 14:30 UTC"| ED[engineer-dispatch.sh]:::script
-    LD -->|"09:00 & 14:00 UTC"| PFD[pr-fixup-dispatch.sh]:::script
-    LD -->|":15 every hour"| UAT[hourly-uat-validation.sh]:::script
-    LD -->|"05:00 UTC daily"| QA[daily-qa-pass.sh]:::script
-    LD -->|"07:00 UTC daily"| PM[daily-pm-triage.sh]:::script
-    LD -->|"06:00 UTC daily"| DS[daily-doc-sync.sh]:::script
+    <div class="flow-row">
+      <div class="node scheduler"><div class="name">launchd</div><div class="detail">macOS service manager</div></div>
+    </div>
 
-    ED -->|via| RUN[run-prompt-locally.sh\ngeneric runner]:::runner
-    PFD -->|via| RUN
-    UAT -->|via| RUN
-    QA -->|via| RUN
-    PM -->|via| RUN
-    DS -->|via| RUN
+    <div class="vline"></div>
 
-    RUN -->|reads| PROMPT[docs/prompts/*.md\nprompt files]:::file
-    RUN -->|"claude --print\n(no ANTHROPIC_API_KEY)"| CLAUDE[claude CLI\nOAuth session]:::claude
-    CLAUDE -->|bills against| SUB[Claude Max subscription]:::external
+    <div class="scripts-grid">
+      <div class="node script"><div class="name">engineer-dispatch.sh</div><div class="detail">09:30 &amp; 14:30 UTC</div></div>
+      <div class="node script"><div class="name">pr-fixup-dispatch.sh</div><div class="detail">09:00 &amp; 14:00 UTC</div></div>
+      <div class="node script"><div class="name">hourly-uat-validation.sh</div><div class="detail">:15 every hour</div></div>
+      <div class="node script"><div class="name">daily-qa-pass.sh</div><div class="detail">05:00 UTC daily</div></div>
+      <div class="node script"><div class="name">daily-pm-triage.sh</div><div class="detail">07:00 UTC daily</div></div>
+      <div class="node script"><div class="name">daily-doc-sync.sh</div><div class="detail">06:00 UTC daily</div></div>
+    </div>
 
-    RUN -->|on failure| IMSG[iMessage alert\n+15082827897]:::notify
+    <div class="vline"></div>
+    <div class="arrow-label">all call via</div>
+    <div class="vline"></div>
 
-    classDef scheduler fill:#1f6feb,stroke:#388bfd,color:#e6edf3
-    classDef script fill:#238636,stroke:#2ea043,color:#e6edf3
-    classDef runner fill:#6e40c9,stroke:#a371f7,color:#e6edf3
-    classDef file fill:#2d333b,stroke:#444c56,color:#8b949e
-    classDef claude fill:#d29922,stroke:#e3b341,color:#0d1117
-    classDef external fill:#161b22,stroke:#388bfd,color:#8b949e,stroke-dasharray:4
-    classDef notify fill:#da3633,stroke:#f85149,color:#e6edf3
+    <div class="flow-row">
+      <div class="node runner"><div class="name">run-prompt-locally.sh</div><div class="detail">generic runner</div></div>
+    </div>
+
+    <div class="vline"></div>
+
+    <div class="flow-row">
+      <div class="node file"><div class="name">docs/prompts/*.md</div><div class="detail">prompt files in repo</div></div>
+      <div style="display:flex;align-items:center;padding:0 4px;color:#444c56;">+</div>
+      <div class="node claude"><div class="name">claude --print</div><div class="detail">no ANTHROPIC_API_KEY<br>OAuth session only</div></div>
+    </div>
+
+    <div class="vline"></div>
+
+    <div class="flow-row">
+      <div class="node external"><div class="name">Claude Max subscription</div><div class="detail">billed here, not API tokens</div></div>
+      <div class="node alert"><div class="name">iMessage alert</div><div class="detail">+15082827897<br>on failure</div></div>
+    </div>
+
   </div>
 </div>
 
-<div class="diagram-wrap">
-  <h2>Event-driven jobs (poll-events daemon → scripts/local/)</h2>
-  <div class="mermaid">
-%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#1f6feb', 'primaryTextColor': '#e6edf3', 'primaryBorderColor': '#388bfd', 'lineColor': '#8b949e', 'secondaryColor': '#161b22', 'tertiaryColor': '#0d1117'}}}%%
-flowchart TD
-    LD2[launchd\npoll-events.plist]:::scheduler
-    LD2 -->|"every 60s\nrestart-on-exit"| PE[poll-events.sh\nlong-running daemon]:::daemon
+<!-- EVENT-DRIVEN JOBS -->
+<div class="section">
+  <div class="section-title">Event-driven jobs — scripts/local/ via poll-events daemon</div>
+  <div class="flow">
 
-    PE -->|polls| GH[GitHub API\ndanielsperoniteam/fhir-place]:::external
+    <div class="flow-row">
+      <div class="node scheduler"><div class="name">launchd</div><div class="detail">poll-events.plist<br>restart-on-exit</div></div>
+    </div>
 
-    GH -->|new issues| IR[event-issue-review.sh]:::script
-    GH -->|PR ready for review| PRR[event-pr-review.sh]:::script
-    GH -->|"/dispatch-engineer comment"| DE[event-dispatch-engineer.sh]:::script
-    GH -->|"/resolve-conflicts comment"| RC[event-resolve-conflicts.sh]:::script
-    GH -->|"/address-comments comment"| AC[event-address-comments.sh]:::script
+    <div class="vline"></div>
 
-    PE -->|"👀 reaction = ack\n(dedup)"| GH
-    PE -->|"~/.fhir-place-state/\npoll-events.json"| STATE[watermark state\nlast-seen timestamps]:::file
-    PE -->|"MAX_CONCURRENT=3\nbackpressure"| CAP[concurrency cap]:::note
+    <div class="flow-row">
+      <div class="node runner"><div class="name">poll-events.sh</div><div class="detail">long-running daemon<br>polls every 60s</div></div>
+    </div>
 
-    IR -->|via| RUN2[run-prompt-locally.sh]:::runner
-    PRR -->|via| RUN2
-    DE -->|via| RUN2
-    RC -->|via| RUN2
-    AC -->|via| RUN2
+    <div class="vline"></div>
 
-    RUN2 -->|"--for issue/PR #N\nprologue + prompt body"| CLAUDE2[claude CLI\nOAuth session]:::claude
-    CLAUDE2 --> SUB2[Claude Max subscription]:::external
+    <div class="flow-row">
+      <div class="node external"><div class="name">GitHub API</div><div class="detail">danielsperoniteam/fhir-place</div></div>
+    </div>
 
-    PE -->|kill switch| KS["~/.fhir-place-pause\n(touch to silence all)"]:::killswitch
+    <div class="vline"></div>
+    <div class="arrow-label">dispatches async (MAX_CONCURRENT=3)</div>
+    <div class="vline"></div>
 
-    classDef scheduler fill:#1f6feb,stroke:#388bfd,color:#e6edf3
-    classDef daemon fill:#1f6feb,stroke:#388bfd,color:#e6edf3,stroke-width:3px
-    classDef script fill:#238636,stroke:#2ea043,color:#e6edf3
-    classDef runner fill:#6e40c9,stroke:#a371f7,color:#e6edf3
-    classDef file fill:#2d333b,stroke:#444c56,color:#8b949e
-    classDef claude fill:#d29922,stroke:#e3b341,color:#0d1117
-    classDef external fill:#161b22,stroke:#388bfd,color:#8b949e,stroke-dasharray:4
-    classDef note fill:#2d333b,stroke:#444c56,color:#8b949e,stroke-dasharray:2
-    classDef killswitch fill:#da3633,stroke:#f85149,color:#e6edf3
+    <div class="scripts-grid">
+      <div class="node script"><div class="name">event-issue-review.sh</div><div class="detail">new issues opened</div></div>
+      <div class="node script"><div class="name">event-pr-review.sh</div><div class="detail">PR ready for review</div></div>
+      <div class="node script"><div class="name">event-dispatch-engineer.sh</div><div class="detail">/dispatch-engineer comment</div></div>
+      <div class="node script"><div class="name">event-resolve-conflicts.sh</div><div class="detail">/resolve-conflicts comment</div></div>
+      <div class="node script"><div class="name">event-address-comments.sh</div><div class="detail">/address-comments comment</div></div>
+    </div>
+
+    <div class="vline"></div>
+    <div class="arrow-label">each calls via</div>
+    <div class="vline"></div>
+
+    <div class="flow-row">
+      <div class="node runner"><div class="name">run-prompt-locally.sh</div><div class="detail">--for issue/PR #N<br>prologue + prompt body</div></div>
+    </div>
+
+    <div class="vline"></div>
+
+    <div class="flow-row">
+      <div class="node claude"><div class="name">claude --print</div><div class="detail">OAuth session</div></div>
+    </div>
+
+    <div class="vline"></div>
+
+    <div class="flow-row">
+      <div class="node external"><div class="name">Claude Max subscription</div></div>
+    </div>
+
+    <div style="height:16px"></div>
+
+    <div class="flow-row">
+      <div class="node state"><div class="name">~/.fhir-place-state/<br>poll-events.json</div><div class="detail">watermark timestamps<br>(last-seen per stream)</div></div>
+      <div class="node state"><div class="name">👀 reaction on comment</div><div class="detail">ack / dedup marker<br>written back to GitHub</div></div>
+      <div class="node alert"><div class="name">~/.fhir-place-pause</div><div class="detail">kill switch<br>touch to silence all</div></div>
+    </div>
+
   </div>
 </div>
 
-<div class="diagram-wrap">
-  <h2>Safety &amp; auth model</h2>
-  <div class="mermaid">
-%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#1f6feb', 'primaryTextColor': '#e6edf3', 'primaryBorderColor': '#388bfd', 'lineColor': '#8b949e', 'secondaryColor': '#161b22', 'tertiaryColor': '#0d1117'}}}%%
-flowchart LR
-    KC[macOS Keychain\ngithub-pat-fhir-place]:::secure -->|security find-generic-password| ENV[GITHUB_TOKEN\nin process env]:::env
-    OAUTH[~/.claude/\nOAuth credentials]:::secure -->|claude login\none-time setup| CLI[claude CLI\nbills Max sub]:::claude
+<!-- AUTH & SAFETY -->
+<div class="section">
+  <div class="section-title">Auth &amp; safety model</div>
+  <div class="two-col">
 
-    ENV --> GH_API[gh / GitHub API calls]:::external
-    CLI --> AI[Anthropic API\nvia subscription]:::external
+    <div class="col">
+      <div class="node safety" style="width:100%;max-width:100%;text-align:left"><div class="name">Auth</div></div>
+      <div class="vline"></div>
+      <div class="node file" style="width:100%;max-width:100%"><div class="name">macOS Keychain</div><div class="detail">github-pat-fhir-place entry</div></div>
+      <div class="vline"></div>
+      <div class="arrow-label">security find-generic-password</div>
+      <div class="vline"></div>
+      <div class="node script" style="width:100%;max-width:100%"><div class="name">GITHUB_TOKEN / GH_TOKEN</div><div class="detail">injected into process env</div></div>
+      <div class="vline"></div>
+      <div class="node external" style="width:100%;max-width:100%"><div class="name">gh + GitHub API calls</div></div>
+      <div style="height:12px"></div>
+      <div class="node file" style="width:100%;max-width:100%"><div class="name">~/.claude/</div><div class="detail">OAuth credentials<br>set once via claude login</div></div>
+      <div class="vline"></div>
+      <div class="node claude" style="width:100%;max-width:100%"><div class="name">claude --print</div><div class="detail">subscription billing</div></div>
+    </div>
 
-    PAUSE["~/.fhir-place-pause\nkill switch"]:::killswitch -->|checked by every script| ALL[all runners]:::runner
-    LOCK["/tmp/fhir-place-*.lock\natomic mkdir lock"]:::lock -->|prevents double-runs| ALL
-    DIRTY[git diff check\ndirty tree guard]:::lock -->|skips run if\nworkdir has edits| ALL
+    <div class="col">
+      <div class="node safety" style="width:100%;max-width:100%;text-align:left"><div class="name">Guards (every runner checks these)</div></div>
+      <div style="height:8px"></div>
+      <div class="node alert" style="width:100%;max-width:100%"><div class="name">~/.fhir-place-pause</div><div class="detail">global kill switch<br>touch to stop everything</div></div>
+      <div style="height:6px"></div>
+      <div class="node state" style="width:100%;max-width:100%"><div class="name">/tmp/fhir-place-*.lock</div><div class="detail">atomic mkdir lock<br>stale-PID recovery built in</div></div>
+      <div style="height:6px"></div>
+      <div class="node state" style="width:100%;max-width:100%"><div class="name">git diff check</div><div class="detail">skips run if working tree<br>has uncommitted edits</div></div>
+      <div style="height:6px"></div>
+      <div class="node state" style="width:100%;max-width:100%"><div class="name">MAX_CONCURRENT=3</div><div class="detail">event daemon backpressure<br>waits 2s then retries</div></div>
+      <div style="height:6px"></div>
+      <div class="node file" style="width:100%;max-width:100%"><div class="name">logs/ (14-day retention)</div><div class="detail">tee'd per run, auto-trimmed</div></div>
+    </div>
 
-    classDef secure fill:#238636,stroke:#2ea043,color:#e6edf3
-    classDef env fill:#2d333b,stroke:#444c56,color:#8b949e
-    classDef claude fill:#d29922,stroke:#e3b341,color:#0d1117
-    classDef external fill:#161b22,stroke:#388bfd,color:#8b949e,stroke-dasharray:4
-    classDef killswitch fill:#da3633,stroke:#f85149,color:#e6edf3
-    classDef lock fill:#6e40c9,stroke:#a371f7,color:#e6edf3
-    classDef runner fill:#6e40c9,stroke:#a371f7,color:#e6edf3
   </div>
 </div>
 
 <div class="legend">
-  <div class="legend-item"><div class="swatch" style="background:#1f6feb"></div> launchd / daemon</div>
-  <div class="legend-item"><div class="swatch" style="background:#238636"></div> shell script</div>
-  <div class="legend-item"><div class="swatch" style="background:#6e40c9"></div> generic runner / lock</div>
-  <div class="legend-item"><div class="swatch" style="background:#d29922"></div> claude CLI (subscription)</div>
-  <div class="legend-item"><div class="swatch" style="background:#da3633"></div> kill switch / alert</div>
-  <div class="legend-item"><div class="swatch" style="background:#2d333b;border:1px solid #444c56"></div> file / state</div>
-  <div class="legend-item"><div class="swatch" style="background:#161b22;border:1px solid #388bfd"></div> external (GitHub / Anthropic)</div>
+  <div class="li"><div class="swatch" style="background:#1c2d4a;border:1px solid #388bfd"></div> launchd / scheduler</div>
+  <div class="li"><div class="swatch" style="background:#1a2e1f;border:1px solid #2ea043"></div> shell script</div>
+  <div class="li"><div class="swatch" style="background:#261d40;border:1px solid #a371f7"></div> runner / daemon</div>
+  <div class="li"><div class="swatch" style="background:#2d2008;border:1px solid #e3b341"></div> claude CLI (subscription)</div>
+  <div class="li"><div class="swatch" style="background:#3a1414;border:1px solid #f85149"></div> alert / kill switch</div>
+  <div class="li"><div class="swatch" style="background:#1e1e2e;border:1px solid #6e40c9"></div> state / locks</div>
+  <div class="li"><div class="swatch" style="background:#161b22;border:1px dashed #388bfd"></div> external (GitHub / Anthropic)</div>
 </div>
 
-<script>
-  mermaid.initialize({ startOnLoad: true, theme: 'dark' });
-</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- `staging-stack-agent.yml` has been failing on every run since at least 2026-05-10 because `claude-code-action@v1` tries to fetch a GitHub App installation token (via curl to `/installation/token`) and gets back 0 bytes — no GitHub App is configured in this repo
- This meant every merge conflict on staging dispatched the resolver, the resolver immediately failed, and the conflicting PR stayed off staging forever
- PR #473 was the first conflict in the stack, so PRs #541 #552 #582 #591 and everything after it never made it onto staging — causing the `uat: unable` label on ~20 open PRs

**Fix:** replace `anthropics/claude-code-action@v1` with a direct `npm install -g @anthropic-ai/claude-code` + `claude --print` call, same pattern as the local dispatch scripts. `gh` CLI (already on ubuntu-latest runners) handles all GitHub API calls via `GITHUB_TOKEN`. Drops `id-token: write` permission (no longer needed) and `mcp__github__*` from the allowlist.

**Also:** closed PR #473 (superseded by #595 which covers the same files with broader e2e coverage).

## Test plan

- [ ] Merge this PR to main
- [ ] Trigger `stack-approved-prs.yml` manually (or wait for the next approved-PR event)
- [ ] Confirm staging rebuilds cleanly with all approved open PRs stacked
- [ ] If a future conflict occurs, confirm `staging-stack-agent.yml` runs past the curl step

## UAT on live staging

N/A — no user-visible change (CI workflow only).