### PR TITLE
feat(resolve-conflicts): enable auto-merge after resolution on approved PRs

### DIFF
--- a/docs/prompts/pr-resolve-conflicts.md
+++ b/docs/prompts/pr-resolve-conflicts.md
@@ -171,7 +171,27 @@ commit fields.
 
 ---
 
-## Step 6 — post a summary comment
+## Step 6 — enable auto-merge if already approved
+
+Check the PR's review decision:
+
+```bash
+gh pr view <pr_number> --json reviewDecision --jq '.reviewDecision'
+```
+
+If the result is `APPROVED`, enable GitHub's auto-merge so the PR merges
+automatically once CI is green:
+
+```bash
+gh pr merge <pr_number> --auto --squash
+```
+
+If the result is anything else (e.g. `REVIEW_REQUIRED`), skip this step —
+the PR still needs a human review before it can merge.
+
+---
+
+## Step 7 — post a summary comment
 
 Use the MCP GitHub tools to post a comment on PR #<pr_number> with this
 structure:
@@ -184,6 +204,8 @@ Merge conflicts resolved. Summary:
   you merged them
 
 **Build status:** typecheck passed / N test(s) skipped / any other notes
+
+**Auto-merge:** enabled (will merge once CI is green) / not enabled (awaiting review)
 
 **Note (if applicable):** any pre-existing failures unrelated to this merge
 ```


### PR DESCRIPTION
## Summary

- After resolving conflicts and pushing, the agent now checks `reviewDecision`
- If `APPROVED`: runs `gh pr merge --auto --squash` — PR merges once CI is green
- If not approved: skips — PR still needs human review
- Summary comment updated to include auto-merge status

## Why

With many approved PRs piled up with conflicts, resolving them one-by-one still required manual merging. Now the cycle is fully automated:

1. Section 5 detects conflict → resolve → auto-merge enabled
2. CI passes → PR merges into main
3. New conflicts detected in other PRs → repeat

## Test plan

- [ ] Merge #665 first (jq fix), restart daemon
- [ ] An approved conflicting PR resolves → verify `gh pr merge --auto` was called
- [ ] CI passes → PR merges automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)