### PR TITLE
fix(resolve-conflicts): dedup bot runs and narrow git fetch

### DIFF
--- a/docs/prompts/pr-resolve-conflicts.md
+++ b/docs/prompts/pr-resolve-conflicts.md
@@ -42,7 +42,7 @@ REPO_ROOT=$(pwd)
 HEAD_REF=$(gh pr view <pr_number> --json headRefName --jq '.headRefName')
 BASE_REF=$(gh pr view <pr_number> --json baseRefName --jq '.baseRefName')
 WORKTREE=../wt-pr-<pr_number>
-git fetch origin
+git fetch origin "$HEAD_REF" main
 # Create local tracking branch if it doesn't exist, then add worktree.
 git branch --track "$HEAD_REF" "origin/$HEAD_REF" 2>/dev/null || true
 git worktree add "$WORKTREE" "$HEAD_REF"
@@ -177,6 +177,7 @@ Use the MCP GitHub tools to post a comment on PR #<pr_number> with this
 structure:
 
 ```
+<!-- resolve-conflicts:bot -->
 Merge conflicts resolved. Summary:
 
 **Files resolved:**

--- a/scripts/poll-events.sh
+++ b/scripts/poll-events.sh
@@ -305,16 +305,18 @@ poll_once() {
       head=$(echo "$row" | jq -r '.head')
       mergeable=$(echo "$row" | jq -r '.mergeable')
       [[ "$mergeable" != "DIRTY" ]] && continue
-      # Dedup: skip if a resolver was dispatched in the last 2 hours.
+      # Dedup: skip if a resolver ran or was dispatched in the last 2 hours.
+      # Match both manual /resolve-conflicts comments and the bot's own
+      # <!-- resolve-conflicts:bot --> marker left in its summary comment.
       local two_hours_ago
       two_hours_ago=$(date -u -v-2H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
                       || date -u --date='2 hours ago' +%Y-%m-%dT%H:%M:%SZ)
       local recent_resolver
       recent_resolver=$(gh api "repos/$REPO/issues/$num/comments?since=$two_hours_ago" \
-        --jq '[.[] | select(.body | contains("/resolve-conflicts"))] | length' \
+        --jq '[.[] | select(.body | (contains("/resolve-conflicts") or contains("<!-- resolve-conflicts:bot -->")))] | length' \
         2>/dev/null || echo '0')
       if [[ "$recent_resolver" -gt 0 ]]; then
-        echo "PR #$num conflict detected but resolver recently dispatched — skip"
+        echo "PR #$num conflict detected but resolver recently ran — skip"
         continue
       fi
       echo "PR #$num ($head) conflicts with main → auto resolve-conflicts"


### PR DESCRIPTION
## Summary

- **Dedup bug**: `poll-events.sh` section 5 checked for `/resolve-conflicts` in recent comments to skip re-dispatch, but the bot's own summary comment starts with `<!-- resolve-conflicts:bot -->` (no match) — so every 5-min poll re-dispatched an already-resolved PR. Fixed by ORing both strings in the jq filter.
- **Fetch race**: `git fetch origin` (full fetch) in Step 0 of the resolver prompt raced with the primary checkout's fetch in `run-prompt-locally.sh`, producing `cannot lock ref 'refs/remotes/origin/main'`. Narrowed to `git fetch origin "$HEAD_REF" main` to reduce the lock surface.

## Test plan

- [ ] Confirm section 5 dedup fires correctly after a resolver posts its summary comment (no re-dispatch within 2 hours)
- [ ] Confirm no `cannot lock ref` errors in logs when two resolvers run near-simultaneously
- [ ] Restart `poll-events` daemon after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)