### PR TITLE
fix(run-prompt-locally): delete local branches whose remote is gone

### DIFF
--- a/scripts/run-prompt-locally.sh
+++ b/scripts/run-prompt-locally.sh
@@ -121,6 +121,8 @@ fi
 
 git fetch origin --prune --tags --quiet
 git worktree prune
+git branch --format '%(if:equals=[gone])%(upstream:track)%(then)%(refname:short)%(end)' \
+  | grep -v '^$' | xargs git branch -D 2>/dev/null || true
 
 # Find the prompt file. Accept either an absolute path, a repo-relative
 # path, or a bare basename (looked up under docs/prompts/).


### PR DESCRIPTION
## Summary

- After each `git fetch --prune`, local branches that tracked a deleted remote (merged bot PRs) were lingering indefinitely
- Add one line after `git worktree prune` to auto-delete them on every bot tick

## Test plan

- [ ] Merge and restart daemon — `git branch` should stop accumulating stale bot branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)